### PR TITLE
Added array math functions with circular buffer capability.

### DIFF
--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Run unittests
       run: |
         cd unit_testing
-        ./unit_tests.py
+        ./unitTests.py
 
         # Also run the old unit tests - to be refactored in the new framework at a later date
         cd "../STM32/UnitTesting"

--- a/.github/workflows/stm32build.yml
+++ b/.github/workflows/stm32build.yml
@@ -4,20 +4,24 @@ on:
   push:
     branches: [ 'main' ]
     paths: ['STM32/**', '.github/workflows/stm32build.yml']
-  pull_request: 
+  pull_request:
     branches: [ 'main' ]
     paths: ['STM32/**', '.github/workflows/stm32build.yml']
 
-jobs: 
+jobs:
   # Run unittest
   run_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3   
+    - uses: actions/checkout@v4
     # Build and run unittests. If the unittest fails the line number is output.
     - name: Run unittests
       run: |
-        cd "STM32/UnitTesting"
+        cd unit_testing
+        ./unit_tests.py
+
+        # Also run the old unit tests - to be refactored in the new framework at a later date
+        cd "../STM32/UnitTesting"
         cmake CMakeLists.txt
         make
         # Extract the values assigned to the TARGET_NAMES variable
@@ -30,8 +34,12 @@ jobs:
         while IFS= read -r target_name; do
           output=$(./$target_name)
           echo $output
-          if [[ $output =~ "failed" ]]; then 
+          if [[ $output =~ "failed" ]]; then
             echo "Test failed"
             exit 1
           fi
         done <<< "$TARGET_NAMES"
+
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+unit_testing/array-math/build

--- a/STM32/Filtering/Inc/array-math.h
+++ b/STM32/Filtering/Inc/array-math.h
@@ -24,6 +24,10 @@ typedef double_cbuf_t * double_cbuf_handle_t;
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Note: Function nomenclature loosely chosen to fit with C++ algorithm.h library */
 int max_element(double arr[], unsigned len, double* result);
 int mean_element(double arr[], unsigned len, double* result);
@@ -33,5 +37,9 @@ int cbInit(double_cbuf_handle_t p_cb, double* buf, unsigned len);
 void cbPush(double_cbuf_handle_t p_cb, double new_val);
 int cbMean(double_cbuf_handle_t p_cb, int elements, double* result);
 int cbMax(double_cbuf_handle_t p_cb, int elements, double* result);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ARRAY_MATH_H_ */

--- a/STM32/Filtering/Inc/array-math.h
+++ b/STM32/Filtering/Inc/array-math.h
@@ -1,0 +1,37 @@
+/*! 
+**  \brief     Array math functions
+**  \details   Functions to find the max/average of arrays
+**  \author    Luke Walker
+**  \date      09/04/2024
+**/
+
+#ifndef ARRAY_MATH_H_
+#define ARRAY_MATH_H_
+
+/***************************************************************************************************
+** TYPE DEFINITIONS
+***************************************************************************************************/
+
+typedef struct {
+    double* buffer;
+    int     len;
+    int     idx;
+} double_cbuf_t;
+
+typedef double_cbuf_t * double_cbuf_handle_t;
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
+
+/* Note: Function nomenclature loosely chosen to fit with C++ algorithm.h library */
+double max_element(double arr[], int len);
+double mean_element(double arr[], int len);
+
+/* Functions for moving average filters */
+void cbInit(double_cbuf_handle_t p_cb, double* buf, int len);
+void cbPush(double_cbuf_handle_t p_cb, double new_val);
+double cbMean(double_cbuf_handle_t p_cb, int elements);
+double cbMax(double_cbuf_handle_t p_cb, int elements);
+
+#endif /* ARRAY_MATH_H_ */

--- a/STM32/Filtering/Inc/array-math.h
+++ b/STM32/Filtering/Inc/array-math.h
@@ -25,13 +25,13 @@ typedef double_cbuf_t * double_cbuf_handle_t;
 ***************************************************************************************************/
 
 /* Note: Function nomenclature loosely chosen to fit with C++ algorithm.h library */
-double max_element(double arr[], int len);
-double mean_element(double arr[], int len);
+int max_element(double arr[], unsigned len, double* result);
+int mean_element(double arr[], unsigned len, double* result);
 
 /* Functions for moving average filters */
