### PR TITLE
SHT45 interface

### DIFF
--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -17,25 +17,23 @@
 #endif
 #include <stdint.h>
 
+// Valid commands can be found in section 4.5 of the datasheet
+#define SHT4X_MEASURE_HIGHREP = 0xFD,
+#define SHT4X_MEASURE_MEDREP = 0xF6,
+#define SHT4X_MEASURE_LOWREP = 0xE0,
+#define SHT4X_READ_SERIAL = 0x89,
+#define SHT4X_SOFT_RESET = 0x94,
+#define SHT4X_HEATER_200mW_1S = 0x39,
+#define SHT4X_HEATER_200mW_100mS = 0x32,
+#define SHT4X_HEATER_110mW_1S = 0x2F,
+#define SHT4X_HEATER_110mW_100mS = 0x24,
+#define SHT4X_HEATER_20mW_1S = 0x1E,
+#define SHT4X_HEATER_20mW_100mS = 0x15
+
+
 typedef struct {
     I2C_HandleTypeDef *hi2c;
     uint16_t device_address;
 } sht4x_handle_t;
-
-// Valid commands can be found in section 4.5 of the datasheet
-typedef enum
-{
-    SHT4X_COMMAND_MEASURE_HIGHREP = 0xFD,
-    SHT4X_COMMAND_MEASURE_MEDREP = 0xF6,
-    SHT4X_COMMAND_MEASURE_LOWREP = 0xE0,
-    SHT4X_COMMAND_READ_SERIAL = 0x89,
-    SHT4X_COMMAND_SOFT_RESET = 0x94,
-    SHT4X_COMMAND_HEATER_200mW_1S = 0x39,
-    SHT4X_COMMAND_HEATER_200mW_100mS = 0x32,
-    SHT4X_COMMAND_HEATER_110mW_1S = 0x2F,
-    SHT4X_COMMAND_HEATER_110mW_100mS = 0x24,
-    SHT4X_COMMAND_HEATER_20mW_1S = 0x1E,
-    SHT4X_COMMAND_HEATER_20mW_100mS = 0x15
-} sht4x_command_t;
 
 #endif /* INC_SHT45_H_ */

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -62,7 +62,8 @@ typedef struct {
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev);
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev);
 HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev);
-HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev, uint8_t command);
+HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev);
+HAL_StatusTypeDef sht4x_initiate_measurement(sht4x_handle_t *dev, uint8_t command);
 HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *dev, uint8_t heating_program);
 
 #endif /* INC_SHT45_H_ */

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -18,17 +18,17 @@
 #include <stdint.h>
 
 // Valid commands can be found in section 4.5 of the datasheet
