### PR TITLE
Dev/usb improvements

### DIFF
--- a/STM32/USBprint/Inc/USBprint.h
+++ b/STM32/USBprint/Inc/USBprint.h
@@ -30,4 +30,6 @@ int usbRx(uint8_t* buf);
 
 void usbFlush();
 
+uint32_t isUsbError();
+
 #endif /* INC_USBPRINT_H_ */

--- a/STM32/USBprint/Inc/usb_cdc_fops.h
+++ b/STM32/USBprint/Inc/usb_cdc_fops.h
@@ -17,22 +17,37 @@
 #ifndef USB_CDC_FOPS_H
 #define USB_CDC_FOPS_H
 
-#ifdef __cplusplus
- extern "C" {
-#endif
+#include <stdbool.h>
+#include <stdint.h>
 
 #include "usbd_cdc.h"
-#include "stdbool.h"
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
+
+#define CIRCULAR_BUFFER_SIZE 1024
+
+/***************************************************************************************************
+** PUBLIC OBJECT DECLARATION
+***************************************************************************************************/
 
 extern USBD_CDC_ItfTypeDef usb_cdc_fops;
 
-#define CIRCULAR_BUFFER_SIZE 1024
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
 
 ssize_t usb_cdc_transmit(const uint8_t* Buf, uint16_t len);
 size_t usb_cdc_tx_available();
 int usb_cdc_rx(uint8_t* buf);
 void usb_cdc_rx_flush();
 bool isComPortOpen();
+bool isUsbError();
 
 #ifdef __cplusplus
 }

--- a/STM32/USBprint/Inc/usb_cdc_fops.h
+++ b/STM32/USBprint/Inc/usb_cdc_fops.h
@@ -32,6 +32,11 @@
 
 #define CIRCULAR_BUFFER_SIZE 1024
 
+#define CDC_ERROR_NONE              0x00000000U
+#define CDC_ERROR_DELAYED_TRANSMIT  0x00000001U
+#define CDC_ERROR_TRANSMIT          0x00000002U
+#define CDC_ERROR_CROPPED_TRANSMIT  0x00000004U
+
 /***************************************************************************************************
 ** PUBLIC OBJECT DECLARATION
 ***************************************************************************************************/
@@ -47,7 +52,7 @@ size_t usb_cdc_tx_available();
 int usb_cdc_rx(uint8_t* buf);
 void usb_cdc_rx_flush();
 bool isComPortOpen();
-bool isUsbError();
+uint32_t isCdcError();
 
 #ifdef __cplusplus
 }

--- a/STM32/USBprint/Inc/usb_cdc_fops.h
+++ b/STM32/USBprint/Inc/usb_cdc_fops.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include "usbd_cdc.h"
 

--- a/STM32/USBprint/Src/USBprint.c
+++ b/STM32/USBprint/Src/USBprint.c
@@ -6,10 +6,11 @@
  */
 
 
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+
 #include "USBprint.h"
-#include "stdarg.h"
-#include "string.h"
-#include "stdio.h"
 #include "usb_cdc_fops.h"
 
 int USBnprintf(const char * format, ... )
@@ -22,14 +23,23 @@ int USBnprintf(const char * format, ... )
     len += vsnprintf(&buffer[len], sizeof(buffer) - len, format, args);
     va_end (args);
 
-    /* Error code actually captured in lower level module */
-    return usb_cdc_transmit((uint8_t*)buffer, len);
+    /* Error code captured in lower level module */
+    ssize_t ret = usb_cdc_transmit((uint8_t*)buffer, len);
+    if(ret >= 2) {
+        return ret - 2;
+    }
+    else if(ret >= 0) {
+        return 0;
+    }
+    else {
+        return ret;
+    }
 }
 
 ssize_t writeUSB(const void *buf, size_t count)
 {
-    /* Error code actually captured in lower level module */
-    return usb_cdc_transmit(buf, count);
+    /* Error code captured in lower level module */
+    return usb_cdc_transmit((const uint8_t*)buf, count);
 }
 
 size_t txAvailable()

--- a/STM32/USBprint/Src/USBprint.c
+++ b/STM32/USBprint/Src/USBprint.c
@@ -24,7 +24,7 @@ int USBnprintf(const char * format, ... )
     va_end (args);
 
     /* Error code captured in lower level module */
-    ssize_t ret = usb_cdc_transmit((uint8_t*)buffer, len);
+    ssize_t ret = usb_cdc_transmit((const uint8_t*)buffer, len);
     if(ret >= 2) {
         return ret - 2;
     }

--- a/STM32/USBprint/Src/USBprint.c
+++ b/STM32/USBprint/Src/USBprint.c
@@ -25,12 +25,19 @@ int USBnprintf(const char * format, ... )
 
     /* Error code captured in lower level module */
     ssize_t ret = usb_cdc_transmit((const uint8_t*)buffer, len);
+
+    /* Since this function adds 2 characters to the transmit, remove those from the return value. 
+    ** It is most likely a user will want to compare the length sent with the length of the input 
+    ** string. */
     if(ret >= 2) {
         return ret - 2;
     }
+    /* This situation should probably never happen, since this function always adds 2, but there 
+    ** could be an issue in a lower level module */
     else if(ret >= 0) {
         return 0;
     }
+    /* Any value less than 0 is an error, so pass that up */
     else {
         return ret;
     }

--- a/STM32/USBprint/Src/USBprint.c
+++ b/STM32/USBprint/Src/USBprint.c
@@ -22,8 +22,7 @@ int USBnprintf(const char * format, ... )
     len += vsnprintf(&buffer[len], sizeof(buffer) - len, format, args);
     va_end (args);
 
-    usb_cdc_transmit((uint8_t*)buffer, len);
-    return len;
+    return usb_cdc_transmit((uint8_t*)buffer, len);
 }
 
 ssize_t writeUSB(const void *buf, size_t count)

--- a/STM32/USBprint/Src/USBprint.c
+++ b/STM32/USBprint/Src/USBprint.c
@@ -22,11 +22,13 @@ int USBnprintf(const char * format, ... )
     len += vsnprintf(&buffer[len], sizeof(buffer) - len, format, args);
     va_end (args);
 