-void cbInit(double_cbuf_handle_t p_cb, double* buf, int len);
+int cbInit(double_cbuf_handle_t p_cb, double* buf, unsigned len);
 void cbPush(double_cbuf_handle_t p_cb, double new_val);
-double cbMean(double_cbuf_handle_t p_cb, int elements);
-double cbMax(double_cbuf_handle_t p_cb, int elements);
+int cbMean(double_cbuf_handle_t p_cb, int elements, double* result);
+int cbMax(double_cbuf_handle_t p_cb, int elements, double* result);
 
 #endif /* ARRAY_MATH_H_ */

--- a/STM32/Filtering/Src/array-math.c
+++ b/STM32/Filtering/Src/array-math.c
@@ -37,6 +37,7 @@ int mean_element(double arr[], unsigned len, double* result) {
             ret_val += arr[i];
         }
         *result = ret_val / len;
+        return 0;
     }
 
     return -1;

--- a/STM32/Filtering/Src/array-math.c
+++ b/STM32/Filtering/Src/array-math.c
@@ -83,6 +83,10 @@ int cbMean(double_cbuf_handle_t p_cb, int elements, double* result) {
     else if(elements == p_cb->len) {
         return mean_element(p_cb->buffer, p_cb->len, result);
     }
+    else if(0 == p_cb->idx) {
+        /* The current index is un-occupied, so start from the previous one */
+        return mean_element(&p_cb->buffer[p_cb->len - elements], elements, result);
+    }
     else if(elements <= p_cb->idx) {
         /* The current index is un-occupied, so start from the previous one */
         return mean_element(&p_cb->buffer[p_cb->idx - elements], elements, result);
@@ -112,6 +116,10 @@ int cbMax(double_cbuf_handle_t p_cb, int elements, double* result) {
     }
     else if(elements == p_cb->len) {
         return max_element(p_cb->buffer, p_cb->len, result);
+    }
+    else if(0 == p_cb->idx) {
+        /* The current index is un-occupied, so start from the previous one */
+        return max_element(&p_cb->buffer[p_cb->len - elements], elements, result);
     }
     else if(elements <= p_cb->idx) {
         /* The current index is un-occupied, so start from the previous one */

--- a/STM32/Filtering/Src/array-math.c
+++ b/STM32/Filtering/Src/array-math.c
@@ -14,44 +14,51 @@
 /*!
 ** @brief Returns the maximum value in an array of double
 */
-double max_element(double arr[], int len) {
+int max_element(double arr[], unsigned len, double* result) {
     if(len != 0) {
         double ret_val = arr[0];
-        for(int i = 1; i < len; i++) {
+        for(unsigned i = 1; i < len; i++) {
             if(arr[i] > ret_val) ret_val = arr[i];
         }
-        return ret_val;
+        *result = ret_val;
+        return 0;
     }
 
-    return -1.0;
+    return -1;
 }
 
 /*!
 ** @brief Returns the average value of an array of double
 */
-double mean_element(double arr[], int len) {
+int mean_element(double arr[], unsigned len, double* result) {
     if(len != 0) {
         double ret_val = arr[0];
         for(int i = 1; i < len; i++) {
             ret_val += arr[i];
         }
-        return ret_val / (double)len;
+        *result = ret_val / len;
     }
 
-    return -1.0;
+    return -1;
 }
 
 /*!
 ** @brief Initialises an empty circular buffer
 */
-void cbInit(double_cbuf_handle_t p_cb, double* buf, int len) {
-    p_cb->buffer = buf;
-    p_cb->len    = len;
-    p_cb->idx    = 0;
+int cbInit(double_cbuf_handle_t p_cb, double* buf, unsigned len) {
+    if(len != 0) {
+        p_cb->buffer = buf;
+        p_cb->len    = len;
+        p_cb->idx    = 0;
 
-    for(int i = 0; i < p_cb->len; i++) {
-        p_cb->buffer[i] = 0.0;
+        for(int i = 0; i < p_cb->len; i++) {
+            p_cb->buffer[i] = 0.0;
+        }
+
+        return 0;
     }
+
+    return -1;
 }
 
 /*!
@@ -68,39 +75,59 @@ void cbPush(double_cbuf_handle_t p_cb, double new_val) {
 /*!
 ** @brief Take the mean of the n most recent elements in the circular buffer
 */
-double cbMean(double_cbuf_handle_t p_cb, int elements) {
-    if(elements == p_cb->len) {
-        return mean_element(p_cb->buffer, p_cb->len);
+int cbMean(double_cbuf_handle_t p_cb, int elements, double* result) {
+    if(elements > p_cb->len) {
+        return -1;
+    }
+    else if(elements == p_cb->len) {
+        return mean_element(p_cb->buffer, p_cb->len, result);
     }
     else if(elements <= p_cb->idx) {
         /* The current index is un-occupied, so start from the previous one */
-        return mean_element(&p_cb->buffer[p_cb->idx - 1 - elements], elements);
+        return mean_element(&p_cb->buffer[p_cb->idx - elements], elements, result);
     }
     else {
-        double  p1 = mean_element(p_cb->buffer, p_cb->idx);
-        int     remaining = elements - p_cb->idx;
-        double  p2 = mean_element(&p_cb->buffer[p_cb->len - 1 - remaining], remaining);
+        double p1, p2;
+        int err = mean_element(p_cb->buffer, p_cb->idx, &p1);
 
-        return p1 + p2;
+        if(err != 0) {
+            return err;
+        }
+
+        int remaining = elements - p_cb->idx;
+        err = mean_element(&p_cb->buffer[p_cb->len - remaining], remaining, &p2);
+
+        *result = p1 + p2;
+        return 0;
     }
 }
 
 /*!
 ** @brief Take the max of the n most recent elements in the circular buffer
 */
-double cbMax(double_cbuf_handle_t p_cb, int elements) {
-    if(elements == p_cb->len) {
-        return max_element(p_cb->buffer, p_cb->len);
+int cbMax(double_cbuf_handle_t p_cb, int elements, double* result) {
+    if(elements > p_cb->len) {
+        return -1;
+    }
+    else if(elements == p_cb->len) {
+        return max_element(p_cb->buffer, p_cb->len, result);
     }
     else if(elements <= p_cb->idx) {
         /* The current index is un-occupied, so start from the previous one */
-        return max_element(&p_cb->buffer[p_cb->idx - 1 - elements], elements);
+        return max_element(&p_cb->buffer[p_cb->idx - elements], elements, result);
     }
     else {
-        double  p1 = max_element(p_cb->buffer, p_cb->idx);
-        int     remaining = elements - p_cb->idx;
-        double  p2 = max_element(&p_cb->buffer[p_cb->len - 1 - remaining], remaining);
+        double  p1, p2;
+        int err = max_element(p_cb->buffer, p_cb->idx, &p1);
 
-        return p1 > p2 ? p1 : p2;
+        if(err != 0) {
+            return err;
+        }
+
+        int     remaining = elements - p_cb->idx;
+        err = max_element(&p_cb->buffer[p_cb->len - remaining], remaining, &p2);
+
+        *result = (p1 > p2) ? p1 : p2;
+        return 0;
     }
 }

--- a/STM32/Filtering/Src/array-math.c
+++ b/STM32/Filtering/Src/array-math.c
@@ -1,0 +1,106 @@
+/*! 
+**  \brief     Array math functions
+**  \details   Functions to find the max/average of arrays
+**  \author    Luke Walker
+**  \date      09/04/2024
+**/
+
+#include "array-math.h"
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DEFINITIONS
+***************************************************************************************************/
+
+/*!
+** @brief Returns the maximum value in an array of double
+*/
+double max_element(double arr[], int len) {
+    if(len != 0) {
+        double ret_val = arr[0];
+        for(int i = 1; i < len; i++) {
+            if(arr[i] > ret_val) ret_val = arr[i];
+        }
+        return ret_val;
+    }
+
+    return -1.0;
+}
+
+/*!
+** @brief Returns the average value of an array of double
+*/
+double mean_element(double arr[], int len) {
+    if(len != 0) {
+        double ret_val = arr[0];
+        for(int i = 1; i < len; i++) {
+            ret_val += arr[i];
+        }
+        return ret_val / (double)len;
+    }
+
+    return -1.0;
+}
+
+/*!
+** @brief Initialises an empty circular buffer
+*/
+void cbInit(double_cbuf_handle_t p_cb, double* buf, int len) {
+    p_cb->buffer = buf;
+    p_cb->len    = len;
+    p_cb->idx    = 0;
+
+    for(int i = 0; i < p_cb->len; i++) {
+        p_cb->buffer[i] = 0.0;
+    }
+}
+
+/*!
+** @brief Add a new element to the circular buffer and discard the oldest element
+*/
+void cbPush(double_cbuf_handle_t p_cb, double new_val) {
+    p_cb->buffer[p_cb->idx++] = new_val;
+
+    if(p_cb->idx >= p_cb->len) {
+        p_cb->idx = 0;
+    }
+}
+
+/*!
+** @brief Take the mean of the n most recent elements in the circular buffer
+*/
+double cbMean(double_cbuf_handle_t p_cb, int elements) {
+    if(elements == p_cb->len) {
+        return mean_element(p_cb->buffer, p_cb->len);
+    }
+    else if(elements <= p_cb->idx) {
+        /* The current index is un-occupied, so start from the previous one */
+        return mean_element(&p_cb->buffer[p_cb->idx - 1 - elements], elements);
+    }
+    else {
+        double  p1 = mean_element(p_cb->buffer, p_cb->idx);
+        int     remaining = elements - p_cb->idx;
+        double  p2 = mean_element(&p_cb->buffer[p_cb->len - 1 - remaining], remaining);
+
+        return p1 + p2;
+    }
+}
+
+/*!
+** @brief Take the max of the n most recent elements in the circular buffer
+*/
+double cbMax(double_cbuf_handle_t p_cb, int elements) {
+    if(elements == p_cb->len) {
+        return max_element(p_cb->buffer, p_cb->len);
+    }
+    else if(elements <= p_cb->idx) {
+        /* The current index is un-occupied, so start from the previous one */
+        return max_element(&p_cb->buffer[p_cb->idx - 1 - elements], elements);
+    }
+    else {
+        double  p1 = max_element(p_cb->buffer, p_cb->idx);
+        int     remaining = elements - p_cb->idx;
+        double  p2 = max_element(&p_cb->buffer[p_cb->len - 1 - remaining], remaining);
+
+        return p1 > p2 ? p1 : p2;
+    }
+}

--- a/unit_testing/array-math/CMakeLists.txt
+++ b/unit_testing/array-math/CMakeLists.txt
@@ -1,0 +1,47 @@
+####################################################################################################
+## Required to install gtest dependency
+####################################################################################################
+
+cmake_minimum_required(VERSION 3.14)
+project(unit_testing)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+####################################################################################################
+## Setup source code locations / include locations
+####################################################################################################
+
+set(SRC ../../STM32)
+set(LIB ../../STM32)
+set(INC_LIB ${LIB}/ADCMonitor/Inc ${LIB}/circularBuffer/Inc ${LIB}/Filtering/Inc 
+            ${LIB}/FLASH_readwrite/Inc ${LIB}/I2C/Inc ${LIB}/jumpToBootloader/Inc 
+            ${LIB}/Regulation/Inc ${LIB}/SPI/Inc ${LIB}/TransformationFunctions/Inc 
+            ${LIB}/USBprint/Inc ${LIB}/Util/Inc)
+set(UT_FAKES ../fakes)
+set(UT_STUBS ../stubs)
+
+####################################################################################################
+## List of tests to run
+###################################################################################################
+
+enable_testing()
+
+include(GoogleTest)
+
+# AC tests
+add_executable(arraymath_test arraymath_tests.cpp ${SRC}/Filtering/Src/array-math.c)
+target_include_directories(arraymath_test PRIVATE ${UT_FAKES} ${UT_STUBS} ${INC_LIB})
+target_link_libraries(arraymath_test GTest::gtest_main gmock_main)
+gtest_discover_tests(arraymath_test)

--- a/unit_testing/array-math/arraymath_tests.cpp
+++ b/unit_testing/array-math/arraymath_tests.cpp
@@ -96,31 +96,141 @@ TEST_F(ArrayMathTest, testMeanElement)
     EXPECT_DOUBLE_EQ(-DBL_MAX, result);
 }
 
-TEST_F(ArrayMathTest, testMeanElement)
+TEST_F(ArrayMathTest, testCbInit)
 {
     double testBuf[100] = {0};
+    double_cbuf_t test_cb;
 
     for(int i = 0; i < 100; i++) {
-        testBuf[i] = 100 * std::sin(2.0 * M_PI * i / 100.0);
+        testBuf[i] = i;
     }
 
+    /* Try calling with the wrong length */
+    EXPECT_EQ(-1, cbInit(&test_cb, testBuf, 0));
+    for(int i = 1; i < 100; i++) {
+        ASSERT_GT(testBuf[i], 0);
+    }
+
+    /* Try a good call */
+    EXPECT_EQ(0, cbInit(&test_cb, testBuf, 100));
+    for(int i = 0; i < 100; i++) {
+        ASSERT_EQ(testBuf[i], 0);
+    }
+}
+
+/* cbPush cannot be blackbox tested alone, only in conjunction with cbMean and cbMax */
+
+TEST_F(ArrayMathTest, testCbMean)
+{
+    double testBuf[100] = {0};
+    double_cbuf_t test_cb;
+    EXPECT_EQ(0, cbInit(&test_cb, testBuf, 100));
+
+    for(int i = 0; i < 50; i++) {
+        cbPush(&test_cb, i);
+    }
+
+    /* With half the array full, the mean of the last 50 and the last 100 should be the same */
     double result;
-    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
-    /* Due to floating point errors, the result is not quite zero. This is acceptable */
-    EXPECT_NEAR(0.0, result, 1E-10);
+    double correct1 = 25 * 49;
+    EXPECT_EQ(0, cbMean(&test_cb, 100, &result));
+    EXPECT_EQ(correct1 / 100, result);
+    EXPECT_EQ(0, cbMean(&test_cb, 50, &result));
+    EXPECT_EQ(correct1 / 50, result);
 
-    /* Check some other numbers influence the outcome */
-    testBuf[0] = -DBL_MAX;
-    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
-    EXPECT_DOUBLE_EQ(-DBL_MAX/100, result);
+    /* Add some more elements in */
+    for(int i = 0; i < 50; i++) {
+        cbPush(&test_cb, i + 100);
+    }
 
-    /* Try a different larger positive number */
-    testBuf[0] = 5000;
-    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
-    EXPECT_DOUBLE_EQ(50, result);
+    double correct2 = 25 * 249;
+    EXPECT_EQ(0, cbMean(&test_cb, 50, &result));
+    EXPECT_EQ(correct2 / 50, result);
+    EXPECT_EQ(0, cbMean(&test_cb, 100, &result));
+    EXPECT_EQ((correct1 + correct2)/100 , result);
+    
+    /* Add enough to loop round and start filling the buffer again */
+    for(int i = 0; i < 26; i++) {
+        cbPush(&test_cb, - 1 * i - 100);
+    }
 
-    /* Check error returned if 0 length selected */
-    result = -DBL_MAX;
-    EXPECT_EQ(-1, mean_element(testBuf, 0, &result));
-    EXPECT_DOUBLE_EQ(-DBL_MAX, result);
+    correct1 += - (13 * 225) - (13 * 25);
+    EXPECT_EQ(0, cbMean(&test_cb, 100, &result));
+    EXPECT_EQ((correct1 + correct2)/100, result);
+}
+
+TEST_F(ArrayMathTest, testCbMeanErrors)
+{
+    double testBuf[100] = {0};
+    double_cbuf_t test_cb;
+    EXPECT_EQ(0, cbInit(&test_cb, testBuf, 100));
+
+    for(int i = 0; i < 50; i++) {
+        cbPush(&test_cb, i);
+    }
+
+    /* With half the array full, the mean of the last 50 and the last 100 should be the same */
+    double result = 0;
+    double correct1 = 25 * 49;
+    EXPECT_EQ(-1, cbMean(&test_cb, 0, &result));
+    EXPECT_EQ(-1, cbMean(&test_cb, 500, &result));
+    EXPECT_EQ(0, result);
+
+}
+
+TEST_F(ArrayMathTest, testCbMax)
+{
+    double testBuf[100] = {0};
+    double_cbuf_t test_cb;
+    EXPECT_EQ(0, cbInit(&test_cb, testBuf, 100));
+
+    for(int i = 0; i < 50; i++) {
+        cbPush(&test_cb, i);
+    }
+
+    /* With half the array full, the mean of the last 50 and the last 100 should be the same */
+    double result;
+    double correct1 = 49;
+    EXPECT_EQ(0, cbMax(&test_cb, 100, &result));
+    EXPECT_EQ(correct1, result);
+    EXPECT_EQ(0, cbMax(&test_cb, 50, &result));
+    EXPECT_EQ(correct1, result);
+
+    /* Add some more elements in */
+    for(int i = 0; i < 50; i++) {
+        cbPush(&test_cb, i + 100);
+    }
+
+    double correct2 = 149;
+    EXPECT_EQ(0, cbMax(&test_cb, 50, &result));
+    EXPECT_EQ(correct2, result);
+    EXPECT_EQ(0, cbMax(&test_cb, 100, &result));
+    EXPECT_EQ(correct2, result);
+    
+    /* Add enough to loop round and start filling the buffer again */
+    for(int i = 0; i < 26; i++) {
+        cbPush(&test_cb, - 1 * i - 200);
+    }
+
+    EXPECT_EQ(0, cbMax(&test_cb, 100, &result));
+    EXPECT_EQ(correct2, result);
+}
+
+TEST_F(ArrayMathTest, testcbMaxErrors)
+{
+    double testBuf[100] = {0};
+    double_cbuf_t test_cb;
+    EXPECT_EQ(0, cbInit(&test_cb, testBuf, 100));
+
+    for(int i = 0; i < 50; i++) {
+        cbPush(&test_cb, i);
+    }
+
+    /* With half the array full, the mean of the last 50 and the last 100 should be the same */
+    double result = 0;
+    double correct1 = 49;
+    EXPECT_EQ(-1, cbMax(&test_cb, 0, &result));
+    EXPECT_EQ(-1, cbMax(&test_cb, 500, &result));
+    EXPECT_EQ(0, result);
+
 }

--- a/unit_testing/array-math/arraymath_tests.cpp
+++ b/unit_testing/array-math/arraymath_tests.cpp
@@ -1,0 +1,126 @@
+/*!
+** @file   arraymath_tests.cpp
+** @author Luke W
+** @date   17/04/2024
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cmath>
+
+/* Fakes */
+
+/* Real supporting units */
+
+/* UUT */
+#include "array-math.h"
+
+using ::testing::AnyOf;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using namespace std;
+
+/***************************************************************************************************
+** TEST FIXTURES
+***************************************************************************************************/
+
+class ArrayMathTest: public ::testing::Test 
+{
+    protected:
+        /*******************************************************************************************
+        ** METHODS
+        *******************************************************************************************/
+        ArrayMathTest() {}
+};
+
+/***************************************************************************************************
+** TESTS
+***************************************************************************************************/
+
+TEST_F(ArrayMathTest, testMaxElement)
+{
+    double testBuf[100] = {0};
+
+    for(int i = 0; i < 100; i++) {
+        testBuf[i] = 100 * std::sin(2.0 * M_PI * i / 100.0);
+    }
+
+    double result;
+    EXPECT_EQ(0, max_element(testBuf, 100, &result));
+    EXPECT_EQ(100.0, result);
+
+    /* Check larger negative numbers don't influence the outcome */
+    testBuf[13] = -DBL_MAX;
+    EXPECT_EQ(0, max_element(testBuf, 100, &result));
+    EXPECT_EQ(100.0, result);
+
+    /* Try a different larger positive number */
+    testBuf[58] = DBL_MAX;
+    EXPECT_EQ(0, max_element(testBuf, 100, &result));
+    EXPECT_EQ(DBL_MAX, result);
+
+    /* Check error returned if 0 length selected */
+    result = -DBL_MAX;
+    EXPECT_EQ(-1, max_element(testBuf, 0, &result));
+    EXPECT_EQ(-DBL_MAX, result);
+}
+
+TEST_F(ArrayMathTest, testMeanElement)
+{
+    double testBuf[100] = {0};
+
+    for(int i = 0; i < 100; i++) {
+        testBuf[i] = 100 * std::sin(2.0 * M_PI * i / 100.0);
+    }
+
+    double result;
+    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
+    /* Due to floating point errors, the result is not quite zero. This is acceptable */
+    EXPECT_NEAR(0.0, result, 1E-10);
+
+    /* Check some other numbers influence the outcome */
+    testBuf[0] = -DBL_MAX;
+    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
+    EXPECT_DOUBLE_EQ(-DBL_MAX/100, result);
+
+    /* Try a different larger positive number */
+    testBuf[0] = 5000;
+    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
+    EXPECT_DOUBLE_EQ(50, result);
+
+    /* Check error returned if 0 length selected */
+    result = -DBL_MAX;
+    EXPECT_EQ(-1, mean_element(testBuf, 0, &result));
+    EXPECT_DOUBLE_EQ(-DBL_MAX, result);
+}
+
+TEST_F(ArrayMathTest, testMeanElement)
+{
+    double testBuf[100] = {0};
+
+    for(int i = 0; i < 100; i++) {
+        testBuf[i] = 100 * std::sin(2.0 * M_PI * i / 100.0);
+    }
+
+    double result;
+    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
+    /* Due to floating point errors, the result is not quite zero. This is acceptable */
+    EXPECT_NEAR(0.0, result, 1E-10);
+
+    /* Check some other numbers influence the outcome */
+    testBuf[0] = -DBL_MAX;
+    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
+    EXPECT_DOUBLE_EQ(-DBL_MAX/100, result);
+
+    /* Try a different larger positive number */
+    testBuf[0] = 5000;
+    EXPECT_EQ(0, mean_element(testBuf, 100, &result));
+    EXPECT_DOUBLE_EQ(50, result);
+
+    /* Check error returned if 0 length selected */
+    result = -DBL_MAX;
+    EXPECT_EQ(-1, mean_element(testBuf, 0, &result));
+    EXPECT_DOUBLE_EQ(-DBL_MAX, result);
+}

--- a/unit_testing/unitTests.py
+++ b/unit_testing/unitTests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import os
+import sys
+
+def run_tests_in_subdirectory(dir, regex, verbose):
+    subprocess.run("cmake -S . -B build", shell=True, cwd=dir)
+    subprocess.run("cmake --build build", shell=True, cwd=dir)
+
+    run_str = "cd build && ctest"
+    run_str += regex
+    run_str += verbose
+
+    ret = subprocess.run(run_str, shell=True, cwd=dir)
+    return ret.returncode
+        
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run unit tests')
+    parser.add_argument('-D', '--dir', help='Run the CMakeLists.txt in the specified directory')
+    parser.add_argument('-R', '--regex', help='Only run the unit tests matching this regex')
+    parser.add_argument('-v', '--verbose', action="store_true", help='Maximum output')
+    args = parser.parse_args()
+
+    regex=""
+    if(args.regex):
+        regex += f" -R {args.regex}"
+
+    verbose=""
+    if(args.verbose):
+        verbose += f" --output-on-failure"
+
+    # Run the tests in the specified directory
+    if (args.dir):
+        sys.exit(run_tests_in_subdirectory(f"{args.dir}", regex, verbose))
+
+    #If the directory is not specified then run all tests from all sub-directories
+    returncodes = []
+    for f in os.scandir(os.getcwd()):
+        if f.is_dir():
+            returncodes.append(run_tests_in_subdirectory(f.name, regex, verbose))
+    sys.exit(any(r != 0 for r in returncodes))

--- a/unit_testing/unitTests.py
+++ b/unit_testing/unitTests.py
@@ -39,6 +39,6 @@ if __name__ == "__main__":
     #If the directory is not specified then run all tests from all sub-directories
     returncodes = []
     for f in os.scandir(os.getcwd()):
-        if f.is_dir():
+        if f.is_dir() and f.name not in ["fakes", "stubs"]:
             returncodes.append(run_tests_in_subdirectory(f.name, regex, verbose))
     sys.exit(any(r != 0 for r in returncodes))


### PR DESCRIPTION
Added functions to:
* Calculate max of buffer of double
* Calculate mean of buffer of double
* Setup circularBuffer of double
* Add new data to circular buffer (automatically discarding old data)
* Calculate max/mean of last N elements of circular buffer.

Note: can't use existing circular buffer implementation from circularBuffer, as this is uint8_t. I could be convinced the new CB functions should go in there though. 