-#define SHT4X_MEASURE_HIGHREP = 0xFD,
-#define SHT4X_MEASURE_MEDREP = 0xF6,
-#define SHT4X_MEASURE_LOWREP = 0xE0,
-#define SHT4X_READ_SERIAL = 0x89,
-#define SHT4X_SOFT_RESET = 0x94,
-#define SHT4X_HEATER_200mW_1S = 0x39,
-#define SHT4X_HEATER_200mW_100mS = 0x32,
-#define SHT4X_HEATER_110mW_1S = 0x2F,
-#define SHT4X_HEATER_110mW_100mS = 0x24,
-#define SHT4X_HEATER_20mW_1S = 0x1E,
-#define SHT4X_HEATER_20mW_100mS = 0x15
+#define SHT4X_MEASURE_HIGHREP       0xFD
+#define SHT4X_MEASURE_MEDREP        0xF6
+#define SHT4X_MEASURE_LOWREP        0xE0
+#define SHT4X_READ_SERIAL           0x89
+#define SHT4X_SOFT_RESET            0x94
+#define SHT4X_HEATER_200mW_1S       0x39
+#define SHT4X_HEATER_200mW_100mS    0x32
+#define SHT4X_HEATER_110mW_1S       0x2F
+#define SHT4X_HEATER_110mW_100mS    0x24
+#define SHT4X_HEATER_20mW_1S        0x1E
+#define SHT4X_HEATER_20mW_100mS     0x15
 
 
 typedef struct {

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -37,25 +37,40 @@
 #define SHT4X_HEATER_110mW_100ms    0x24
 #define SHT4X_HEATER_20mW_1s        0x1E
 #define SHT4X_HEATER_20mW_100ms     0x15
-#define SHT4X_ABORT_CALL            0x06
 
 /***************************************************************************************************
 ** TYPEDEFS
 ***************************************************************************************************/
 
+typedef enum {
+    SET_MODE,
+    MEASURE_DATA,
+    HEAT_CYCLE,
+    SOFT_RESET
+} sht4x_status;
+
+typedef struct {
+    float temperature;
+    float relative_humidity;
+    float absolute_humidity;
+} sht4x_data;
+
 typedef struct {
     I2C_HandleTypeDef *hi2c;
-    uint16_t device_address;
+    uint8_t device_address;     // 0x44
+    uint32_t serial_number;
+    sht4x_data data;
+    sht4x_status status;
 } sht4x_handle_t;
 
 /***************************************************************************************************
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
-HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle);
-HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle);
-HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number);
-HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity);
-HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, uint8_t heating_program);
+HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev);
+HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev);
+HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev);
+HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev, uint8_t command);
+HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *dev, uint8_t heating_program);
 
 #endif /* INC_SHT45_H_ */

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -1,0 +1,41 @@
+/*
+ * sht45.h
+ *
+ *  Created on: June 10, 2024
+ *      Author: Matias
+ * 
+ *  Datasheet: https://sensirion.com/media/documents/33FD6951/662A593A/HT_DS_Datasheet_SHT4x.pdf
+ */
+
+#ifndef INC_SHT45_H_
+#define INC_SHT45_H_
+
+#if defined(STM32F401xC)
+#include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
+#include <stdint.h>
+
+typedef struct {
+	I2C_HandleTypeDef *hi2c;
+	uint16_t device_address;
+} sht4x_handle_t;
+
+// Valid commands can be found in section 4.5 of the datasheet
+typedef enum
+{
+	SHT4X_COMMAND_MEASURE_HIGHREP = 0xFD,
+	SHT4X_COMMAND_MEASURE_MEDREP = 0xF6,
+	SHT4X_COMMAND_MEASURE_LOWREP = 0xE0,
+	SHT4X_COMMAND_READ_SERIAL = 0x89,
+    SHT4X_COMMAND_SOFT_RESET = 0x94,
+	SHT4X_COMMAND_HEATER_200mW_1S = 0x39,
+    SHT4X_COMMAND_HEATER_200mW_100mS = 0x32,
+    SHT4X_COMMAND_HEATER_110mW_1S = 0x2F,
+    SHT4X_COMMAND_HEATER_110mW_100mS = 0x24,
+    SHT4X_COMMAND_HEATER_20mW_1S = 0x1E,
+    SHT4X_COMMAND_HEATER_20mW_100mS = 0x15
+} sht4x_command_t;
+
+#endif /* INC_SHT45_H_ */

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -18,19 +18,19 @@
 #include <stdint.h>
 
 typedef struct {
-	I2C_HandleTypeDef *hi2c;
-	uint16_t device_address;
+    I2C_HandleTypeDef *hi2c;
+    uint16_t device_address;
 } sht4x_handle_t;
 
 // Valid commands can be found in section 4.5 of the datasheet
 typedef enum
 {
-	SHT4X_COMMAND_MEASURE_HIGHREP = 0xFD,
-	SHT4X_COMMAND_MEASURE_MEDREP = 0xF6,
-	SHT4X_COMMAND_MEASURE_LOWREP = 0xE0,
-	SHT4X_COMMAND_READ_SERIAL = 0x89,
+    SHT4X_COMMAND_MEASURE_HIGHREP = 0xFD,
+    SHT4X_COMMAND_MEASURE_MEDREP = 0xF6,
+    SHT4X_COMMAND_MEASURE_LOWREP = 0xE0,
+    SHT4X_COMMAND_READ_SERIAL = 0x89,
     SHT4X_COMMAND_SOFT_RESET = 0x94,
-	SHT4X_COMMAND_HEATER_200mW_1S = 0x39,
+    SHT4X_COMMAND_HEATER_200mW_1S = 0x39,
     SHT4X_COMMAND_HEATER_200mW_100mS = 0x32,
     SHT4X_COMMAND_HEATER_110mW_1S = 0x2F,
     SHT4X_COMMAND_HEATER_110mW_100mS = 0x24,

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -42,13 +42,6 @@
 ** TYPEDEFS
 ***************************************************************************************************/
 
-typedef enum {
-    SET_MODE,
-    MEASURE_DATA,
-    HEAT_CYCLE,
-    SOFT_RESET
-} sht4x_status;
-
 typedef struct {
     float temperature;
     float relative_humidity;
@@ -60,7 +53,6 @@ typedef struct {
     uint8_t device_address;     // 0x44
     uint32_t serial_number;
     sht4x_data data;
-    sht4x_status status;
 } sht4x_handle_t;
 
 /***************************************************************************************************

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -15,12 +15,17 @@
 #elif defined(STM32H753xx)
 #include "stm32h7xx_hal.h"
 #endif
+
 #include <stdint.h>
+
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
 
 // I2C addresses for SHT45 devices
 #define SHT45_I2C_ADDR              0x44
 
-// Valid commands can be found in section 4.5 of the datasheet
+// List of valid commands (Section 4.5 of the datasheet)
 #define SHT4X_MEASURE_HIGHREP       0xFD
 #define SHT4X_MEASURE_MEDREP        0xF6
 #define SHT4X_MEASURE_LOWREP        0xE0
@@ -34,10 +39,18 @@
 #define SHT4X_HEATER_20mW_100ms     0x15
 #define SHT4X_ABORT_CALL            0x06
 
+/***************************************************************************************************
+** TYPEDEFS
+***************************************************************************************************/
+
 typedef struct {
     I2C_HandleTypeDef *hi2c;
     uint16_t device_address;
 } sht4x_handle_t;
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
 
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle);
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle);

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -17,23 +17,42 @@
 #endif
 #include <stdint.h>
 
+// I2C addresses for SHT45 devices
+#define SHT45_I2C_ADDR              0x44
+
 // Valid commands can be found in section 4.5 of the datasheet
 #define SHT4X_MEASURE_HIGHREP       0xFD
 #define SHT4X_MEASURE_MEDREP        0xF6
 #define SHT4X_MEASURE_LOWREP        0xE0
 #define SHT4X_READ_SERIAL           0x89
 #define SHT4X_SOFT_RESET            0x94
-#define SHT4X_HEATER_200mW_1S       0x39
-#define SHT4X_HEATER_200mW_100mS    0x32
-#define SHT4X_HEATER_110mW_1S       0x2F
-#define SHT4X_HEATER_110mW_100mS    0x24
-#define SHT4X_HEATER_20mW_1S        0x1E
-#define SHT4X_HEATER_20mW_100mS     0x15
+#define SHT4X_HEATER_200mW_1s       0x39
+#define SHT4X_HEATER_200mW_100ms    0x32
+#define SHT4X_HEATER_110mW_1s       0x2F
+#define SHT4X_HEATER_110mW_100ms    0x24
+#define SHT4X_HEATER_20mW_1s        0x1E
+#define SHT4X_HEATER_20mW_100ms     0x15
+#define SHT4X_ABORT_CALL            0x06
 
+typedef enum
+{
+    HEATER_200mW_1s,
+    HEATER_200mW_100ms,
+    HEATER_110mW_1s,
+    HEATER_110mW_100ms,
+    HEATER_20mW_1s,
+    HEATER_20mW_100ms,
+} sht4x_heater_program;
 
 typedef struct {
     I2C_HandleTypeDef *hi2c;
     uint16_t device_address;
 } sht4x_handle_t;
+
+HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle);
+HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle);
+HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number);
+HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity);
+HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, sht4x_heater_program program);
 
 #endif /* INC_SHT45_H_ */