+    /* Error code actually captured in lower level module */
     return usb_cdc_transmit((uint8_t*)buffer, len);
 }
 
 ssize_t writeUSB(const void *buf, size_t count)
 {
+    /* Error code actually captured in lower level module */
     return usb_cdc_transmit(buf, count);
 }
 
@@ -57,4 +59,11 @@ int usbRx(uint8_t* buf)
 void usbFlush()
 {
     usb_cdc_rx_flush();
+}
+
+/*!
+** @brief Returns if there has been an error in the USB stack
+*/
+uint32_t isUsbError() {
+    return isCdcError();
 }

--- a/STM32/USBprint/Src/usb_cdc_fops.c
+++ b/STM32/USBprint/Src/usb_cdc_fops.c
@@ -1,18 +1,34 @@
-/*
- * TODO:
- */
+/*!
+** @file usb_cdc_fops.h
+** @author Luke W
+** @date   Apr 2024
+*/
+
+#include <assert.h>
+#include <stdbool.h>
 
 #include "usb_cdc_fops.h"
 #include "circular_buffer.h"
-#include <stdbool.h>
+
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
 
 #define CDC_INIT_TIME 10
+
+/***************************************************************************************************
+** PRIVATE FUNCTION DECLARATIONS
+***************************************************************************************************/
 
 static int8_t CDC_Init_FS(void);
 static int8_t CDC_DeInit_FS(void);
 static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length);
 static int8_t CDC_Receive_FS(uint8_t* pbuf, uint32_t *Len);
 static int8_t CDC_TransmitCplt_FS(uint8_t *pbuf, uint32_t *Len, uint8_t epnum);
+
+/***************************************************************************************************
+** PUBLIC OBJECTS
+***************************************************************************************************/
 
 extern USBD_HandleTypeDef hUsbDeviceFS;
 USBD_CDC_ItfTypeDef usb_cdc_fops =
@@ -23,6 +39,10 @@ USBD_CDC_ItfTypeDef usb_cdc_fops =
         CDC_Receive_FS,
         CDC_TransmitCplt_FS
 };
+
+/***************************************************************************************************
+** PRIVATE OBJECTS
+***************************************************************************************************/
 
 static USBD_CDC_LineCodingTypeDef LineCoding = {
         115200, /* baud rate     */
@@ -39,23 +59,121 @@ static struct
         uint8_t irqBuf[CIRCULAR_BUFFER_SIZE];   // lower layer buffer for IRQ USB_CDC driver callback
     } tx, rx;
     enum {
-    	closed,
-		preOpen,
-		open
+        closed,
+        preOpen,
+        open
     } isComPortOpen;
     unsigned long portOpenTime;
 } usb_cdc_if = { {0}, {0}, closed, 0};
 
+static volatile bool usb_error = false;
+
+static circular_buf_t   tx_cb;
+static uint8_t          tx_buf[CIRCULAR_BUFFER_SIZE] = {0};
+static circular_buf_t   rx_cb;
+static uint8_t          rx_buf[CIRCULAR_BUFFER_SIZE] = {0};
+
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DEFINITIONS
+***************************************************************************************************/
+
 bool isComPortOpen() {
-	// The USB CDC needs to be initialised and open for some time before the COM port is opened properly
-	if (usb_cdc_if.isComPortOpen == open ||
-	   (HAL_GetTick() - usb_cdc_if.portOpenTime > CDC_INIT_TIME && usb_cdc_if.isComPortOpen == preOpen))
-	{
-		usb_cdc_if.isComPortOpen = open;
-		return true;
-	}
-	return false;
+    // The USB CDC needs to be initialised and open for some time before the COM port is opened properly
+    if (usb_cdc_if.isComPortOpen == open ||
+       (HAL_GetTick() - usb_cdc_if.portOpenTime > CDC_INIT_TIME && usb_cdc_if.isComPortOpen == preOpen))
+    {
+        usb_cdc_if.isComPortOpen = open;
+        return true;
+    }
+    return false;
 }
+
+void usb_cdc_rx_flush()
+{
+    if (!usb_cdc_if.tx.ctx)
+        return; // Error, USB CDC is not initialized
+
+    circular_buf_reset(usb_cdc_if.rx.ctx);
+}
+
+int usb_cdc_rx(uint8_t* rxByte)
+{
+    if (!usb_cdc_if.tx.ctx)
+        return -1; // Error, USB CDC is not initialized
+
+    return circular_buf_get(usb_cdc_if.rx.ctx, rxByte);
+}
+
+/**
+  * @brief  CDC_Transmit_FS
+  *         Data to send over USB IN endpoint are sent over CDC interface
+  *         through this function.
+  *
+  * @param  Buf: Buffer of data to be sent
+  * @param  Len: Number of data to be sent (in bytes)
+  * @retval USBD_OK if all operations are OK else USBD_FAIL or USBD_BUSY
+  */
+ssize_t usb_cdc_transmit(const uint8_t* Buf, uint16_t Len)
+{
+    if (!usb_cdc_if.tx.ctx)
+        return -1; // Error, USB CDC is not initialized
+
+    USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
+
+    if (hcdc->TxState != 0)
+    {
+        // USB CDC is transmitting data to the network. Leave transmit handling to CDC_TransmitCplt_FS
+        for (int len = 0;len < Len; len++)
+        {
+            if (circular_buf_put(usb_cdc_if.tx.ctx, *Buf))
+                return len; // len < Len since not enough space in buffer. Leave error handling to caller.
+            Buf++;
+        }
+        return Len;
+    }
+
+    // Fill in the data from buffer directly, no need copy bytes
+    if (Len > sizeof(usb_cdc_if.tx.irqBuf))
+    {
+        // remaining bytes could be moved to circular buffer but in this case,
+        // system is possible in a lack of resources. That problem can not be solved hear.
+        Len = sizeof(usb_cdc_if.tx.irqBuf);
+        usb_error = true;
+    }
+
+    memcpy(usb_cdc_if.tx.irqBuf, Buf, Len);
+    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, Len);
+    if (USBD_CDC_TransmitPacket(&hUsbDeviceFS) != USBD_OK) {
+        usb_error = true;
+        return -1; // Something went wrong in IO layer.
+    }
+
+    // All good.
+    return Len;
+}
+
+size_t usb_cdc_tx_available()
+{
+    if (!usb_cdc_if.tx.ctx)
+        return 0; // Error, USB CDC is not initialised, for now return 0.
+
+    return circular_buf_capacity(usb_cdc_if.tx.ctx) - circular_buf_size(usb_cdc_if.tx.ctx);
+}
+
+
+bool isUsbError() {
+    bool r = usb_error;
+    if(usb_error) {
+        usb_error = false;
+    }
+    
+    return r;
+}
+
+/***************************************************************************************************
+** PRIVATE FUNCTION DEFINITIONS
+***************************************************************************************************/
 
 /**
   * @brief  Initializes the CDC media low layer over the FS USB IP
@@ -63,13 +181,16 @@ bool isComPortOpen() {
   */
 static int8_t CDC_Init_FS(void)
 {
+    /* Only way subsequent USBD_CDC functions can fail is if this parameter is NULL */
+    assert(hUsbDeviceFS.pClassDataCmsit[hUsbDeviceFS.classId] != NULL);
+    
     // Setup TX Buffer
     USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, 0);
