### PR TITLE
boardSetup

### DIFF
--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -136,6 +136,11 @@ void setFirmwareBoardType(BoardType type);
 */
 void setFirmwareBoardVersion(pcbVersion version);
 
+/*!
+** @brief Sets the board type and version the firmware was compiled for
+*/
+int boardSetup(BoardType type, pcbVersion breaking_version);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
* Added boardSetup() to pull various boardStatus setup elements into a single function.
* Fixed unit test compile warnings due in scanf functions