--- a/STM32/I2C/Inc/sht45.h
+++ b/STM32/I2C/Inc/sht45.h
@@ -34,16 +34,6 @@
 #define SHT4X_HEATER_20mW_100ms     0x15
 #define SHT4X_ABORT_CALL            0x06
 
-typedef enum
-{
-    HEATER_200mW_1s,
-    HEATER_200mW_100ms,
-    HEATER_110mW_1s,
-    HEATER_110mW_100ms,
-    HEATER_20mW_1s,
-    HEATER_20mW_100ms,
-} sht4x_heater_program;
-
 typedef struct {
     I2C_HandleTypeDef *hi2c;
     uint16_t device_address;
@@ -53,6 +43,6 @@ HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle);
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle);
 HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number);
 HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity);
-HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, sht4x_heater_program program);
+HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, uint8_t heating_program);
 
 #endif /* INC_SHT45_H_ */

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -60,7 +60,6 @@ static void relativeToAbsolute(sht4x_handle_t *dev)
 */
 static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *dev, uint8_t command)
 {
-
     if (HAL_I2C_Master_Transmit(dev->hi2c, dev->device_address << 1u, &command, 1, 10) != HAL_OK) {
         return HAL_BUSY;
     }
@@ -103,7 +102,6 @@ HAL_StatusTypeDef sht4x_set_measurement_mode(sht4x_handle_t *dev, uint8_t comman
 */
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev)
 {
-    // Soft reset the chip
     return sht4x_set_mode(dev, SHT4X_SOFT_RESET);
 }
 
@@ -112,8 +110,8 @@ HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev)
 */
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev)
 {
-    uint8_t abort_call = 0x06;
-    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &abort_call, 1, 10) != HAL_OK) {
+    static const uint8_t ABORT_CALL = 0x06;
+    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &ABORT_CALL, 1, 10) != HAL_OK) {
         return HAL_BUSY;
     }
     return HAL_OK;