-    usb_cdc_if.tx.ctx = circular_buf_init(CIRCULAR_BUFFER_SIZE);
+    usb_cdc_if.tx.ctx = circular_buf_init_static(&tx_cb, tx_buf, CIRCULAR_BUFFER_SIZE);
 
     // Setup RX Buffer
     USBD_CDC_SetRxBuffer(&hUsbDeviceFS, usb_cdc_if.rx.irqBuf);
-    usb_cdc_if.rx.ctx = circular_buf_init(CIRCULAR_BUFFER_SIZE);
+    usb_cdc_if.rx.ctx = circular_buf_init_static(&rx_cb, rx_buf, CIRCULAR_BUFFER_SIZE);
 
     // Default is no host attached.
     usb_cdc_if.isComPortOpen = false;
@@ -140,15 +261,15 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
     break;
 
     case CDC_SET_CONTROL_LINE_STATE:
-    	if ((((USBD_SetupReqTypedef *) pbuf)->wValue & 0x0001) == 0)
-    	{
-    		usb_cdc_if.isComPortOpen = closed;
-    	}
-    	else
-    	{
-    		usb_cdc_if.isComPortOpen = preOpen;
-    		usb_cdc_if.portOpenTime = HAL_GetTick();
-    	}
+        if ((((USBD_SetupReqTypedef *) pbuf)->wValue & 0x0001) == 0)
+        {
+            usb_cdc_if.isComPortOpen = closed;
+        }
+        else
+        {
+            usb_cdc_if.isComPortOpen = preOpen;
+            usb_cdc_if.portOpenTime = HAL_GetTick();
+        }
     break;
 
     case CDC_SEND_BREAK:    break;
@@ -175,87 +296,21 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
   */
 static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 {
+    /* Only way subsequent USBD_CDC functions can fail is if this parameter is NULL */
+    assert(hUsbDeviceFS.pClassDataCmsit[hUsbDeviceFS.classId] != NULL);
+
     USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
     USBD_CDC_ReceivePacket(&hUsbDeviceFS);
 
     uint16_t len = (uint16_t)*Len;
 
     // Update circular buffer with incoming values
-    for(uint8_t i = 0; i < len; i++)
+    for(uint8_t i = 0; i < len; i++) {
         circular_buf_put(usb_cdc_if.rx.ctx, Buf[i]);
+    }
 
     memset(Buf, '\0', len); // clear the buffer
     return (USBD_OK);
-}
-
-
-void usb_cdc_rx_flush()
-{
-    if (!usb_cdc_if.tx.ctx)
-        return; // Error, USB CDC is not initialized
-
-    circular_buf_reset(usb_cdc_if.rx.ctx);
-}
-
-int usb_cdc_rx(uint8_t* rxByte)
-{
-    if (!usb_cdc_if.tx.ctx)
-        return -1; // Error, USB CDC is not initialized
-
-    return circular_buf_get(usb_cdc_if.rx.ctx, rxByte);
-}
-
-/**
-  * @brief  CDC_Transmit_FS
-  *         Data to send over USB IN endpoint are sent over CDC interface
-  *         through this function.
-  *
-  * @param  Buf: Buffer of data to be sent
-  * @param  Len: Number of data to be sent (in bytes)
-  * @retval USBD_OK if all operations are OK else USBD_FAIL or USBD_BUSY
-  */
-ssize_t usb_cdc_transmit(const uint8_t* Buf, uint16_t Len)
-{
-    if (!usb_cdc_if.tx.ctx)
-        return -1; // Error, USB CDC is not initialized
-
-    USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
-
-    if (hcdc->TxState != 0)
-    {
-        // USB CDC is transmitting data to the network. Leave transmit handling to CDC_TransmitCplt_FS
-        for (int len = 0;len < Len; len++)
-        {
-            if (circular_buf_put(usb_cdc_if.tx.ctx, *Buf))
-                return len; // len < Len since not enough space in buffer. Leave error handling to caller.
-            Buf++;
-        }
-        return Len;
-    }
-
-    // Fill in the data from buffer directly, no need copy bytes
-    if (Len > sizeof(usb_cdc_if.tx.irqBuf))
-    {
-        // remaining bytes could be moved to circular buffer but in this case,
-        // system is possible in a lack of resources. That problem can not be solved hear.
-        Len = sizeof(usb_cdc_if.tx.irqBuf);
-    }
-
-    memcpy(usb_cdc_if.tx.irqBuf, Buf, Len);
-    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, Len);
-    if (USBD_CDC_TransmitPacket(&hUsbDeviceFS) != USBD_OK)
-        return -1; // Something went wrong in IO layer.
-
-    // All good.
-    return Len;
-}
-
-size_t usb_cdc_tx_available()
-{
-    if (!usb_cdc_if.tx.ctx)
-        return 0; // Error, USB CDC is not initialised, for now return 0.
-
-    return circular_buf_capacity(usb_cdc_if.tx.ctx) - circular_buf_size(usb_cdc_if.tx.ctx);
 }
 
 /**
@@ -272,6 +327,9 @@ size_t usb_cdc_tx_available()
   */
 static int8_t CDC_TransmitCplt_FS(uint8_t *Buf, uint32_t *Len, uint8_t epnum)
 {
+    /* Only way subsequent USBD_CDC functions can fail is if this parameter is NULL */
+    assert(hUsbDeviceFS.pClassDataCmsit[hUsbDeviceFS.classId] != NULL);
+
     uint8_t result = USBD_OK;
 
     // Fill in the next number of bytes.
@@ -288,6 +346,10 @@ static int8_t CDC_TransmitCplt_FS(uint8_t *Buf, uint32_t *Len, uint8_t epnum)
     {
         USBD_CDC_SetTxBuffer(&hUsbDeviceFS, usb_cdc_if.tx.irqBuf, len);
         result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
+    }
+
+    if(result != USBD_OK) {
+        usb_error = true;
     }
 
     return result;

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -27,10 +27,13 @@ extern "C" {
 #define BS_VERSION_ERROR_Pos                26U
 #define BS_VERSION_ERROR_Msk                (1UL << BS_VERSION_ERROR_Pos)
 
+#define BS_USB_ERROR_Pos                    25U
+#define BS_USB_ERROR_Msk                    (1UL << BS_USB_ERROR_Pos)
+
 /* Used for defining which bits are errors, and which are statuses */
 #define BS_SYSTEM_ERRORS_Msk                (BS_OVER_TEMPERATURE_Msk | BS_UNDER_VOLTAGE_Msk | \
                                              BS_OVER_VOLTAGE_Msk | BS_OVER_CURRENT_Msk | \
-                                             BS_VERSION_ERROR_Msk)
+                                             BS_VERSION_ERROR_Msk | BS_USB_ERROR_Msk)
 
 // NOTE!! Do not change order or values since this list must match ALL OTP programmers.
 typedef enum {
@@ -120,6 +123,7 @@ uint32_t bsGetField(uint32_t field);
 void setBoardTemp(float temp);
 void setBoardVoltage(float voltage);
 void setBoardCurrent(float current);
+void setBoardUsbError(uint32_t err);
 
 /*!
 ** @brief Sets the board type, the firmware is expecting to be used with

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -3,6 +3,7 @@
  */
 
 #include <stdio.h>
+
 #include "HAL_otp.h"
 #include "systemInfo.h"
 
@@ -28,6 +29,7 @@ static struct BS
     float temp;
     float voltage;
     float current;
+    uint32_t usb;
     BoardType boardType;
     pcbVersion pcb_version;
 } BS = {0};
