### PR TITLE
Library: Board status

### DIFF
--- a/STM32/UnitTesting/Inc/stm32f4xx_hal.h
+++ b/STM32/UnitTesting/Inc/stm32f4xx_hal.h
@@ -20,7 +20,7 @@ void HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length
 void HAL_Delay(uint32_t);
 int USBnprintf(const char * format, ... );
 void JumpToBootloader();
-
+void CAPrintStatus(bool printStart);
 void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
 
 #ifdef __cplusplus

--- a/STM32/UnitTesting/src/stubs.cpp
+++ b/STM32/UnitTesting/src/stubs.cpp
@@ -16,6 +16,8 @@ int USBnprintf(const char * format, ... ) {
     return 0;
 }
 void JumpToBootloader() {};
+void CAPrintStatus(bool printStart) {};
+
 
 static void generate4Sines(int16_t* pData, int length, int offset, int freq)
 {

--- a/STM32/Util/Inc/CAProtocol.h
+++ b/STM32/Util/Inc/CAProtocol.h
@@ -31,6 +31,9 @@ typedef struct
 
     // system info request using "Serial". These should be overwritten
     void (*printHeader)();
+    // system info request using "Status". These should be overwritten with additional 
+    // board specific status codes.
+    void (*printStatus)();
     void (*jumpToBootLoader)();
 
     // Calibration request.

--- a/STM32/Util/Inc/CAProtocolStm.h
+++ b/STM32/Util/Inc/CAProtocolStm.h
@@ -1,10 +1,11 @@
 #pragma once
 #include "CAProtocol.h"
+#include <stdbool.h>
 
 void HALundefined(const char *input);
 void HALJumpToBootloader();
 void CAPrintHeader();
-void CAPrintStatus();
+void CAPrintStatus(bool printStart);
 void CAotpRead();
 
 // analyse reason for boot and in case of SW reset jump to DFU SW update.

--- a/STM32/Util/Inc/CAProtocolStm.h
+++ b/STM32/Util/Inc/CAProtocolStm.h
@@ -4,6 +4,7 @@
 void HALundefined(const char *input);
 void HALJumpToBootloader();
 void CAPrintHeader();
+void CAPrintStatus();
 void CAotpRead();
 
 // analyse reason for boot and in case of SW reset jump to DFU SW update.

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -1,6 +1,8 @@
 #ifndef SYSTEM_INFO_H
 #define SYSTEM_INFO_H
 
+#include <stdbool.h>
+
 /* General Board Status register definitions */
 #define BS_ERROR_Pos                        31U
 #define BS_ERROR_Msk                        (1UL << BS_ERROR_Pos)
@@ -59,6 +61,11 @@ int getBoardInfo(BoardType* bdt, SubBoardType* sbdt);
 // @param ver: Pointer to struct pcbVersion
 // Return 0 if data is valid, else negative value.
 int getPcbVersion(pcbVersion* ver);
+
+// Description: set a board status field.
+// @param field: a 1 bit shifted to the field index to be set in addition to
+// the error bit also being set.
+void bsSetError(uint32_t field);
 
 // Description: set a board status field.
 // @param field: a 1 bit shifted to the field index to be set.

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -1,6 +1,23 @@
 #ifndef SYSTEM_INFO_H
 #define SYSTEM_INFO_H
 
+/* General Board Status register definitions */
+#define BS_ERROR_Pos                        0U
+#define BS_ERROR_Msk                        (1UL << BS_ERROR_Pos)
+
+#define BS_OVER_TEMPERATURE_Pos             1U
+#define BS_OVER_TEMPERATURE_Msk             (1UL << BS_OVER_TEMPERATURE_Pos)
+
+#define BS_UNDER_VOLTAGE_Pos                2U
+#define BS_UNDER_VOLTAGE_Msk                (1UL << BS_UNDER_VOLTAGE_Pos)
+
+#define BS_OVER_VOLTAGE_Pos                 3U
+#define BS_OVER_VOLTAGE_Msk                 (1UL << BS_OVER_VOLTAGE_Pos)
+
+#define BS_OVER_CURRENT_Pos                 4U
+#define BS_OVER_CURRENT_Msk                 (1UL << BS_OVER_CURRENT_Pos)
+
+
 // NOTE!! Do not change order or values since this list must match ALL OTP programmers.
 typedef enum {
     AC_Board          = 1,
@@ -42,5 +59,22 @@ int getBoardInfo(BoardType* bdt, SubBoardType* sbdt);
 // @param ver: Pointer to struct pcbVersion
 // Return 0 if data is valid, else negative value.
 int getPcbVersion(pcbVersion* ver);
+
+// Description: set a board status field.
+// @param field: a 1 bit shifted to the field index to be set.
+void bsSetField(uint32_t field);
+
+// Description: set a board status field.
+// @param field: a 1 bit shifted to the field index to be cleared.
+void bsClearField(uint32_t field);
+
+// Description: Get the board status registry.
+// Return a uint32_t containing the board status.
+uint32_t bsGetStatus();
+
+void setBoardTemp(float temp);
+void setBoardUnderVoltage(float voltage);
+void setBoardOverVoltage(float voltage);
+void setBoardCurrent(float current);
 
 #endif // SYSTEM_INFO_H

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -2,19 +2,19 @@
 #define SYSTEM_INFO_H
 
 /* General Board Status register definitions */
-#define BS_ERROR_Pos                        0U
+#define BS_ERROR_Pos                        31U
 #define BS_ERROR_Msk                        (1UL << BS_ERROR_Pos)
 
-#define BS_OVER_TEMPERATURE_Pos             1U
+#define BS_OVER_TEMPERATURE_Pos             30U
 #define BS_OVER_TEMPERATURE_Msk             (1UL << BS_OVER_TEMPERATURE_Pos)
 
-#define BS_UNDER_VOLTAGE_Pos                2U
+#define BS_UNDER_VOLTAGE_Pos                29U
 #define BS_UNDER_VOLTAGE_Msk                (1UL << BS_UNDER_VOLTAGE_Pos)
 
-#define BS_OVER_VOLTAGE_Pos                 3U
+#define BS_OVER_VOLTAGE_Pos                 28U
 #define BS_OVER_VOLTAGE_Msk                 (1UL << BS_OVER_VOLTAGE_Pos)
 
-#define BS_OVER_CURRENT_Pos                 4U
+#define BS_OVER_CURRENT_Pos                 27U
 #define BS_OVER_CURRENT_Msk                 (1UL << BS_OVER_CURRENT_Pos)
 
 

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -51,6 +51,10 @@ typedef struct pcbVersion {
  * @return info about system in null terminated string. */
 const char* systemInfo();
 
+/* Generic info about system status.
+ * @return info about system in null terminated string. */
+const char* statusInfo(bool printStart);
+
 // Description: Get Boardinfo. If input values are NULL these are ignored.
 // @param bdt:  Boardtype used in the SW running
 // @param sbdt: SubBoardtype used in the SW running, if 0xFF value is ignore in compare

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -10,6 +10,7 @@
 #include <strings.h>
 #include <stdlib.h>
 #include "CAProtocol.h"
+#include "CAProtocolStm.h"
 
 typedef struct CAProtocolData {
     size_t len;         // Length of current data.

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -9,8 +9,8 @@
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
-#include "CAProtocol.h"
 #include "CAProtocolStm.h"
+#include "CAProtocol.h"
 
 typedef struct CAProtocolData {
     size_t len;         // Length of current data.

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -194,8 +194,10 @@ void inputCAProtocol(CAProtocolCtx* ctx)
     }
     else if(strncmp(input, "Status", 6) == 0)
     {
+        CAPrintStatus(true); // Print start of status message
         if (ctx->printStatus)
-            ctx->printStatus();
+            ctx->printStatus(); // Print board specific part of status message
+        CAPrintStatus(false); // Print end of status message
     }
     else if(strncmp(input, "DFU", 3) == 0)
     {

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -5,6 +5,7 @@
  *      Author: agp
  */
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -191,6 +191,11 @@ void inputCAProtocol(CAProtocolCtx* ctx)
         if (ctx->printHeader)
             ctx->printHeader();
     }
+    else if(strncmp(input, "Status", 6) == 0)
+    {
+        if (ctx->printStatus)
+            ctx->printStatus();
+    }
     else if(strncmp(input, "DFU", 3) == 0)
     {
         if (ctx->jumpToBootLoader)

--- a/STM32/Util/Src/CAProtocolStm.c
+++ b/STM32/Util/Src/CAProtocolStm.c
@@ -41,9 +41,9 @@ void CAPrintHeader()
     USBnprintf(systemInfo());
 }
 
-void CAPrintStatus()
+void CAPrintStatus(bool printStart)
 {
-    USBnprintf(statusInfo());
+    USBnprintf(statusInfo(printStart));
 }
 
 void CAotpRead()

--- a/STM32/Util/Src/CAProtocolStm.c
+++ b/STM32/Util/Src/CAProtocolStm.c
@@ -41,6 +41,11 @@ void CAPrintHeader()
     USBnprintf(systemInfo());
 }
 
+void CAPrintStatus()
+{
+    USBnprintf(statusInfo());
+}
+
 void CAotpRead()
 {
     BoardInfo info;

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -131,25 +131,25 @@ const char* statusInfo()
     } 
     len += snprintf(&buf[len], sizeof(buf) - len, "Board Status: ");
 
-    if ((BS.boardStatus & BS_OVER_TEMPERATURE_Msk))
+    if (BS.boardStatus & BS_OVER_TEMPERATURE_Msk)
     {
         len += snprintf(&buf[len], sizeof(buf) - len, 
                         "Over temperature. The board temperature is %.2fC.\r\n", BS.temp);
     }
 
-    if ((BS.boardStatus & BS_UNDER_VOLTAGE_Msk))
+    if (BS.boardStatus & BS_UNDER_VOLTAGE_Msk)
     {
         len += snprintf(&buf[len], sizeof(buf) - len, 
                         "Under voltage. The board operates at too low voltage of %.2fV. Check power supply.\r\n", BS.underVoltage);
     }
 
-    if ((BS.boardStatus & BS_OVER_VOLTAGE_Msk))
+    if (BS.boardStatus & BS_OVER_VOLTAGE_Msk)
     {
         len += snprintf(&buf[len], sizeof(buf) - len, 
                         "Over voltage. One of the ports has reached its voltage limit of %.2fV. \r\n", BS.overVoltage);
     }
 
-    if ((BS.boardStatus & BS_OVER_CURRENT_Msk))
+    if (BS.boardStatus & BS_OVER_CURRENT_Msk)
     {
         len += snprintf(&buf[len], sizeof(buf) - len, 
                         "Over current. One of the ports has reached its current limit of %.2fA.\r\n", BS.overCurrent);

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -28,6 +28,9 @@ static struct BS
     float overCurrent;
 } BS = {0, 0, 0, 0};
 
+// Print buffer for systemInfo & statusInfo
+static char buf[600] = { 0 };
+
 // F4xx UID
 #define ID1 *((unsigned long *) (UID_BASE))
 #define ID2 *((unsigned long *) (UID_BASE + 4U))
@@ -81,7 +84,6 @@ static char* productType(uint8_t id)
 
 const char* systemInfo()
 {
-    static char buf[600] = { 0 };
     BoardInfo info = { 0 };
 
     if (HAL_otpRead(&info) != OTP_SUCCESS)
@@ -127,7 +129,6 @@ const char* systemInfo()
 
 const char* statusInfo(bool printStart)
 {
-    static char buf[600] = { 0 };
     int len = 0;
 
     // Print end of message and return


### PR DESCRIPTION
**New board status library.**

The board status is a uint32_t software registry that is split between 16 bits of generic board information (MSB) and 16 bits of board specific information (LSB).

| 31 | 30 | 29 | 28 | 27 | ... | 16 | 15 | ... | 0 |
| :---: | ------ |  ------ | ------ |  ------ | ------ |  ------ | ------ |  ------ | ------ |
| Error  | Over Temp | Under Voltage | Over Voltage | Over Current | ... | Generic LSB | Specific MSB | ... | Specific LSB |  

The MSB is an overall error bit. If this bit is set then an interpreter knows some error has occurred and can parse the rest of the status registry if needed. 

The specific status bits may be used for both error indications, but also just overall board status e.g. to indicate whether an output port is turned on or off.

**General usage**
Every board should use the status registry a print the status as a hex value and as the last value being printed. 

A user can also poll a **verbose** status of a board by sending `Status` to the board.   