@@ -159,7 +157,7 @@ HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev)
 */
 HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev, uint8_t command)
 {
-    HAL_StatusTypeDef ret;
+    HAL_StatusTypeDef ret = HAL_ERROR;
     // Send measurement command to output temp and humidity from SHT45 at next read 
     ret = sht4x_set_measurement_mode(dev, command);
     

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -156,9 +156,8 @@ HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev)
 */
 HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev, uint8_t command)
 {
-    HAL_StatusTypeDef ret = HAL_ERROR;
     // Send measurement command to output temp and humidity from SHT45 at next read 
-    ret = sht4x_set_measurement_mode(dev, command);
+    HAL_StatusTypeDef ret = sht4x_set_measurement_mode(dev, command);
     
     if(ret != HAL_OK) {
         return ret;

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -11,87 +11,87 @@
 
 // CRC parameters can be found in section 4.4 of the datasheet 
 static uint8_t calculate_crc(const uint8_t *data, size_t length){
-	uint8_t crc = 0xff;
-	for (size_t i = 0; i < length; i++) {
-		crc ^= data[i];
-		for (size_t j = 0; j < 8; j++) {
-			if ((crc & 0x80u) != 0) {
-				crc = (uint8_t)((uint8_t)(crc << 1u) ^ 0x31u);
-			} else {
-				crc <<= 1u;
-			}
-		}
-	}
-	return crc;
+    uint8_t crc = 0xff;
+    for (size_t i = 0; i < length; i++) {
+        crc ^= data[i];
+        for (size_t j = 0; j < 8; j++) {
+            if ((crc & 0x80u) != 0) {
+                crc = (uint8_t)((uint8_t)(crc << 1u) ^ 0x31u);
+            } else {
+                crc <<= 1u;
+            }
+        }
+    }
+    return crc;
 }
 
 static int checkCRC(uint8_t *buffer)
 {
-	// Ensure data is valid
-	if (calculate_crc(buffer, 2) != buffer[2] || calculate_crc(buffer + 3, 2) != buffer[5]) {
-		return 1;
-	}
-	return 0;
+    // Ensure data is valid
+    if (calculate_crc(buffer, 2) != buffer[2] || calculate_crc(buffer + 3, 2) != buffer[5]) {
+        return 1;
+    }
+    return 0;
 }
 
 HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, sht4x_command_t command){
 
-	if (HAL_I2C_Master_Transmit(handle->hi2c, handle->device_address << 1u, command, 1, 10) != HAL_OK) {
-		return HAL_BUSY;
-	}
-	return HAL_OK;
+    if (HAL_I2C_Master_Transmit(handle->hi2c, handle->device_address << 1u, command, 1, 10) != HAL_OK) {
+        return HAL_BUSY;
+    }
+    return HAL_OK;
 }
 
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle)
 {
-	// Soft reset the chip
-	sht4x_set_mode(handle, SHT4X_COMMAND_SOFT_RESET);
+    // Soft reset the chip
+    sht4x_set_mode(handle, SHT4X_COMMAND_SOFT_RESET);
 }
 
 
 HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number)
 {
-	// Send serial read command to output serial from SHT45 at next read 
-	sht4x_set_mode(handle, SHT4X_COMMAND_READ_SERIAL);
+    // Send serial read command to output serial from SHT45 at next read 
+    sht4x_set_mode(handle, SHT4X_COMMAND_READ_SERIAL);
 
-	uint8_t buffer[6];
-	ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
-	if(ret != HAL_OK) {
-		return ret;
-	}
+    uint8_t buffer[6];
+    ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+    if(ret != HAL_OK) {
+        return ret;
+    }
 
-	if (checkCRC(buffer) != 0)
-	{
-		return HAL_ERROR;
-	}
+    if (checkCRC(buffer) != 0)
+    {
+        return HAL_ERROR;
+    }
 
-	*serial_number = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[3] << 8) | buffer[4];
-	return HAL_OK;
+    *serial_number = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[3] << 8) | buffer[4];
+    return HAL_OK;
 }
 
 HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity){
-	
-	// Send measurement command to output temp and humidity from SHT45 at next read 
-	sht4x_set_mode(handle, SHT4X_COMMAND_MEASURE_HIGHREP);
+    
+    // Send measurement command to output temp and humidity from SHT45 at next read 
+    sht4x_set_mode(handle, SHT4X_COMMAND_MEASURE_HIGHREP);
 
-	uint8_t buffer[6];
-	ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
-	if(ret != HAL_OK) {
-		return ret;
-	}
+    uint8_t buffer[6];
+    ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+    if(ret != HAL_OK) {
+        return ret;
+    }
 
-	if (checkCRC(buffer) != 0)
-	{
-		return HAL_ERROR;
-	}
+    if (checkCRC(buffer) != 0)
+    {
+        return HAL_ERROR;
+    }
 
-	//merges data into a uint16
-	uint16_t temperature_adc = (buffer[0] << 8) | buffer[1];
-	uint16_t humidity_adc = (buffer[3] << 8) | buffer[4];
+    //merges data into a uint16
+    uint16_t temperature_adc = (buffer[0] << 8) | buffer[1];
+    uint16_t humidity_adc = (buffer[3] << 8) | buffer[4];
 
-	//processes data
-	*temperature = -45.0f + 175.0f * temperature_adc / 65535.0f;
-	*humidity = -6.0f + 125.0f * humidity_adc / 65535.0f;
+    //processes data
+    *temperature = -45.0f + 175.0f * temperature_adc / 65535.0f;
+    *humidity = -6.0f + 125.0f * humidity_adc / 65535.0f;
 
-	return HAL_OK;
+    return HAL_OK;
 }

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -110,8 +110,8 @@ HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev)
 */
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev)
 {
-    static const uint8_t ABORT_CALL = 0x06;
-    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &ABORT_CALL, 1, 10) != HAL_OK) {
+    static uint8_t abort_call = 0x06;
+    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &abort_call, 1, 10) != HAL_OK) {
         return HAL_BUSY;
     }
     return HAL_OK;

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -47,7 +47,7 @@ HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command)
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle)
 {
     // Soft reset the chip
-    sht4x_set_mode(handle, SHT4X_SOFT_RESET);
+    return sht4x_set_mode(handle, SHT4X_SOFT_RESET);
 }
 
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle)
@@ -105,33 +105,7 @@ HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperatu
     return HAL_OK;
 }
 
-HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, sht4x_heater_program program)
+HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, uint8_t heating_program)
 {
-    HAL_StatusTypeDef ret = HAL_OK;
-    
-    switch (program)
-    {
-    case HEATER_200mW_1s:
-        ret = sht4x_set_mode(handle, SHT4X_HEATER_200mW_1s);
-        break;
-    case HEATER_200mW_100ms:
-        ret = sht4x_set_mode(handle, SHT4X_HEATER_200mW_100ms);
-        break;
-    case HEATER_110mW_1s:
-        ret = sht4x_set_mode(handle, SHT4X_HEATER_110mW_1s);
-        break;
-    case HEATER_110mW_100ms:
-        ret = sht4x_set_mode(handle, SHT4X_HEATER_110mW_100ms);
-        break;
-    case HEATER_20mW_1s:
-        ret = sht4x_set_mode(handle, SHT4X_HEATER_20mW_1s);
-        break;
-    case HEATER_20mW_100ms:
-        ret = sht4x_set_mode(handle, SHT4X_HEATER_20mW_100ms);
-        break;
-    default:
-        ret = HAL_ERROR;
-        break;
-    }
-    return HAL_OK;
+    return sht4x_set_mode(handle, heating_program);
 }

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -1,0 +1,97 @@
+/*
+ * sht45.c
+ *
+ *  Created on: June 10, 2024
+ *      Author: matias
+ * 
+ *  Datasheet: https://sensirion.com/media/documents/33FD6951/662A593A/HT_DS_Datasheet_SHT4x.pdf
+ */
+
+#include "sht45.h"
+
+// CRC parameters can be found in section 4.4 of the datasheet 
+static uint8_t calculate_crc(const uint8_t *data, size_t length){
+	uint8_t crc = 0xff;
+	for (size_t i = 0; i < length; i++) {
+		crc ^= data[i];
+		for (size_t j = 0; j < 8; j++) {
+			if ((crc & 0x80u) != 0) {
+				crc = (uint8_t)((uint8_t)(crc << 1u) ^ 0x31u);
+			} else {
+				crc <<= 1u;
+			}
+		}
+	}
+	return crc;
+}
+
+static int checkCRC(uint8_t *buffer)
+{
+	// Ensure data is valid
+	if (calculate_crc(buffer, 2) != buffer[2] || calculate_crc(buffer + 3, 2) != buffer[5]) {
+		return 1;
+	}
+	return 0;
+}
+
+HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, sht4x_command_t command){
+
+	if (HAL_I2C_Master_Transmit(handle->hi2c, handle->device_address << 1u, command, 1, 10) != HAL_OK) {
+		return HAL_BUSY;
+	}
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle)
+{
+	// Soft reset the chip
+	sht4x_set_mode(handle, SHT4X_COMMAND_SOFT_RESET);
+}
+
+
+HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number)
+{
+	// Send serial read command to output serial from SHT45 at next read 
+	sht4x_set_mode(handle, SHT4X_COMMAND_READ_SERIAL);
+
+	uint8_t buffer[6];
+	ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+	if(ret != HAL_OK) {
+		return ret;
+	}
+
+	if (checkCRC(buffer) != 0)
+	{
+		return HAL_ERROR;
+	}
+
+	*serial_number = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[3] << 8) | buffer[4];
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity){
+	
+	// Send measurement command to output temp and humidity from SHT45 at next read 
+	sht4x_set_mode(handle, SHT4X_COMMAND_MEASURE_HIGHREP);
+
+	uint8_t buffer[6];
+	ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+	if(ret != HAL_OK) {
+		return ret;
+	}
+
+	if (checkCRC(buffer) != 0)
+	{
+		return HAL_ERROR;
+	}
+
+	//merges data into a uint16
+	uint16_t temperature_adc = (buffer[0] << 8) | buffer[1];
+	uint16_t humidity_adc = (buffer[3] << 8) | buffer[4];
+
+	//processes data
+	*temperature = -45.0f + 175.0f * temperature_adc / 65535.0f;
+	*humidity = -6.0f + 125.0f * humidity_adc / 65535.0f;
+
+	return HAL_OK;
+}

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -60,7 +60,7 @@ static void relativeToAbsolute(sht4x_handle_t *dev)
 */
 static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *dev, uint8_t command)
 {
-    if (HAL_I2C_Master_Transmit(dev->hi2c, dev->device_address << 1u, &command, 1, 10) != HAL_OK) {
+    if (HAL_I2C_Master_Transmit(dev->hi2c, dev->device_address << 1u, &command, 1, 1) != HAL_OK) {
         return HAL_BUSY;
     }
     return HAL_OK;
@@ -111,7 +111,7 @@ HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev)
 HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev)
 {
     static uint8_t abort_call = 0x06;
-    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &abort_call, 1, 10) != HAL_OK) {
+    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &abort_call, 1, 1) != HAL_OK) {
         return HAL_BUSY;
     }
     return HAL_OK;