@@ -205,6 +207,13 @@ const char* statusInfo(bool printStart)
             (int)bt, (int)BS.boardType, pv.major, pv.minor, BS.pcb_version.major, BS.pcb_version.minor);
     }
 
+    if (BS.usb)
+    {
+        len += snprintf(&buf[len], sizeof(buf) - len, 
+                        "USB. USB communication error 0x%08lx occurred most recently.\r\n", BS.usb);
+        BS.usb = 0U;
+    }
+
     return buf;
 }
 
@@ -292,5 +301,6 @@ uint32_t bsGetField(uint32_t field){ return BS.boardStatus & field; }
 void setBoardTemp(float temp){ BS.temp = temp; }
 void setBoardVoltage(float voltage){ BS.voltage = voltage; }
 void setBoardCurrent(float current){ BS.current = current; }
+void setBoardUsbError(uint32_t err) {BS.usb = err; }
 void setFirmwareBoardType(BoardType type){ BS.boardType = type; }
 void setFirmwareBoardVersion(pcbVersion version){ BS.pcb_version = version; }

--- a/STM32/circularBuffer/Inc/circular_buffer.h
+++ b/STM32/circularBuffer/Inc/circular_buffer.h
@@ -4,8 +4,14 @@
 #include <stdio.h>       // Needed for size_t
 #include <stdbool.h>     // Needed for bool
 
-/// Opaque circular buffer structure
-typedef struct circular_buf_t circular_buf_t;
+/// Circular buffer structure
+typedef struct circular_buf_t {
+    uint8_t * buffer;
+    size_t head;
+    size_t tail;
+    size_t max;
+    bool full;
+} circular_buf_t;
 
 /// Handle type, the way users interact with the API
 typedef circular_buf_t* cbuf_handle_t;
@@ -14,6 +20,11 @@ typedef circular_buf_t* cbuf_handle_t;
 /// Requires: buffer is not NULL, size > 0
 /// Ensures: cbuf has been created and is returned in an empty state
 cbuf_handle_t circular_buf_init(size_t size);
+
+/// Pass in a storage buffer and size, returns a circular buffer handle
+/// Requires: buffer is not NULL, size > 0
+/// Ensures: cbuf has been created and is returned in an empty state
+cbuf_handle_t circular_buf_init_static(circular_buf_t* cb, uint8_t* buf, size_t size);
 
 /// Free a circular buffer structure
 /// Requires: cbuf is valid and created by circular_buf_init

--- a/STM32/circularBuffer/Inc/circular_buffer.h
+++ b/STM32/circularBuffer/Inc/circular_buffer.h
@@ -4,6 +4,10 @@
 #include <stdio.h>       // Needed for size_t
 #include <stdbool.h>     // Needed for bool
 
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
 /// Circular buffer structure
 typedef struct circular_buf_t {
     uint8_t * buffer;
@@ -64,5 +68,9 @@ size_t circular_buf_capacity(cbuf_handle_t cbuf);
 /// Requires: cbuf is valid and created by circular_buf_init
 /// Returns the current number of elements in the buffer
 size_t circular_buf_size(cbuf_handle_t cbuf);
+
+#ifdef __cplusplus
+  }
+#endif
 
 #endif //CIRCULAR_BUFFER_H_

--- a/STM32/circularBuffer/Src/circular_buffer.c
+++ b/STM32/circularBuffer/Src/circular_buffer.c
@@ -15,38 +15,29 @@
 #include <string.h> /* memset */
 #include "circular_buffer.h"
 