@@ -123,9 +123,8 @@ HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev)
 */
 HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev)
 {
-    HAL_StatusTypeDef ret = HAL_ERROR;
     // Send serial read command to output serial from SHT45 at next read 
-    ret = sht4x_set_mode(dev, SHT4X_READ_SERIAL);
+    HAL_StatusTypeDef ret = sht4x_set_mode(dev, SHT4X_READ_SERIAL);
     HAL_Delay(1);
 
     if(ret != HAL_OK) {
@@ -133,7 +132,7 @@ HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev)
     }
 
     uint8_t buffer[6];
-    ret = HAL_I2C_Master_Receive(dev->hi2c, dev->device_address << 1u, buffer, sizeof(buffer), 50);
+    ret = HAL_I2C_Master_Receive(dev->hi2c, dev->device_address << 1u, buffer, sizeof(buffer), 1);
     if(ret != HAL_OK) {
         return ret;
     }
@@ -166,7 +165,7 @@ HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev, uint8_t command)
     }
     
     uint8_t buffer[6];
-    ret = HAL_I2C_Master_Receive(dev->hi2c, dev->device_address << 1u, buffer, sizeof(buffer), 50);
+    ret = HAL_I2C_Master_Receive(dev->hi2c, dev->device_address << 1u, buffer, sizeof(buffer), 1);
     
     if(ret != HAL_OK) {
         return ret;

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -9,6 +9,10 @@
 
 #include "sht45.h"
 
+/***************************************************************************************************
+** PRIVATE FUNCTIONS
+***************************************************************************************************/
+
 // CRC parameters can be found in section 4.4 of the datasheet 
 static uint8_t calculate_crc(const uint8_t *data, size_t length)
 {
@@ -35,7 +39,7 @@ static int checkCRC(uint8_t *buffer)
     return 0;
 }
 
-HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command)
+static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command)
 {
 
     if (HAL_I2C_Master_Transmit(handle->hi2c, handle->device_address << 1u, command, 1, 10) != HAL_OK) {
@@ -43,6 +47,10 @@ HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command)
     }
     return HAL_OK;
 }
+
+/***************************************************************************************************
+** PUBLIC FUNCTIONS
+***************************************************************************************************/
 
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle)
 {

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -11,6 +11,15 @@
 #include <math.h>
 
 /***************************************************************************************************
+** PRIVATE FUNCTION PROTOTYPES
+***************************************************************************************************/
+
+static uint8_t calculate_crc(const uint8_t *data, size_t length);
+static int checkCRC(uint8_t *buffer);
+static void relativeToAbsolute(sht4x_handle_t *dev);
+static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *dev, uint8_t command);
+
+/***************************************************************************************************
 ** PRIVATE FUNCTIONS
 ***************************************************************************************************/
 

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -8,6 +8,7 @@
  */
 
 #include "sht45.h"