-// The definition of our circular buffer structure is hidden from the user
-struct circular_buf_t {
-	uint8_t * buffer;
-	size_t head;
-	size_t tail;
-	size_t max;
-	bool full;
-};
-
 //#pragma mark - Private Functions -
 
 static void advance_pointer(cbuf_handle_t cbuf)
 {
-	assert(cbuf);
+    assert(cbuf);
 
-	if(circular_buf_full(cbuf))
+    if(circular_buf_full(cbuf))
     {
         cbuf->tail = (cbuf->tail + 1) % cbuf->max;
     }
 
-	cbuf->head = (cbuf->head + 1) % cbuf->max;
+    cbuf->head = (cbuf->head + 1) % cbuf->max;
 
-	// We mark full because we will advance tail on the next time around
-	cbuf->full = (cbuf->head == cbuf->tail);
+    // We mark full because we will advance tail on the next time around
+    cbuf->full = (cbuf->head == cbuf->tail);
 }
 
 static void retreat_pointer(cbuf_handle_t cbuf)
 {
-	assert(cbuf);
+    assert(cbuf);
 
-	cbuf->full = false;
-	cbuf->tail = (cbuf->tail + 1) % cbuf->max;
+    cbuf->full = false;
+    cbuf->tail = (cbuf->tail + 1) % cbuf->max;
 }
 
 cbuf_handle_t circular_buf_init(size_t size)
@@ -58,6 +49,18 @@ cbuf_handle_t circular_buf_init(size_t size)
     cbuf->buffer = malloc(size);
     assert(cbuf->buffer);
 