+#include <math.h>
 
 /***************************************************************************************************
 ** PRIVATE FUNCTIONS
@@ -47,15 +48,49 @@ static int checkCRC(uint8_t *buffer)
 }
 
 /*!
+** @brief Conversion from relative [% to dew point] to absolute humidity [grams/m^3]
+*/
+static void relativeToAbsolute(sht4x_handle_t *dev)
+{
+    dev->data.absolute_humidity = 6.112 * exp((17.67*dev->data.temperature)/(dev->data.temperature+243.5))*dev->data.relative_humidity*2.1674/(273.15+dev->data.temperature);
+}
+
+/*!
 ** @brief Function to send any valid command to SHT4x chip (except for abort call)
 */
-static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command)
+static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *dev, uint8_t command)
 {
 
-    if (HAL_I2C_Master_Transmit(handle->hi2c, handle->device_address << 1u, command, 1, 10) != HAL_OK) {
+    if (HAL_I2C_Master_Transmit(dev->hi2c, dev->device_address << 1u, &command, 1, 10) != HAL_OK) {
         return HAL_BUSY;
     }
     return HAL_OK;
+}
+
+/*!
+** @brief Choose measurement mode and add corresponding delay
+*/
+HAL_StatusTypeDef sht4x_set_measurement_mode(sht4x_handle_t *dev, uint8_t command)
+{
+    HAL_StatusTypeDef ret = HAL_ERROR;
+    switch (command)
+    {
+    case SHT4X_MEASURE_HIGHREP:
+        ret = sht4x_set_mode(dev, SHT4X_MEASURE_HIGHREP);
+        HAL_Delay(9);   // Max duration of operation = 8.3 ms
+        break;
+    case SHT4X_MEASURE_MEDREP:
+        ret = sht4x_set_mode(dev, SHT4X_MEASURE_MEDREP);
+        HAL_Delay(5);   // Max duration of operation = 4.5 ms
+        break;
+    case SHT4X_MEASURE_LOWREP:
+        ret = sht4x_set_mode(dev, SHT4X_MEASURE_LOWREP);
+        HAL_Delay(2);   // Max duration of operation = 1.6 ms
+        break;
+    default:
+        break;
+    }
+    return ret;
 }
 
 /***************************************************************************************************
@@ -66,18 +101,19 @@ static HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command)
 ** @brief Soft reset of SHT4x chip
 ** @note Soft reset takes approximately 1ms
 */
-HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle)
+HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *dev)
 {
     // Soft reset the chip
-    return sht4x_set_mode(handle, SHT4X_SOFT_RESET);
+    return sht4x_set_mode(dev, SHT4X_SOFT_RESET);
 }
 
 /*!
 ** @brief Abort any ongoing command or heating process
 */
-HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle)
+HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *dev)
 {
-    if (HAL_I2C_Master_Transmit(handle->hi2c, 0x00, SHT4X_ABORT_CALL, 1, 10) != HAL_OK) {
+    uint8_t abort_call = 0x06;
+    if (HAL_I2C_Master_Transmit(dev->hi2c, 0x00, &abort_call, 1, 10) != HAL_OK) {
         return HAL_BUSY;
     }
     return HAL_OK;
@@ -87,13 +123,19 @@ HAL_StatusTypeDef sht4x_abort_command(sht4x_handle_t *handle)
 ** @brief Get serial number of SHT4x chip
 ** @param serial_number: pointer to uint32_t
 */
-HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number)
+HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *dev)
 {
+    HAL_StatusTypeDef ret = HAL_ERROR;
     // Send serial read command to output serial from SHT45 at next read 
-    sht4x_set_mode(handle, SHT4X_READ_SERIAL);
+    ret = sht4x_set_mode(dev, SHT4X_READ_SERIAL);
+    HAL_Delay(1);
+
+    if(ret != HAL_OK) {
+        return ret;
+    }
 
     uint8_t buffer[6];
-    ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+    ret = HAL_I2C_Master_Receive(dev->hi2c, dev->device_address << 1u, buffer, sizeof(buffer), 50);
     if(ret != HAL_OK) {
         return ret;
     }
@@ -103,22 +145,31 @@ HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_numb
         return HAL_ERROR;
     }
 
-    *serial_number = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[3] << 8) | buffer[4];
+    dev->serial_number = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[3] << 8) | buffer[4];
+    if (dev->serial_number == 0)
+    {
+        return HAL_ERROR;
+    }
+
     return HAL_OK;
 }
 
 /*!
 ** @brief Get temperature and RH% measurement
-** @param temperature: pointer to float
-**        humidity:    pointer to float
 */
-HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity)
+HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *dev, uint8_t command)
 {
+    HAL_StatusTypeDef ret;
     // Send measurement command to output temp and humidity from SHT45 at next read 
-    sht4x_set_mode(handle, SHT4X_MEASURE_HIGHREP);
-
+    ret = sht4x_set_measurement_mode(dev, command);
+    
+    if(ret != HAL_OK) {
+        return ret;
+    }
+    
     uint8_t buffer[6];
-    HAL_StatusTypeDef ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
+    ret = HAL_I2C_Master_Receive(dev->hi2c, dev->device_address << 1u, buffer, sizeof(buffer), 50);
+    
     if(ret != HAL_OK) {
         return ret;
     }
@@ -132,11 +183,24 @@ HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperatu
     uint16_t temperature_adc = (buffer[0] << 8) | buffer[1];
     uint16_t humidity_adc = (buffer[3] << 8) | buffer[4];
 
-    //processes data
-    *temperature = -45.0f + 175.0f * temperature_adc / 65535.0f;
-    *humidity = -6.0f + 125.0f * humidity_adc / 65535.0f;
+    // Convert data to physical quantities
+    dev->data.temperature = -45.0f + 175.0f * temperature_adc / 65535.0f;
+    dev->data.relative_humidity = -6.0f + 125.0f * humidity_adc / 65535.0f;
 
-    return HAL_OK;
+    // Cut relative humidity measure if outside of physical bounds
+    if (dev->data.relative_humidity > 100)
+    {
+        dev->data.relative_humidity = 100;
+    } 
+    else if (dev->data.relative_humidity < 0)
+    {
+        dev->data.relative_humidity = 0;
+    }
+
+    // Compute absolute humidity
+    relativeToAbsolute(dev);
+
+    return ret;
 }
 
 /*!
@@ -150,7 +214,7 @@ HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperatu
 **       At the end of the heater cycle a new measurement is available. The user is responsible for
 **       waiting for heater duration + 10% before requesting the next measurement.
 */
-HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *handle, uint8_t heating_program)
+HAL_StatusTypeDef sht4x_turn_on_heater(sht4x_handle_t *dev, uint8_t heating_program)
 {
-    return sht4x_set_mode(handle, heating_program);
+    return sht4x_set_mode(dev, heating_program);
 }

--- a/STM32/I2C/Src/sht45.c
+++ b/STM32/I2C/Src/sht45.c
@@ -34,7 +34,7 @@ static int checkCRC(uint8_t *buffer)
     return 0;
 }
 
-HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, sht4x_command_t command){
+HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, uint8_t command){
 
     if (HAL_I2C_Master_Transmit(handle->hi2c, handle->device_address << 1u, command, 1, 10) != HAL_OK) {
         return HAL_BUSY;
@@ -45,14 +45,14 @@ HAL_StatusTypeDef sht4x_set_mode(sht4x_handle_t *handle, sht4x_command_t command
 HAL_StatusTypeDef sht4x_soft_reset(sht4x_handle_t *handle)
 {
     // Soft reset the chip
-    sht4x_set_mode(handle, SHT4X_COMMAND_SOFT_RESET);
+    sht4x_set_mode(handle, SHT4X_SOFT_RESET);
 }
 
 
 HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_number)
 {
     // Send serial read command to output serial from SHT45 at next read 
-    sht4x_set_mode(handle, SHT4X_COMMAND_READ_SERIAL);
+    sht4x_set_mode(handle, SHT4X_READ_SERIAL);
 
     uint8_t buffer[6];
     ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);
@@ -72,7 +72,7 @@ HAL_StatusTypeDef sht4x_get_serial(sht4x_handle_t *handle, uint32_t *serial_numb
 HAL_StatusTypeDef sht4x_get_measurement(sht4x_handle_t *handle, float *temperature, float *humidity){
     
     // Send measurement command to output temp and humidity from SHT45 at next read 
-    sht4x_set_mode(handle, SHT4X_COMMAND_MEASURE_HIGHREP);
+    sht4x_set_mode(handle, SHT4X_MEASURE_HIGHREP);
 
     uint8_t buffer[6];
     ret = HAL_I2C_Master_Receive(handle->hi2c, handle->device_address << 1u, buffer, sizeof(buffer), 50);


### PR DESCRIPTION
Implementation of SHT45 humidity sensor interface. 

**Note:** The SPI communication is setup in a way where a command is first sent to make the sensor perform a corresponding action e.g. there are three types of measurement accuracies which takes has three different acquisition times. As of now these wait times are hard-coded as HAL_Delays. It would also be possible to store the time of sending the command and then let the user make the SPI getting call whenever a sufficient time has elapsed.

The upside of using HAL_Delays is that the user does not need to communicate with the sensor multiple times to get a measurement. The downside is of course that it stalls the program. 

@LukeWalker-CA let me know if you find the use of HAL_Delays bad in which case I will convert it to a state-machine-ish implementation. 