+    cbuf->max = size;
+    circular_buf_reset(cbuf);
+
+    assert(circular_buf_empty(cbuf));
+    return cbuf;
+}
+
+cbuf_handle_t circular_buf_init_static(circular_buf_t* cb, uint8_t* buf, size_t size) {
+    assert(size);
+
+    cbuf_handle_t cbuf = cb;
+    cbuf->buffer = buf;
     cbuf->max = size;
     circular_buf_reset(cbuf);
 
@@ -86,31 +89,31 @@ void circular_buf_reset(cbuf_handle_t cbuf)
 
 size_t circular_buf_size(cbuf_handle_t cbuf)
 {
-	assert(cbuf);
+    assert(cbuf);
 
-	size_t size = cbuf->max;
+    size_t size = cbuf->max;
 
-	if(!circular_buf_full(cbuf))
-	{
-		if(cbuf->head >= cbuf->tail)
-		{
-			size = (cbuf->head - cbuf->tail);
-		}
-		else
-		{
-			size = (cbuf->max + cbuf->head - cbuf->tail);
-		}
+    if(!circular_buf_full(cbuf))
+    {
+        if(cbuf->head >= cbuf->tail)
+        {
+            size = (cbuf->head - cbuf->tail);
+        }
+        else
+        {
+            size = (cbuf->max + cbuf->head - cbuf->tail);
+        }
 
-	}
+    }
 
-	return size;
+    return size;
 }
 
 size_t circular_buf_capacity(cbuf_handle_t cbuf)
 {
-	assert(cbuf);
+    assert(cbuf);
 
-	return cbuf->max;
+    return cbuf->max;
 }
 
 int circular_buf_put(cbuf_handle_t cbuf, uint8_t data)
@@ -148,14 +151,14 @@ int circular_buf_get(cbuf_handle_t cbuf, uint8_t * data)
 
 bool circular_buf_empty(cbuf_handle_t cbuf)
 {
-	assert(cbuf);
+    assert(cbuf);
 
     return (!circular_buf_full(cbuf) && (cbuf->head == cbuf->tail));
 }
 
 bool circular_buf_full(cbuf_handle_t cbuf)
 {
-	assert(cbuf);
+    assert(cbuf);
 
     return cbuf->full;
 }

--- a/unit_testing/USBprint/CMakeLists.txt
+++ b/unit_testing/USBprint/CMakeLists.txt
@@ -1,0 +1,47 @@
+####################################################################################################
+## Required to install gtest dependency
+####################################################################################################
+
+cmake_minimum_required(VERSION 3.14)
+project(unit_testing)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+####################################################################################################
+## Setup source code locations / include locations
+####################################################################################################
+
+set(SRC ../../STM32/USBprint/Src)
+set(LIB ../../STM32)
+set(INC_LIB ${LIB}/USBprint/Inc ${LIB}/USBprint/Src ${LIB}/circularBuffer/Inc)
+set(UT_FAKES ../fakes)
+set(UT_STUBS ../stubs)
+set(UT_REDIRECTS ../redirects)
+
+
+####################################################################################################
+## List of tests to run
+###################################################################################################
+
+enable_testing()
+
+include(GoogleTest)
+
+# USBprint tests
+add_executable(usbprint_test usbprint_tests.cpp ${LIB}/circularBuffer/Src/circular_buffer.c ${UT_FAKES}/fake_stm32xxxx_hal.cpp ${UT_FAKES}/fake_usbd_cdc.cpp)
+target_include_directories(usbprint_test PRIVATE ${UT_FAKES} ${UT_STUBS} ${UT_REDIRECTS} ${INC_LIB})
+target_link_libraries(usbprint_test GTest::gtest_main gmock_main)
+target_compile_definitions(usbprint_test PUBLIC UNIT_TESTING)
+gtest_discover_tests(usbprint_test)

--- a/unit_testing/USBprint/usbprint_tests.cpp
+++ b/unit_testing/USBprint/usbprint_tests.cpp
@@ -1,0 +1,218 @@
+/*!
+** @file   arraymath_tests.cpp
+** @author Luke W
+** @date   17/04/2024
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+/* Fakes */
+#include "fake_usbd_cdc.h"
+#include "fake_stm32xxxx_hal.h"
+
+/* Real supporting units */
+#include "usb_cdc_fops.c"
+
+/* UUT */
+#include "USBprint.c"
+
+using ::testing::AnyOf;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::IsSubsetOf;
+using ::testing::IsSupersetOf;
+using namespace std;
+
+/***************************************************************************************************
+** TEST FIXTURES
+***************************************************************************************************/
+
+USBD_HandleTypeDef hUsbDeviceFS;
+
+class UsbPrintTest: public ::testing::Test 
+{
+    protected:
+        /*******************************************************************************************
+        ** METHODS
+        *******************************************************************************************/
+        UsbPrintTest() {
+            /* Minimal setup required for usb_cdc_fops.c */
+            hUsbDeviceFS.pClassData = (void*) malloc(sizeof(USBD_CDC_HandleTypeDef));
+            ((USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData)->TxState = 0;
+
+            /* Only required to prevent asserts from triggering */
+            hUsbDeviceFS.classId = 0;
+            hUsbDeviceFS.pClassDataCmsit[hUsbDeviceFS.classId] = (void*)0x00000004U;
+
+            /* For manipulating lower level fake/mock - pass by defult */
+            hUsbDeviceFS.ret_val = 0;
+        }
+
+        void sendUsbData(const char * data) {
+            uint32_t len = strlen(data);
+            char buf[20];
+            memcpy(buf, data, len);
+            usb_cdc_fops.Receive((uint8_t*)buf, &len);
+
+            /* Buffer should be cleared after receive */
+            for(int i = 0; i < len; i++) {
+                ASSERT_EQ(0, buf[i]);
+            }
+        }
+};
+
+/***************************************************************************************************
+** TESTS
+***************************************************************************************************/
+
+TEST_F(UsbPrintTest, test_init) {
+    EXPECT_EQ(-1, USBnprintf("Hello world!"));
+    usb_cdc_fops.Init();
+    EXPECT_NE(-1, USBnprintf("Hello world!"));
+    EXPECT_READ_USB(Contains("Hello world!"));
+}
+
+TEST_F(UsbPrintTest, test_usbformatting) {
+    usb_cdc_fops.Init();
+
+    EXPECT_EQ(txAvailable(), 1024);
+    EXPECT_EQ(7, USBnprintf("Testing"));
+    
+    /* For a handful of used format specifiers, check them */
+    EXPECT_EQ(10, USBnprintf("Testing %u", 11));
+    EXPECT_READ_USB(Contains("Testing 11"));
+
+    EXPECT_EQ(12, USBnprintf("Testing %lu", 1122));
+    EXPECT_READ_USB(Contains("Testing 1122"));
+
+    EXPECT_EQ(11, USBnprintf("Testing %d", -12));
+    EXPECT_READ_USB(Contains("Testing -12"));
+
+    EXPECT_EQ(12, USBnprintf("Testing %x", 0x1234));
+    EXPECT_READ_USB(Contains("Testing 1234"));
+
+    EXPECT_EQ(8, USBnprintf("%8x", 0x1234));
+    EXPECT_READ_USB(Contains("    1234"));
+
+    EXPECT_EQ(6, USBnprintf("%06x", 0x1234));
+    EXPECT_READ_USB(Contains("001234"));
+
+    EXPECT_EQ(10, USBnprintf("%f", 392.65));
+    EXPECT_READ_USB(Contains("392.650000"));
+
+    EXPECT_EQ(8, USBnprintf("%.4f", 392.65));
+    EXPECT_READ_USB(Contains("392.6500"));
+    
+    EXPECT_EQ(9, USBnprintf("%09.4f", 987.654));
+    EXPECT_READ_USB(Contains("0987.6540"));
+
+    EXPECT_EQ(16, USBnprintf("Testing: %s", "Success"));
+    EXPECT_READ_USB(Contains("Testing: Success"));
+
+    EXPECT_EQ(txAvailable(), 1024);
+}
+
+TEST_F(UsbPrintTest, test_usbRecv) {
+    usb_cdc_fops.Init();
+
+    sendUsbData("Test String\n12345");
+
+    uint8_t buf[20] = {0};
+    int i = 0;
+    while(usbRx(&buf[i++]) == 0) {}
+    EXPECT_EQ(i - 1, 17);
+    EXPECT_STREQ((char*) buf, "Test String\n12345");
+}
+
+TEST_F(UsbPrintTest, test_delayedSend) {
+    usb_cdc_fops.Init();
+
+    /* Make the USB "busy" */
+    ((USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData)->TxState = 1;
+
+    EXPECT_EQ(txAvailable(), 1024);
+    USBnprintf("test_delayed_send");
+    /* Note additional 2 bytes are from CRLF USBnprintf adds */
+    EXPECT_EQ(txAvailable(), 1024 - 17 - 2);
+    USBnprintf("second message");
+    EXPECT_EQ(txAvailable(), 1024 - 17 - 14 - 2 * 2);
+
+    /* Free up the USB */
+    ((USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData)->TxState = 0;
+
+    uint32_t len = 10;
+    uint8_t buf[len];
+    usb_cdc_fops.TransmitCplt(buf, &len, 0);
+
+    EXPECT_EQ(txAvailable(), 1024);
+    EXPECT_READ_USB(IsSupersetOf({"test_delayed_send\r", "second message"}));
+}
+
+TEST_F(UsbPrintTest, test_usb_connection) {
+    forceTick(0);
+    EXPECT_FALSE(isUsbPortOpen());
+    USBD_SetupReqTypedef cmd = {
+        .wValue = 0x0001
+    };
+    usb_cdc_fops.Control(CDC_SET_CONTROL_LINE_STATE, (uint8_t*)&cmd, sizeof(cmd));
+    
+    /* Note: it should take a few milliseconds before the port opens for "stabilisation" */
+    forceTick(10);
+    EXPECT_FALSE(isUsbPortOpen());
+    forceTick(11);
+    EXPECT_TRUE(isUsbPortOpen());
+    
+    cmd.wValue = 0;
+    usb_cdc_fops.Control(CDC_SET_CONTROL_LINE_STATE, (uint8_t*)&cmd, sizeof(cmd));
+    EXPECT_FALSE(isUsbPortOpen());
+}
+
+TEST_F(UsbPrintTest, test_usbFlush) {
+    usb_cdc_fops.Init();
+
+    sendUsbData("testFlush");
+    char test;
+    EXPECT_EQ(0, usbRx((uint8_t*)&test));
+    EXPECT_EQ('t', test);
+
+    usbFlush();
+    EXPECT_EQ(-1, usbRx((uint8_t*)&test));
+}
+
+TEST_F(UsbPrintTest, test_usbErrors) {
+    usb_cdc_fops.Init();
+
+    /* Error 1 - Not enough space in send buffer */
+    char buf[CIRCULAR_BUFFER_SIZE + 1] = {0};
+    EXPECT_EQ(CIRCULAR_BUFFER_SIZE, writeUSB(buf, CIRCULAR_BUFFER_SIZE + 1));
+
+    EXPECT_EQ(isUsbError(), CDC_ERROR_CROPPED_TRANSMIT);
+    USBnprintf("clear");
+    EXPECT_EQ(isUsbError(), CDC_ERROR_NONE);
+
+    /* Error 2 - Something went wrong during transmit */
+    hUsbDeviceFS.ret_val = 3;
+    USBnprintf("err2");
+    EXPECT_EQ(isUsbError(), CDC_ERROR_TRANSMIT);
+    hUsbDeviceFS.ret_val = 0;
+    USBnprintf("clear2");
+    EXPECT_EQ(isUsbError(), CDC_ERROR_NONE);
+
+    /* Error 3 - A transmit was delayed, but then there was a problem at a later stage */
+    ((USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData)->TxState = 1;
+    USBnprintf("err3");
+    EXPECT_EQ(isUsbError(), CDC_ERROR_NONE);
+    
+    hUsbDeviceFS.ret_val = 3;
+    uint32_t len = 10;
+    uint8_t buf2[len];
+    usb_cdc_fops.TransmitCplt(buf2, &len, 0);
+    EXPECT_EQ(isUsbError(), CDC_ERROR_DELAYED_TRANSMIT);
+    ((USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData)->TxState = 0;
+    hUsbDeviceFS.ret_val = 0;
+    USBnprintf("clear3");
+    EXPECT_EQ(isUsbError(), CDC_ERROR_NONE);
+}

--- a/unit_testing/fakes/fake_USBprint.cpp
+++ b/unit_testing/fakes/fake_USBprint.cpp
@@ -1,5 +1,5 @@
 /*!
-** @file   fake_USBprint.c
+** @file   fake_USBprint.cpp
 ** @author Luke W
 ** @date   22/01/2024
 */

--- a/unit_testing/fakes/fake_usbd_cdc.cpp
+++ b/unit_testing/fakes/fake_usbd_cdc.cpp
@@ -1,0 +1,92 @@
+/*!
+** @file   fake_usbd_cdc.cpp
+** @author Luke W
+** @date   03/05/2024
+*/
+
+#include <fstream>
+#include <cstdio>
+#include <cstdarg>
+#include <vector>
+#include <sstream>
+
+#include "fake_usbd_cdc.h"
+
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
+
+#define TX_RX_BUFFER_LENGTH 1024
+#define TEST_OUT_FILENAME   "testout.txt"
+
+/***************************************************************************************************
+** NAMESPACES
+***************************************************************************************************/
+
+using namespace std;
+
+/***************************************************************************************************
+** PRIVATE OBJECTS
+***************************************************************************************************/
+
+static ofstream test_out, test_in;
+static stringstream test_ss;
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DEFINITIONS
+***************************************************************************************************/
+
+
+uint8_t USBD_CDC_RegisterInterface(USBD_HandleTypeDef *pdev, USBD_CDC_ItfTypeDef *fops) {
+    return pdev->ret_val;
+}
+
+uint8_t USBD_CDC_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t *pbuff, uint32_t length) {
+    pdev->tx_buf   = pbuff;
+    pdev->tx_count = length;
+    return pdev->ret_val;
+}
+
+uint8_t USBD_CDC_SetRxBuffer(USBD_HandleTypeDef *pdev, uint8_t *pbuff) {
+    /* Does nothing */
+    return pdev->ret_val;
+}
+
+uint8_t USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev) {
+    /* Does nothing */
+    return pdev->ret_val;
+}
+
+uint8_t USBD_CDC_TransmitPacket(USBD_HandleTypeDef *pdev) {
+    /* For first time, open a new file */
+    if(!test_out.is_open()) {
+        test_out.open(TEST_OUT_FILENAME);
+    }
+
+    test_out.write((const char *)pdev->tx_buf, pdev->tx_count);
+    test_out.flush();
+
+    /* Also write the string to the internal copy buffer */
+    test_ss.clear();
+    test_ss << string((const char *)pdev->tx_buf, pdev->tx_count);
+    
+    return pdev->ret_val;
+}
+
+vector<string>* host_USBD_CDC_Receive(bool flush) {
+    vector<string>* result = new vector<string>;
+    string str;
+    while(getline(test_ss, str)) {
+        result->push_back(str);
+    }
+
+    if(!flush) {
+        /* Put everything back into the stream */
+        test_ss.clear();
+        for(vector<string>::iterator it = result->begin(); it != result->end(); it++) {
+            test_ss << *it;
+        }
+    }
+
+    return result;
+}

--- a/unit_testing/fakes/fake_usbd_cdc.h
+++ b/unit_testing/fakes/fake_usbd_cdc.h
@@ -1,0 +1,149 @@
+/*!
+** @file fake_usbd_cdc.h
+** @author Luke W
+** @date 03/05/2024
+*/
+
+/* Define to prevent inclusion of real module */
+#ifndef __USB_CDC_H
+#define __USB_CDC_H
+
+
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+  #include <vector>
+  #include <string>
+  
+  /* Allow a range of single line container tests */
+  #define EXPECT_READ_USB(x) { \
+      vector<string>* ss = host_USBD_CDC_Receive(); \
+      EXPECT_THAT(*ss, (x)); \
+      delete ss; \
+  }
+  
+  /* Allow a range of single line container tests */
+  #define EXPECT_FLUSH_USB(x) { \
+      vector<string>* ss = host_USBD_CDC_Receive(true); \
+      EXPECT_THAT(*ss, (x)); \
+      delete ss; \
+  }
+  
+  extern "C" {
+#endif
+
+#define USBD_OK 0
+
+#ifndef CDC_IN_EP
+#define CDC_IN_EP                                   0x81U  /* EP1 for data IN */
+#endif /* CDC_IN_EP */
+#ifndef CDC_OUT_EP
+#define CDC_OUT_EP                                  0x01U  /* EP1 for data OUT */
+#endif /* CDC_OUT_EP */
+#ifndef CDC_CMD_EP
+#define CDC_CMD_EP                                  0x82U  /* EP2 for CDC commands */
+#endif /* CDC_CMD_EP  */
+
+#ifndef CDC_HS_BINTERVAL
+#define CDC_HS_BINTERVAL                            0x10U
+#endif /* CDC_HS_BINTERVAL */
+
+#ifndef CDC_FS_BINTERVAL
+#define CDC_FS_BINTERVAL                            0x10U
+#endif /* CDC_FS_BINTERVAL */
+
+/* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
+#define CDC_DATA_HS_MAX_PACKET_SIZE                 512U  /* Endpoint IN & OUT Packet size */
+#define CDC_DATA_FS_MAX_PACKET_SIZE                 64U  /* Endpoint IN & OUT Packet size */
+#define CDC_CMD_PACKET_SIZE                         8U  /* Control Endpoint Packet size */
+
+#define USB_CDC_CONFIG_DESC_SIZ                     67U
+#define CDC_DATA_HS_IN_PACKET_SIZE                  CDC_DATA_HS_MAX_PACKET_SIZE
+#define CDC_DATA_HS_OUT_PACKET_SIZE                 CDC_DATA_HS_MAX_PACKET_SIZE
+
+#define CDC_DATA_FS_IN_PACKET_SIZE                  CDC_DATA_FS_MAX_PACKET_SIZE
+#define CDC_DATA_FS_OUT_PACKET_SIZE                 CDC_DATA_FS_MAX_PACKET_SIZE
+
+#define CDC_REQ_MAX_DATA_SIZE                       0x7U
+/*---------------------------------------------------------------------*/
+/*  CDC definitions                                                    */
+/*---------------------------------------------------------------------*/
+#define CDC_SEND_ENCAPSULATED_COMMAND               0x00U
+#define CDC_GET_ENCAPSULATED_RESPONSE               0x01U
+#define CDC_SET_COMM_FEATURE                        0x02U
+#define CDC_GET_COMM_FEATURE                        0x03U
+#define CDC_CLEAR_COMM_FEATURE                      0x04U
+#define CDC_SET_LINE_CODING                         0x20U
+#define CDC_GET_LINE_CODING                         0x21U
+#define CDC_SET_CONTROL_LINE_STATE                  0x22U
+#define CDC_SEND_BREAK                              0x23U
+
+typedef struct
+{
+  uint32_t bitrate;
+  uint8_t  format;
+  uint8_t  paritytype;
+  uint8_t  datatype;
+} USBD_CDC_LineCodingTypeDef;
+
+typedef struct _USBD_CDC_Itf
+{
+  int8_t (* Init)(void);
+  int8_t (* DeInit)(void);
+  int8_t (* Control)(uint8_t cmd, uint8_t *pbuf, uint16_t length);
+  int8_t (* Receive)(uint8_t *Buf, uint32_t *Len);
+  int8_t (* TransmitCplt)(uint8_t *Buf, uint32_t *Len, uint8_t epnum);
+} USBD_CDC_ItfTypeDef;
+
+typedef struct
+{
+  uint32_t data[CDC_DATA_HS_MAX_PACKET_SIZE / 4U];      /* Force 32-bit alignment */
+  uint8_t  CmdOpCode;
+  uint8_t  CmdLength;
+  uint8_t  *RxBuffer;
+  uint8_t  *TxBuffer;
+  uint32_t RxLength;
+  uint32_t TxLength;
+
+  volatile uint32_t TxState;
+  volatile uint32_t RxState;
+} USBD_CDC_HandleTypeDef;
+
+typedef struct {
+    uint8_t* tx_buf;
+    uint32_t tx_count;
+    void* pClassData;
+    void *pClassDataCmsit[1];
+    uint8_t classId;
+    uint32_t ret_val;
+} USBD_HandleTypeDef;
+
+typedef struct
+{
+  uint8_t   bmRequest;
+  uint8_t   bRequest;
+  uint16_t  wValue;
+  uint16_t  wIndex;
+  uint16_t  wLength;
+} USBD_SetupReqTypedef;
+
+uint8_t USBD_CDC_RegisterInterface(USBD_HandleTypeDef *pdev,
+                                   USBD_CDC_ItfTypeDef *fops);
+
+uint8_t USBD_CDC_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t *pbuff,
+                             uint32_t length);
+
+uint8_t USBD_CDC_SetRxBuffer(USBD_HandleTypeDef *pdev, uint8_t *pbuff);
+uint8_t USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev);
+uint8_t USBD_CDC_TransmitPacket(USBD_HandleTypeDef *pdev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+std::vector<std::string>* host_USBD_CDC_Receive(bool flush=false);
+#endif
+
+#endif  /* __USB_CDC_H */

--- a/unit_testing/redirects/usbd_cdc.h
+++ b/unit_testing/redirects/usbd_cdc.h
@@ -1,0 +1,1 @@
+#include "fake_usbd_cdc.h"

--- a/unit_testing/unitTests.py
+++ b/unit_testing/unitTests.py
@@ -39,6 +39,12 @@ if __name__ == "__main__":
     #If the directory is not specified then run all tests from all sub-directories
     returncodes = []
     for f in os.scandir(os.getcwd()):
-        if f.is_dir() and f.name not in ["fakes", "stubs"]:
+        if f.is_dir() and f.name not in ["fakes", "stubs", "redirects"]:
             returncodes.append(run_tests_in_subdirectory(f.name, regex, verbose))
-    sys.exit(any(r != 0 for r in returncodes))
+    
+    if any(r != 0 for r in returncodes):
+        print("\r\nSome errors occurred")
+        sys.exit(1)
+    else:
+        print("\r\nNo errors occurred")
+        sys.exit(0)


### PR DESCRIPTION
* Made it so circular buffer can be allocated statically
* Added retrievable error object from USB - can be used to react to errors
* Added some asserts and other minor error handling to usb_cdc_fops
* Added USB error object into BoardStatus

For usage on an actual board, see https://github.com/copenhagenatomics/CA_embedded_private/pull/648