### PR TITLE
Feature/fake hal improvements

### DIFF
--- a/STM32/FLASH_readwrite/Inc/FLASH_readwrite.h
+++ b/STM32/FLASH_readwrite/Inc/FLASH_readwrite.h
@@ -9,9 +9,9 @@ Description:		Provides an interface to read and write FLASH memory.
 
 #include <stdint.h>
 #if defined(HAL_CRC_MODULE_ENABLED) && defined(STM32F401xC)
-  #include "stm32f4xx_hal_crc.h"
+  #include "stm32f4xx_hal.h"
 #elif defined(HAL_CRC_MODULE_ENABLED) && defined(STM32H753xx)
-  #include "stm32h7xx_hal_crc.h"
+  #include "stm32h7xx_hal.h"
 #endif
 
 

--- a/unit_testing/fakes/fake_stm32f401xc.h
+++ b/unit_testing/fakes/fake_stm32f401xc.h
@@ -1,0 +1,8708 @@
+/**
+  ******************************************************************************
+  * @file    stm32f401xc.h
+  * @author  MCD Application Team
+  * @brief   CMSIS STM32F401xC Device Peripheral Access Layer Header File.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - peripherals registers declarations and bits definition
+  *           - Macros to access peripheral’s registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32f401xc
+  * @{
+  */
+    
+#ifndef __STM32F401xC_H
+#define __STM32F401xC_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+  * @brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+  */
+#define __CM4_REV                 0x0001U  /*!< Core revision r0p1                            */
+#define __MPU_PRESENT             1U       /*!< STM32F4XX provides an MPU                     */
+#define __NVIC_PRIO_BITS          4U       /*!< STM32F4XX uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U       /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1U       /*!< FPU present                                   */
+
+/**
+  * @}
+  */
+  
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+ * @brief STM32F4XX Interrupt Number Definition, according to the selected device 
+ *        in @ref Library_configuration_section 
+ */
+typedef enum
+{
+/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M4 Memory Management Interrupt                           */
+  BusFault_IRQn               = -11,    /*!< 5 Cortex-M4 Bus Fault Interrupt                                   */
+  UsageFault_IRQn             = -10,    /*!< 6 Cortex-M4 Usage Fault Interrupt                                 */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M4 SV Call Interrupt                                    */
+  DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M4 Debug Monitor Interrupt                              */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M4 Pend SV Interrupt                                    */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                                */
+/******  STM32 specific Interrupt Numbers **********************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt                         */
+  TAMP_STAMP_IRQn             = 2,      /*!< Tamper and TimeStamp interrupts through the EXTI line             */
+  RTC_WKUP_IRQn               = 3,      /*!< RTC Wakeup interrupt through the EXTI line                        */
+  FLASH_IRQn                  = 4,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 5,      /*!< RCC global Interrupt                                              */
+  EXTI0_IRQn                  = 6,      /*!< EXTI Line0 Interrupt                                              */
+  EXTI1_IRQn                  = 7,      /*!< EXTI Line1 Interrupt                                              */
+  EXTI2_IRQn                  = 8,      /*!< EXTI Line2 Interrupt                                              */
+  EXTI3_IRQn                  = 9,      /*!< EXTI Line3 Interrupt                                              */
+  EXTI4_IRQn                  = 10,     /*!< EXTI Line4 Interrupt                                              */
+  DMA1_Stream0_IRQn           = 11,     /*!< DMA1 Stream 0 global Interrupt                                    */
+  DMA1_Stream1_IRQn           = 12,     /*!< DMA1 Stream 1 global Interrupt                                    */
+  DMA1_Stream2_IRQn           = 13,     /*!< DMA1 Stream 2 global Interrupt                                    */
+  DMA1_Stream3_IRQn           = 14,     /*!< DMA1 Stream 3 global Interrupt                                    */
+  DMA1_Stream4_IRQn           = 15,     /*!< DMA1 Stream 4 global Interrupt                                    */
+  DMA1_Stream5_IRQn           = 16,     /*!< DMA1 Stream 5 global Interrupt                                    */
+  DMA1_Stream6_IRQn           = 17,     /*!< DMA1 Stream 6 global Interrupt                                    */
+  ADC_IRQn                    = 18,     /*!< ADC1, ADC2 and ADC3 global Interrupts                             */
+  EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
+  TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
+  TIM1_UP_TIM10_IRQn          = 25,     /*!< TIM1 Update Interrupt and TIM10 global interrupt                  */
+  TIM1_TRG_COM_TIM11_IRQn     = 26,     /*!< TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+  TIM1_CC_IRQn                = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 28,     /*!< TIM2 global Interrupt                                             */
+  TIM3_IRQn                   = 29,     /*!< TIM3 global Interrupt                                             */
+  TIM4_IRQn                   = 30,     /*!< TIM4 global Interrupt                                             */
+  I2C1_EV_IRQn                = 31,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                = 32,     /*!< I2C1 Error Interrupt                                              */
+  I2C2_EV_IRQn                = 33,     /*!< I2C2 Event Interrupt                                              */
+  I2C2_ER_IRQn                = 34,     /*!< I2C2 Error Interrupt                                              */
+  SPI1_IRQn                   = 35,     /*!< SPI1 global Interrupt                                             */
+  SPI2_IRQn                   = 36,     /*!< SPI2 global Interrupt                                             */
+  USART1_IRQn                 = 37,     /*!< USART1 global Interrupt                                           */
+  USART2_IRQn                 = 38,     /*!< USART2 global Interrupt                                           */
+  EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                                   */
+  RTC_Alarm_IRQn              = 41,     /*!< RTC Alarm (A and B) through EXTI Line Interrupt                   */
+  OTG_FS_WKUP_IRQn            = 42,     /*!< USB OTG FS Wakeup through EXTI line interrupt                     */
+  DMA1_Stream7_IRQn           = 47,     /*!< DMA1 Stream7 Interrupt                                            */
+  SDIO_IRQn                   = 49,     /*!< SDIO global Interrupt                                             */
+  TIM5_IRQn                   = 50,     /*!< TIM5 global Interrupt                                             */
+  SPI3_IRQn                   = 51,     /*!< SPI3 global Interrupt                                             */
+  DMA2_Stream0_IRQn           = 56,     /*!< DMA2 Stream 0 global Interrupt                                    */
+  DMA2_Stream1_IRQn           = 57,     /*!< DMA2 Stream 1 global Interrupt                                    */
+  DMA2_Stream2_IRQn           = 58,     /*!< DMA2 Stream 2 global Interrupt                                    */
+  DMA2_Stream3_IRQn           = 59,     /*!< DMA2 Stream 3 global Interrupt                                    */
+  DMA2_Stream4_IRQn           = 60,     /*!< DMA2 Stream 4 global Interrupt                                    */
+  OTG_FS_IRQn                 = 67,     /*!< USB OTG FS global Interrupt                                       */
+  DMA2_Stream5_IRQn           = 68,     /*!< DMA2 Stream 5 global interrupt                                    */
+  DMA2_Stream6_IRQn           = 69,     /*!< DMA2 Stream 6 global interrupt                                    */
+  DMA2_Stream7_IRQn           = 70,     /*!< DMA2 Stream 7 global interrupt                                    */
+  USART6_IRQn                 = 71,     /*!< USART6 global interrupt                                           */
+  I2C3_EV_IRQn                = 72,     /*!< I2C3 event interrupt                                              */
+  I2C3_ER_IRQn                = 73,     /*!< I2C3 error interrupt                                              */
+  FPU_IRQn                    = 81,     /*!< FPU global interrupt                                              */
+  SPI4_IRQn                   = 84      /*!< SPI4 global Interrupt                                              */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+//#include "core_cm4.h"             /* Cortex-M4 processor and core peripherals */
+#define __IO            volatile
+#define __STATIC_INLINE static inline
+#define __RBIT          __rbit
+
+extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Clock) */
+extern const uint8_t  AHBPrescTable[16];    /*!< AHB prescalers table values */
+extern const uint8_t  APBPrescTable[8];     /*!< APB prescalers table values */
+extern void SystemInit(void);
+extern void SystemCoreClockUpdate(void);
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */   
+
+/** 
+  * @brief Analog to Digital Converter  
+  */
+
+typedef struct
+{
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
+                             AND triple modes,                            Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+/** 
+  * @brief CRC calculation unit 
+  */
+
+typedef struct
+{
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
+  uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+} CRC_TypeDef;
+
+/** 
+  * @brief Debug MCU
+  */
+
+typedef struct
+{
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+}DBGMCU_TypeDef;
+
+
+/** 
+  * @brief DMA Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+} DMA_Stream_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+} DMA_TypeDef;
+
+/** 
+  * @brief External Interrupt/Event Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+} EXTI_TypeDef;
+
+/** 
+  * @brief FLASH Registers
+  */
+
+typedef struct
+{
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+} FLASH_TypeDef;
+
+/** 
+  * @brief General Purpose I/O
+  */
+
+typedef struct
+{
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+} GPIO_TypeDef;
+
+/** 
+  * @brief System configuration controller
+  */
+
+typedef struct
+{
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+} SYSCFG_TypeDef;
+
+/** 
+  * @brief Inter-integrated Circuit Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+} I2C_TypeDef;
+
+/** 
+  * @brief Independent WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+} IWDG_TypeDef;
+
+
+/** 
+  * @brief Power Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+} PWR_TypeDef;
+
+/** 
+  * @brief Reset and Clock Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  uint32_t      RESERVED7[1];  /*!< Reserved, 0x88                                                                    */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+} RCC_TypeDef;
+
+/** 
+  * @brief Real-Time Clock
+  */
+
+typedef struct
+{
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+} RTC_TypeDef;
+
+/** 
+  * @brief SD host Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+} SDIO_TypeDef;
+
+/** 
+  * @brief Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+} SPI_TypeDef;
+
+
+/** 
+  * @brief TIM
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+} TIM_TypeDef;
+
+/** 
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+ 
+typedef struct
+{
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+} USART_TypeDef;
+
+/** 
+  * @brief Window WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+/** 
+  * @brief USB_OTG_Core_Registers
+  */
+typedef struct
+{
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  uint32_t Reserved30[2];             /*!< Reserved                                     030h */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
+  uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+} USB_OTG_GlobalTypeDef;
+
+/** 
+  * @brief USB_OTG_device_Registers
+  */
+typedef struct 
+{
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  uint32_t Reserved0C;           /*!< Reserved                     80Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  uint32_t  Reserved20;          /*!< Reserved                     820h */
+  uint32_t Reserved9;            /*!< Reserved                     824h */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  uint32_t Reserved40;           /*!< dedicated EP mask            840h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+} USB_OTG_DeviceTypeDef;
+
+/** 
+  * @brief USB_OTG_IN_Endpoint-Specific_Register
+  */
+typedef struct 
+{
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
+} USB_OTG_INEndpointTypeDef;
+
+/** 
+  * @brief USB_OTG_OUT_Endpoint-Specific_Registers
+  */
+typedef struct 
+{
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
+} USB_OTG_OUTEndpointTypeDef;
+
+/** 
+  * @brief USB_OTG_Host_Mode_Register_Structures
+  */
+typedef struct 
+{
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  uint32_t Reserved40C;           /*!< Reserved                             40Ch */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+} USB_OTG_HostTypeDef;
+
+/** 
+  * @brief USB_OTG_Host_Channel_Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  uint32_t Reserved[2];           /*!< Reserved                                      */
+} USB_OTG_HostChannelTypeDef;
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+// #define FLASH_BASE            0x08000000UL /*!< FLASH(up to 1 MB) base address in the alias region                         */
+// #define SRAM1_BASE            0x20000000UL /*!< SRAM1(64 KB) base address in the alias region                              */
+// #define PERIPH_BASE           0x40000000UL /*!< Peripheral base address in the alias region                                */
+// #define SRAM1_BB_BASE         0x22000000UL /*!< SRAM1(64 KB) base address in the bit-band region                           */
+// #define PERIPH_BB_BASE        0x42000000UL /*!< Peripheral base address in the bit-band region                             */
+// #define BKPSRAM_BB_BASE       0x42480000UL /*!< Backup SRAM(4 KB) base address in the bit-band region                      */
+// #define FLASH_END             0x0803FFFFUL /*!< FLASH end address                                                          */
+// #define FLASH_OTP_BASE        0x1FFF7800UL /*!< Base address of : (up to 528 Bytes) embedded FLASH OTP Area                */
+// #define FLASH_OTP_END         0x1FFF7A0FUL /*!< End address of : (up to 528 Bytes) embedded FLASH OTP Area                 */
+
+// /* Legacy defines */
+// #define SRAM_BASE             SRAM1_BASE
+// #define SRAM_BB_BASE          SRAM1_BB_BASE
+
+// /*!< Peripheral memory map */
+// #define APB1PERIPH_BASE       PERIPH_BASE
+// #define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000UL)
+// #define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000UL)
+// #define AHB2PERIPH_BASE       (PERIPH_BASE + 0x10000000UL)
+
+// /*!< APB1 peripherals */
+// #define TIM2_BASE             (APB1PERIPH_BASE + 0x0000UL)
+// #define TIM3_BASE             (APB1PERIPH_BASE + 0x0400UL)
+// #define TIM4_BASE             (APB1PERIPH_BASE + 0x0800UL)
+// #define TIM5_BASE             (APB1PERIPH_BASE + 0x0C00UL)
+// #define RTC_BASE              (APB1PERIPH_BASE + 0x2800UL)
+// #define WWDG_BASE             (APB1PERIPH_BASE + 0x2C00UL)
+// #define IWDG_BASE             (APB1PERIPH_BASE + 0x3000UL)
+// #define I2S2ext_BASE          (APB1PERIPH_BASE + 0x3400UL)
+// #define SPI2_BASE             (APB1PERIPH_BASE + 0x3800UL)
+// #define SPI3_BASE             (APB1PERIPH_BASE + 0x3C00UL)
+// #define I2S3ext_BASE          (APB1PERIPH_BASE + 0x4000UL)
+// #define USART2_BASE           (APB1PERIPH_BASE + 0x4400UL)
+// #define I2C1_BASE             (APB1PERIPH_BASE + 0x5400UL)
+// #define I2C2_BASE             (APB1PERIPH_BASE + 0x5800UL)
+// #define I2C3_BASE             (APB1PERIPH_BASE + 0x5C00UL)
+// #define PWR_BASE              (APB1PERIPH_BASE + 0x7000UL)
+
+// /*!< APB2 peripherals */
+// #define TIM1_BASE             (APB2PERIPH_BASE + 0x0000UL)
+// #define USART1_BASE           (APB2PERIPH_BASE + 0x1000UL)
+// #define USART6_BASE           (APB2PERIPH_BASE + 0x1400UL)
+// #define ADC1_BASE             (APB2PERIPH_BASE + 0x2000UL)
+// #define ADC1_COMMON_BASE      (APB2PERIPH_BASE + 0x2300UL)
+// /* Legacy define */
+// #define ADC_BASE               ADC1_COMMON_BASE
+// #define SDIO_BASE             (APB2PERIPH_BASE + 0x2C00UL)
+// #define SPI1_BASE             (APB2PERIPH_BASE + 0x3000UL)
+// #define SPI4_BASE             (APB2PERIPH_BASE + 0x3400UL)
+// #define SYSCFG_BASE           (APB2PERIPH_BASE + 0x3800UL)
+// #define EXTI_BASE             (APB2PERIPH_BASE + 0x3C00UL)
+// #define TIM9_BASE             (APB2PERIPH_BASE + 0x4000UL)
+// #define TIM10_BASE            (APB2PERIPH_BASE + 0x4400UL)
+// #define TIM11_BASE            (APB2PERIPH_BASE + 0x4800UL)
+
+// /*!< AHB1 peripherals */
+// #define GPIOA_BASE            (AHB1PERIPH_BASE + 0x0000UL)
+// #define GPIOB_BASE            (AHB1PERIPH_BASE + 0x0400UL)
+// #define GPIOC_BASE            (AHB1PERIPH_BASE + 0x0800UL)
+// #define GPIOD_BASE            (AHB1PERIPH_BASE + 0x0C00UL)
+// #define GPIOE_BASE            (AHB1PERIPH_BASE + 0x1000UL)
+// #define GPIOH_BASE            (AHB1PERIPH_BASE + 0x1C00UL)
+// #define CRC_BASE              (AHB1PERIPH_BASE + 0x3000UL)
+// #define RCC_BASE              (AHB1PERIPH_BASE + 0x3800UL)
+// #define FLASH_R_BASE          (AHB1PERIPH_BASE + 0x3C00UL)
+// #define DMA1_BASE             (AHB1PERIPH_BASE + 0x6000UL)
+// #define DMA1_Stream0_BASE     (DMA1_BASE + 0x010UL)
+// #define DMA1_Stream1_BASE     (DMA1_BASE + 0x028UL)
+// #define DMA1_Stream2_BASE     (DMA1_BASE + 0x040UL)
+// #define DMA1_Stream3_BASE     (DMA1_BASE + 0x058UL)
+// #define DMA1_Stream4_BASE     (DMA1_BASE + 0x070UL)
+// #define DMA1_Stream5_BASE     (DMA1_BASE + 0x088UL)
+// #define DMA1_Stream6_BASE     (DMA1_BASE + 0x0A0UL)
+// #define DMA1_Stream7_BASE     (DMA1_BASE + 0x0B8UL)
+// #define DMA2_BASE             (AHB1PERIPH_BASE + 0x6400UL)
+// #define DMA2_Stream0_BASE     (DMA2_BASE + 0x010UL)
+// #define DMA2_Stream1_BASE     (DMA2_BASE + 0x028UL)
+// #define DMA2_Stream2_BASE     (DMA2_BASE + 0x040UL)
+// #define DMA2_Stream3_BASE     (DMA2_BASE + 0x058UL)
+// #define DMA2_Stream4_BASE     (DMA2_BASE + 0x070UL)
+// #define DMA2_Stream5_BASE     (DMA2_BASE + 0x088UL)
+// #define DMA2_Stream6_BASE     (DMA2_BASE + 0x0A0UL)
+// #define DMA2_Stream7_BASE     (DMA2_BASE + 0x0B8UL)
+
+
+// /*!< Debug MCU registers base address */
+// #define DBGMCU_BASE           0xE0042000UL
+// /*!< USB registers base address */
+// #define USB_OTG_FS_PERIPH_BASE               0x50000000UL
+
+// #define USB_OTG_GLOBAL_BASE                  0x000UL
+// #define USB_OTG_DEVICE_BASE                  0x800UL
+// #define USB_OTG_IN_ENDPOINT_BASE             0x900UL
+// #define USB_OTG_OUT_ENDPOINT_BASE            0xB00UL
+// #define USB_OTG_EP_REG_SIZE                  0x20UL
+// #define USB_OTG_HOST_BASE                    0x400UL
+// #define USB_OTG_HOST_PORT_BASE               0x440UL
+// #define USB_OTG_HOST_CHANNEL_BASE            0x500UL
+// #define USB_OTG_HOST_CHANNEL_SIZE            0x20UL
+// #define USB_OTG_PCGCCTL_BASE                 0xE00UL
+// #define USB_OTG_FIFO_BASE                    0x1000UL
+// #define USB_OTG_FIFO_SIZE                    0x1000UL
+
+// #define UID_BASE                     0x1FFF7A10UL           /*!< Unique device ID register base address */
+// #define FLASHSIZE_BASE               0x1FFF7A22UL           /*!< FLASH Size register base address       */
+// #define PACKAGE_BASE                 0x1FFF7BF0UL           /*!< Package size register base address     */
+// /**
+//   * @}
+//   */
+
+extern TIM_TypeDef TIM2_obj;
+extern TIM_TypeDef TIM3_obj;
+extern TIM_TypeDef TIM4_obj;
+extern TIM_TypeDef TIM5_obj;
+extern RTC_TypeDef RTC_obj;
+extern WWDG_TypeDef WWDG_obj;
+extern IWDG_TypeDef IWDG_obj;
+extern SPI_TypeDef I2S2ext_obj;
+extern SPI_TypeDef SPI2_obj;
+extern SPI_TypeDef SPI3_obj;
+extern SPI_TypeDef I2S3ext_obj;
+extern USART_TypeDef USART2_obj;
+extern I2C_TypeDef I2C1_obj;
+extern I2C_TypeDef I2C2_obj;
+extern I2C_TypeDef I2C3_obj;
+extern PWR_TypeDef PWR_obj;
+extern TIM_TypeDef TIM1_obj;
+extern USART_TypeDef USART1_obj;
+extern USART_TypeDef USART6_obj;
+extern ADC_TypeDef ADC1_obj;
+extern ADC_Common_TypeDef ADC1_COMMON_obj;
+extern SDIO_TypeDef SDIO_obj;
+extern SPI_TypeDef SPI1_obj;
+extern SPI_TypeDef SPI4_obj;
+extern SYSCFG_TypeDef SYSCFG_obj;
+extern EXTI_TypeDef EXTI_obj;
+extern TIM_TypeDef TIM9_obj;
+extern TIM_TypeDef TIM10_obj;
+extern TIM_TypeDef TIM11_obj;
+extern GPIO_TypeDef GPIOA_obj;
+extern GPIO_TypeDef GPIOB_obj;
+extern GPIO_TypeDef GPIOC_obj;
+extern GPIO_TypeDef GPIOD_obj;
+extern GPIO_TypeDef GPIOE_obj;
+extern GPIO_TypeDef GPIOH_obj;
+extern CRC_TypeDef CRC_obj;
+extern RCC_TypeDef RCC_obj;
+extern FLASH_TypeDef FLASH_obj;
+extern DMA_TypeDef DMA1_obj;
+extern DMA_Stream_TypeDef DMA1_Stream0_obj;
+extern DMA_Stream_TypeDef DMA1_Stream1_obj;
+extern DMA_Stream_TypeDef DMA1_Stream2_obj;
+extern DMA_Stream_TypeDef DMA1_Stream3_obj;
+extern DMA_Stream_TypeDef DMA1_Stream4_obj;
+extern DMA_Stream_TypeDef DMA1_Stream5_obj;
+extern DMA_Stream_TypeDef DMA1_Stream6_obj;
+extern DMA_Stream_TypeDef DMA1_Stream7_obj;
+extern DMA_TypeDef DMA2_obj;
+extern DMA_Stream_TypeDef DMA2_Stream0_obj;
+extern DMA_Stream_TypeDef DMA2_Stream1_obj;
+extern DMA_Stream_TypeDef DMA2_Stream2_obj;
+extern DMA_Stream_TypeDef DMA2_Stream3_obj;
+extern DMA_Stream_TypeDef DMA2_Stream4_obj;
+extern DMA_Stream_TypeDef DMA2_Stream5_obj;
+extern DMA_Stream_TypeDef DMA2_Stream6_obj;
+extern DMA_Stream_TypeDef DMA2_Stream7_obj;
+extern DBGMCU_TypeDef DBGMCU_obj;
+extern USB_OTG_GlobalTypeDef USB_OTG_FS_obj;
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */  
+#define TIM2                ((TIM_TypeDef *) &TIM2_obj)
+#define TIM3                ((TIM_TypeDef *) &TIM3_obj)
+#define TIM4                ((TIM_TypeDef *) &TIM4_obj)
+#define TIM5                ((TIM_TypeDef *) &TIM5_obj)
+#define RTC                 ((RTC_TypeDef *) &RTC_obj)
+#define WWDG                ((WWDG_TypeDef *) &WWDG_obj)
+#define IWDG                ((IWDG_TypeDef *) &IWDG_obj)
+#define I2S2ext             ((SPI_TypeDef *) &I2S2ext_obj)
+#define SPI2                ((SPI_TypeDef *) &SPI2_obj)
+#define SPI3                ((SPI_TypeDef *) &SPI3_obj)
+#define I2S3ext             ((SPI_TypeDef *) &I2S3ext_obj)
+#define USART2              ((USART_TypeDef *) &USART2_obj)
+#define I2C1                ((I2C_TypeDef *) &I2C1_obj)
+#define I2C2                ((I2C_TypeDef *) &I2C2_obj)
+#define I2C3                ((I2C_TypeDef *) &I2C3_obj)
+#define PWR                 ((PWR_TypeDef *) &PWR_obj)
+#define TIM1                ((TIM_TypeDef *) &TIM1_obj)
+#define USART1              ((USART_TypeDef *) &USART1_obj)
+#define USART6              ((USART_TypeDef *) &USART6_obj)
+#define ADC1                ((ADC_TypeDef *) &ADC1_obj)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) &ADC1_COMMON_obj)
+#define ADC                  ADC1_COMMON
+#define SDIO                ((SDIO_TypeDef *) &SDIO_obj)
+#define SPI1                ((SPI_TypeDef *) &SPI1_obj)
+#define SPI4                ((SPI_TypeDef *) &SPI4_obj)
+#define SYSCFG              ((SYSCFG_TypeDef *) &SYSCFG_obj)
+#define EXTI                ((EXTI_TypeDef *) &EXTI_obj)
+#define TIM9                ((TIM_TypeDef *) &TIM9_obj)
+#define TIM10               ((TIM_TypeDef *) &TIM10_obj)
+#define TIM11               ((TIM_TypeDef *) &TIM11_obj)
+#define GPIOA               ((GPIO_TypeDef *) &GPIOA_obj)
+#define GPIOB               ((GPIO_TypeDef *) &GPIOB_obj)
+#define GPIOC               ((GPIO_TypeDef *) &GPIOC_obj)
+#define GPIOD               ((GPIO_TypeDef *) &GPIOD_obj)
+#define GPIOE               ((GPIO_TypeDef *) &GPIOE_obj)
+#define GPIOH               ((GPIO_TypeDef *) &GPIOH_obj)
+#define CRC                 ((CRC_TypeDef *) &CRC_obj)
+#define RCC                 ((RCC_TypeDef *) &RCC_obj)
+#define FLASH               ((FLASH_TypeDef *) &FLASH_obj)
+#define DMA1                ((DMA_TypeDef *) &DMA1_obj)
+#define DMA1_Stream0        ((DMA_Stream_TypeDef *) &DMA1_Stream0_obj)
+#define DMA1_Stream1        ((DMA_Stream_TypeDef *) &DMA1_Stream1_obj)
+#define DMA1_Stream2        ((DMA_Stream_TypeDef *) &DMA1_Stream2_obj)
+#define DMA1_Stream3        ((DMA_Stream_TypeDef *) &DMA1_Stream3_obj)
+#define DMA1_Stream4        ((DMA_Stream_TypeDef *) &DMA1_Stream4_obj)
+#define DMA1_Stream5        ((DMA_Stream_TypeDef *) &DMA1_Stream5_obj)
+#define DMA1_Stream6        ((DMA_Stream_TypeDef *) &DMA1_Stream6_obj)
+#define DMA1_Stream7        ((DMA_Stream_TypeDef *) &DMA1_Stream7_obj)
+#define DMA2                ((DMA_TypeDef *) &DMA2_obj)
+#define DMA2_Stream0        ((DMA_Stream_TypeDef *) &DMA2_Stream0_obj)
+#define DMA2_Stream1        ((DMA_Stream_TypeDef *) &DMA2_Stream1_obj)
+#define DMA2_Stream2        ((DMA_Stream_TypeDef *) &DMA2_Stream2_obj)
+#define DMA2_Stream3        ((DMA_Stream_TypeDef *) &DMA2_Stream3_obj)
+#define DMA2_Stream4        ((DMA_Stream_TypeDef *) &DMA2_Stream4_obj)
+#define DMA2_Stream5        ((DMA_Stream_TypeDef *) &DMA2_Stream5_obj)
+#define DMA2_Stream6        ((DMA_Stream_TypeDef *) &DMA2_Stream6_obj)
+#define DMA2_Stream7        ((DMA_Stream_TypeDef *) &DMA2_Stream7_obj)
+#define DBGMCU              ((DBGMCU_TypeDef *) &DBGMCU_obj)
+#define USB_OTG_FS          ((USB_OTG_GlobalTypeDef *) &USB_OTG_FS_obj)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME                40U /*!< LSI Maximum startup time in us */
+/**
+  * @}
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+    
+/******************************************************************************/
+/*                         Peripheral Registers_Bits_Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Analog to Digital Converter                         */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for ADC_SR register  ********************/
+#define ADC_SR_AWD_Pos            (0U)                                         
+#define ADC_SR_AWD_Msk            (0x1UL << ADC_SR_AWD_Pos)                     /*!< 0x00000001 */
+#define ADC_SR_AWD                ADC_SR_AWD_Msk                               /*!<Analog watchdog flag */
+#define ADC_SR_EOC_Pos            (1U)                                         
+#define ADC_SR_EOC_Msk            (0x1UL << ADC_SR_EOC_Pos)                     /*!< 0x00000002 */
+#define ADC_SR_EOC                ADC_SR_EOC_Msk                               /*!<End of conversion */
+#define ADC_SR_JEOC_Pos           (2U)                                         
+#define ADC_SR_JEOC_Msk           (0x1UL << ADC_SR_JEOC_Pos)                    /*!< 0x00000004 */
+#define ADC_SR_JEOC               ADC_SR_JEOC_Msk                              /*!<Injected channel end of conversion */
+#define ADC_SR_JSTRT_Pos          (3U)                                         
+#define ADC_SR_JSTRT_Msk          (0x1UL << ADC_SR_JSTRT_Pos)                   /*!< 0x00000008 */
+#define ADC_SR_JSTRT              ADC_SR_JSTRT_Msk                             /*!<Injected channel Start flag */
+#define ADC_SR_STRT_Pos           (4U)                                         
+#define ADC_SR_STRT_Msk           (0x1UL << ADC_SR_STRT_Pos)                    /*!< 0x00000010 */
+#define ADC_SR_STRT               ADC_SR_STRT_Msk                              /*!<Regular channel Start flag */
+#define ADC_SR_OVR_Pos            (5U)                                         
+#define ADC_SR_OVR_Msk            (0x1UL << ADC_SR_OVR_Pos)                     /*!< 0x00000020 */
+#define ADC_SR_OVR                ADC_SR_OVR_Msk                               /*!<Overrun flag */
+
+/*******************  Bit definition for ADC_CR1 register  ********************/
+#define ADC_CR1_AWDCH_Pos         (0U)                                         
+#define ADC_CR1_AWDCH_Msk         (0x1FUL << ADC_CR1_AWDCH_Pos)                 /*!< 0x0000001F */
+#define ADC_CR1_AWDCH             ADC_CR1_AWDCH_Msk                            /*!<AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define ADC_CR1_AWDCH_0           (0x01UL << ADC_CR1_AWDCH_Pos)                 /*!< 0x00000001 */
+#define ADC_CR1_AWDCH_1           (0x02UL << ADC_CR1_AWDCH_Pos)                 /*!< 0x00000002 */
+#define ADC_CR1_AWDCH_2           (0x04UL << ADC_CR1_AWDCH_Pos)                 /*!< 0x00000004 */
+#define ADC_CR1_AWDCH_3           (0x08UL << ADC_CR1_AWDCH_Pos)                 /*!< 0x00000008 */
+#define ADC_CR1_AWDCH_4           (0x10UL << ADC_CR1_AWDCH_Pos)                 /*!< 0x00000010 */
+#define ADC_CR1_EOCIE_Pos         (5U)                                         
+#define ADC_CR1_EOCIE_Msk         (0x1UL << ADC_CR1_EOCIE_Pos)                  /*!< 0x00000020 */
+#define ADC_CR1_EOCIE             ADC_CR1_EOCIE_Msk                            /*!<Interrupt enable for EOC */
+#define ADC_CR1_AWDIE_Pos         (6U)                                         
+#define ADC_CR1_AWDIE_Msk         (0x1UL << ADC_CR1_AWDIE_Pos)                  /*!< 0x00000040 */
+#define ADC_CR1_AWDIE             ADC_CR1_AWDIE_Msk                            /*!<AAnalog Watchdog interrupt enable */
+#define ADC_CR1_JEOCIE_Pos        (7U)                                         
+#define ADC_CR1_JEOCIE_Msk        (0x1UL << ADC_CR1_JEOCIE_Pos)                 /*!< 0x00000080 */
+#define ADC_CR1_JEOCIE            ADC_CR1_JEOCIE_Msk                           /*!<Interrupt enable for injected channels */
+#define ADC_CR1_SCAN_Pos          (8U)                                         
+#define ADC_CR1_SCAN_Msk          (0x1UL << ADC_CR1_SCAN_Pos)                   /*!< 0x00000100 */
+#define ADC_CR1_SCAN              ADC_CR1_SCAN_Msk                             /*!<Scan mode */
+#define ADC_CR1_AWDSGL_Pos        (9U)                                         
+#define ADC_CR1_AWDSGL_Msk        (0x1UL << ADC_CR1_AWDSGL_Pos)                 /*!< 0x00000200 */
+#define ADC_CR1_AWDSGL            ADC_CR1_AWDSGL_Msk                           /*!<Enable the watchdog on a single channel in scan mode */
+#define ADC_CR1_JAUTO_Pos         (10U)                                        
+#define ADC_CR1_JAUTO_Msk         (0x1UL << ADC_CR1_JAUTO_Pos)                  /*!< 0x00000400 */
+#define ADC_CR1_JAUTO             ADC_CR1_JAUTO_Msk                            /*!<Automatic injected group conversion */
+#define ADC_CR1_DISCEN_Pos        (11U)                                        
+#define ADC_CR1_DISCEN_Msk        (0x1UL << ADC_CR1_DISCEN_Pos)                 /*!< 0x00000800 */
+#define ADC_CR1_DISCEN            ADC_CR1_DISCEN_Msk                           /*!<Discontinuous mode on regular channels */
+#define ADC_CR1_JDISCEN_Pos       (12U)                                        
+#define ADC_CR1_JDISCEN_Msk       (0x1UL << ADC_CR1_JDISCEN_Pos)                /*!< 0x00001000 */
+#define ADC_CR1_JDISCEN           ADC_CR1_JDISCEN_Msk                          /*!<Discontinuous mode on injected channels */
+#define ADC_CR1_DISCNUM_Pos       (13U)                                        
+#define ADC_CR1_DISCNUM_Msk       (0x7UL << ADC_CR1_DISCNUM_Pos)                /*!< 0x0000E000 */
+#define ADC_CR1_DISCNUM           ADC_CR1_DISCNUM_Msk                          /*!<DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define ADC_CR1_DISCNUM_0         (0x1UL << ADC_CR1_DISCNUM_Pos)                /*!< 0x00002000 */
+#define ADC_CR1_DISCNUM_1         (0x2UL << ADC_CR1_DISCNUM_Pos)                /*!< 0x00004000 */
+#define ADC_CR1_DISCNUM_2         (0x4UL << ADC_CR1_DISCNUM_Pos)                /*!< 0x00008000 */
+#define ADC_CR1_JAWDEN_Pos        (22U)                                        
+#define ADC_CR1_JAWDEN_Msk        (0x1UL << ADC_CR1_JAWDEN_Pos)                 /*!< 0x00400000 */
+#define ADC_CR1_JAWDEN            ADC_CR1_JAWDEN_Msk                           /*!<Analog watchdog enable on injected channels */
+#define ADC_CR1_AWDEN_Pos         (23U)                                        
+#define ADC_CR1_AWDEN_Msk         (0x1UL << ADC_CR1_AWDEN_Pos)                  /*!< 0x00800000 */
+#define ADC_CR1_AWDEN             ADC_CR1_AWDEN_Msk                            /*!<Analog watchdog enable on regular channels */
+#define ADC_CR1_RES_Pos           (24U)                                        
+#define ADC_CR1_RES_Msk           (0x3UL << ADC_CR1_RES_Pos)                    /*!< 0x03000000 */
+#define ADC_CR1_RES               ADC_CR1_RES_Msk                              /*!<RES[2:0] bits (Resolution) */
+#define ADC_CR1_RES_0             (0x1UL << ADC_CR1_RES_Pos)                    /*!< 0x01000000 */
+#define ADC_CR1_RES_1             (0x2UL << ADC_CR1_RES_Pos)                    /*!< 0x02000000 */
+#define ADC_CR1_OVRIE_Pos         (26U)                                        
+#define ADC_CR1_OVRIE_Msk         (0x1UL << ADC_CR1_OVRIE_Pos)                  /*!< 0x04000000 */
+#define ADC_CR1_OVRIE             ADC_CR1_OVRIE_Msk                            /*!<overrun interrupt enable */
+  
+/*******************  Bit definition for ADC_CR2 register  ********************/
+#define ADC_CR2_ADON_Pos          (0U)                                         
+#define ADC_CR2_ADON_Msk          (0x1UL << ADC_CR2_ADON_Pos)                   /*!< 0x00000001 */
+#define ADC_CR2_ADON              ADC_CR2_ADON_Msk                             /*!<A/D Converter ON / OFF */
+#define ADC_CR2_CONT_Pos          (1U)                                         
+#define ADC_CR2_CONT_Msk          (0x1UL << ADC_CR2_CONT_Pos)                   /*!< 0x00000002 */
+#define ADC_CR2_CONT              ADC_CR2_CONT_Msk                             /*!<Continuous Conversion */
+#define ADC_CR2_DMA_Pos           (8U)                                         
+#define ADC_CR2_DMA_Msk           (0x1UL << ADC_CR2_DMA_Pos)                    /*!< 0x00000100 */
+#define ADC_CR2_DMA               ADC_CR2_DMA_Msk                              /*!<Direct Memory access mode */
+#define ADC_CR2_DDS_Pos           (9U)                                         
+#define ADC_CR2_DDS_Msk           (0x1UL << ADC_CR2_DDS_Pos)                    /*!< 0x00000200 */
+#define ADC_CR2_DDS               ADC_CR2_DDS_Msk                              /*!<DMA disable selection (Single ADC) */
+#define ADC_CR2_EOCS_Pos          (10U)                                        
+#define ADC_CR2_EOCS_Msk          (0x1UL << ADC_CR2_EOCS_Pos)                   /*!< 0x00000400 */
+#define ADC_CR2_EOCS              ADC_CR2_EOCS_Msk                             /*!<End of conversion selection */
+#define ADC_CR2_ALIGN_Pos         (11U)                                        
+#define ADC_CR2_ALIGN_Msk         (0x1UL << ADC_CR2_ALIGN_Pos)                  /*!< 0x00000800 */
+#define ADC_CR2_ALIGN             ADC_CR2_ALIGN_Msk                            /*!<Data Alignment */
+#define ADC_CR2_JEXTSEL_Pos       (16U)                                        
+#define ADC_CR2_JEXTSEL_Msk       (0xFUL << ADC_CR2_JEXTSEL_Pos)                /*!< 0x000F0000 */
+#define ADC_CR2_JEXTSEL           ADC_CR2_JEXTSEL_Msk                          /*!<JEXTSEL[3:0] bits (External event select for injected group) */
+#define ADC_CR2_JEXTSEL_0         (0x1UL << ADC_CR2_JEXTSEL_Pos)                /*!< 0x00010000 */
+#define ADC_CR2_JEXTSEL_1         (0x2UL << ADC_CR2_JEXTSEL_Pos)                /*!< 0x00020000 */
+#define ADC_CR2_JEXTSEL_2         (0x4UL << ADC_CR2_JEXTSEL_Pos)                /*!< 0x00040000 */
+#define ADC_CR2_JEXTSEL_3         (0x8UL << ADC_CR2_JEXTSEL_Pos)                /*!< 0x00080000 */
+#define ADC_CR2_JEXTEN_Pos        (20U)                                        
+#define ADC_CR2_JEXTEN_Msk        (0x3UL << ADC_CR2_JEXTEN_Pos)                 /*!< 0x00300000 */
+#define ADC_CR2_JEXTEN            ADC_CR2_JEXTEN_Msk                           /*!<JEXTEN[1:0] bits (External Trigger Conversion mode for injected channelsp) */
+#define ADC_CR2_JEXTEN_0          (0x1UL << ADC_CR2_JEXTEN_Pos)                 /*!< 0x00100000 */
+#define ADC_CR2_JEXTEN_1          (0x2UL << ADC_CR2_JEXTEN_Pos)                 /*!< 0x00200000 */
+#define ADC_CR2_JSWSTART_Pos      (22U)                                        
+#define ADC_CR2_JSWSTART_Msk      (0x1UL << ADC_CR2_JSWSTART_Pos)               /*!< 0x00400000 */
+#define ADC_CR2_JSWSTART          ADC_CR2_JSWSTART_Msk                         /*!<Start Conversion of injected channels */
+#define ADC_CR2_EXTSEL_Pos        (24U)                                        
+#define ADC_CR2_EXTSEL_Msk        (0xFUL << ADC_CR2_EXTSEL_Pos)                 /*!< 0x0F000000 */
+#define ADC_CR2_EXTSEL            ADC_CR2_EXTSEL_Msk                           /*!<EXTSEL[3:0] bits (External Event Select for regular group) */
+#define ADC_CR2_EXTSEL_0          (0x1UL << ADC_CR2_EXTSEL_Pos)                 /*!< 0x01000000 */
+#define ADC_CR2_EXTSEL_1          (0x2UL << ADC_CR2_EXTSEL_Pos)                 /*!< 0x02000000 */
+#define ADC_CR2_EXTSEL_2          (0x4UL << ADC_CR2_EXTSEL_Pos)                 /*!< 0x04000000 */
+#define ADC_CR2_EXTSEL_3          (0x8UL << ADC_CR2_EXTSEL_Pos)                 /*!< 0x08000000 */
+#define ADC_CR2_EXTEN_Pos         (28U)                                        
+#define ADC_CR2_EXTEN_Msk         (0x3UL << ADC_CR2_EXTEN_Pos)                  /*!< 0x30000000 */
+#define ADC_CR2_EXTEN             ADC_CR2_EXTEN_Msk                            /*!<EXTEN[1:0] bits (External Trigger Conversion mode for regular channelsp) */
+#define ADC_CR2_EXTEN_0           (0x1UL << ADC_CR2_EXTEN_Pos)                  /*!< 0x10000000 */
+#define ADC_CR2_EXTEN_1           (0x2UL << ADC_CR2_EXTEN_Pos)                  /*!< 0x20000000 */
+#define ADC_CR2_SWSTART_Pos       (30U)                                        
+#define ADC_CR2_SWSTART_Msk       (0x1UL << ADC_CR2_SWSTART_Pos)                /*!< 0x40000000 */
+#define ADC_CR2_SWSTART           ADC_CR2_SWSTART_Msk                          /*!<Start Conversion of regular channels */
+
+/******************  Bit definition for ADC_SMPR1 register  *******************/
+#define ADC_SMPR1_SMP10_Pos       (0U)                                         
+#define ADC_SMPR1_SMP10_Msk       (0x7UL << ADC_SMPR1_SMP10_Pos)                /*!< 0x00000007 */
+#define ADC_SMPR1_SMP10           ADC_SMPR1_SMP10_Msk                          /*!<SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define ADC_SMPR1_SMP10_0         (0x1UL << ADC_SMPR1_SMP10_Pos)                /*!< 0x00000001 */
+#define ADC_SMPR1_SMP10_1         (0x2UL << ADC_SMPR1_SMP10_Pos)                /*!< 0x00000002 */
+#define ADC_SMPR1_SMP10_2         (0x4UL << ADC_SMPR1_SMP10_Pos)                /*!< 0x00000004 */
+#define ADC_SMPR1_SMP11_Pos       (3U)                                         
+#define ADC_SMPR1_SMP11_Msk       (0x7UL << ADC_SMPR1_SMP11_Pos)                /*!< 0x00000038 */
+#define ADC_SMPR1_SMP11           ADC_SMPR1_SMP11_Msk                          /*!<SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define ADC_SMPR1_SMP11_0         (0x1UL << ADC_SMPR1_SMP11_Pos)                /*!< 0x00000008 */
+#define ADC_SMPR1_SMP11_1         (0x2UL << ADC_SMPR1_SMP11_Pos)                /*!< 0x00000010 */
+#define ADC_SMPR1_SMP11_2         (0x4UL << ADC_SMPR1_SMP11_Pos)                /*!< 0x00000020 */
+#define ADC_SMPR1_SMP12_Pos       (6U)                                         
+#define ADC_SMPR1_SMP12_Msk       (0x7UL << ADC_SMPR1_SMP12_Pos)                /*!< 0x000001C0 */
+#define ADC_SMPR1_SMP12           ADC_SMPR1_SMP12_Msk                          /*!<SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define ADC_SMPR1_SMP12_0         (0x1UL << ADC_SMPR1_SMP12_Pos)                /*!< 0x00000040 */
+#define ADC_SMPR1_SMP12_1         (0x2UL << ADC_SMPR1_SMP12_Pos)                /*!< 0x00000080 */
+#define ADC_SMPR1_SMP12_2         (0x4UL << ADC_SMPR1_SMP12_Pos)                /*!< 0x00000100 */
+#define ADC_SMPR1_SMP13_Pos       (9U)                                         
+#define ADC_SMPR1_SMP13_Msk       (0x7UL << ADC_SMPR1_SMP13_Pos)                /*!< 0x00000E00 */
+#define ADC_SMPR1_SMP13           ADC_SMPR1_SMP13_Msk                          /*!<SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define ADC_SMPR1_SMP13_0         (0x1UL << ADC_SMPR1_SMP13_Pos)                /*!< 0x00000200 */
+#define ADC_SMPR1_SMP13_1         (0x2UL << ADC_SMPR1_SMP13_Pos)                /*!< 0x00000400 */
+#define ADC_SMPR1_SMP13_2         (0x4UL << ADC_SMPR1_SMP13_Pos)                /*!< 0x00000800 */
+#define ADC_SMPR1_SMP14_Pos       (12U)                                        
+#define ADC_SMPR1_SMP14_Msk       (0x7UL << ADC_SMPR1_SMP14_Pos)                /*!< 0x00007000 */
+#define ADC_SMPR1_SMP14           ADC_SMPR1_SMP14_Msk                          /*!<SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define ADC_SMPR1_SMP14_0         (0x1UL << ADC_SMPR1_SMP14_Pos)                /*!< 0x00001000 */
+#define ADC_SMPR1_SMP14_1         (0x2UL << ADC_SMPR1_SMP14_Pos)                /*!< 0x00002000 */
+#define ADC_SMPR1_SMP14_2         (0x4UL << ADC_SMPR1_SMP14_Pos)                /*!< 0x00004000 */
+#define ADC_SMPR1_SMP15_Pos       (15U)                                        
+#define ADC_SMPR1_SMP15_Msk       (0x7UL << ADC_SMPR1_SMP15_Pos)                /*!< 0x00038000 */
+#define ADC_SMPR1_SMP15           ADC_SMPR1_SMP15_Msk                          /*!<SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define ADC_SMPR1_SMP15_0         (0x1UL << ADC_SMPR1_SMP15_Pos)                /*!< 0x00008000 */
+#define ADC_SMPR1_SMP15_1         (0x2UL << ADC_SMPR1_SMP15_Pos)                /*!< 0x00010000 */
+#define ADC_SMPR1_SMP15_2         (0x4UL << ADC_SMPR1_SMP15_Pos)                /*!< 0x00020000 */
+#define ADC_SMPR1_SMP16_Pos       (18U)                                        
+#define ADC_SMPR1_SMP16_Msk       (0x7UL << ADC_SMPR1_SMP16_Pos)                /*!< 0x001C0000 */
+#define ADC_SMPR1_SMP16           ADC_SMPR1_SMP16_Msk                          /*!<SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define ADC_SMPR1_SMP16_0         (0x1UL << ADC_SMPR1_SMP16_Pos)                /*!< 0x00040000 */
+#define ADC_SMPR1_SMP16_1         (0x2UL << ADC_SMPR1_SMP16_Pos)                /*!< 0x00080000 */
+#define ADC_SMPR1_SMP16_2         (0x4UL << ADC_SMPR1_SMP16_Pos)                /*!< 0x00100000 */
+#define ADC_SMPR1_SMP17_Pos       (21U)                                        
+#define ADC_SMPR1_SMP17_Msk       (0x7UL << ADC_SMPR1_SMP17_Pos)                /*!< 0x00E00000 */
+#define ADC_SMPR1_SMP17           ADC_SMPR1_SMP17_Msk                          /*!<SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define ADC_SMPR1_SMP17_0         (0x1UL << ADC_SMPR1_SMP17_Pos)                /*!< 0x00200000 */
+#define ADC_SMPR1_SMP17_1         (0x2UL << ADC_SMPR1_SMP17_Pos)                /*!< 0x00400000 */
+#define ADC_SMPR1_SMP17_2         (0x4UL << ADC_SMPR1_SMP17_Pos)                /*!< 0x00800000 */
+#define ADC_SMPR1_SMP18_Pos       (24U)                                        
+#define ADC_SMPR1_SMP18_Msk       (0x7UL << ADC_SMPR1_SMP18_Pos)                /*!< 0x07000000 */
+#define ADC_SMPR1_SMP18           ADC_SMPR1_SMP18_Msk                          /*!<SMP18[2:0] bits (Channel 18 Sample time selection) */
+#define ADC_SMPR1_SMP18_0         (0x1UL << ADC_SMPR1_SMP18_Pos)                /*!< 0x01000000 */
+#define ADC_SMPR1_SMP18_1         (0x2UL << ADC_SMPR1_SMP18_Pos)                /*!< 0x02000000 */
+#define ADC_SMPR1_SMP18_2         (0x4UL << ADC_SMPR1_SMP18_Pos)                /*!< 0x04000000 */
+
+/******************  Bit definition for ADC_SMPR2 register  *******************/
+#define ADC_SMPR2_SMP0_Pos        (0U)                                         
+#define ADC_SMPR2_SMP0_Msk        (0x7UL << ADC_SMPR2_SMP0_Pos)                 /*!< 0x00000007 */
+#define ADC_SMPR2_SMP0            ADC_SMPR2_SMP0_Msk                           /*!<SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define ADC_SMPR2_SMP0_0          (0x1UL << ADC_SMPR2_SMP0_Pos)                 /*!< 0x00000001 */
+#define ADC_SMPR2_SMP0_1          (0x2UL << ADC_SMPR2_SMP0_Pos)                 /*!< 0x00000002 */
+#define ADC_SMPR2_SMP0_2          (0x4UL << ADC_SMPR2_SMP0_Pos)                 /*!< 0x00000004 */
+#define ADC_SMPR2_SMP1_Pos        (3U)                                         
+#define ADC_SMPR2_SMP1_Msk        (0x7UL << ADC_SMPR2_SMP1_Pos)                 /*!< 0x00000038 */
+#define ADC_SMPR2_SMP1            ADC_SMPR2_SMP1_Msk                           /*!<SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define ADC_SMPR2_SMP1_0          (0x1UL << ADC_SMPR2_SMP1_Pos)                 /*!< 0x00000008 */
+#define ADC_SMPR2_SMP1_1          (0x2UL << ADC_SMPR2_SMP1_Pos)                 /*!< 0x00000010 */
+#define ADC_SMPR2_SMP1_2          (0x4UL << ADC_SMPR2_SMP1_Pos)                 /*!< 0x00000020 */
+#define ADC_SMPR2_SMP2_Pos        (6U)                                         
+#define ADC_SMPR2_SMP2_Msk        (0x7UL << ADC_SMPR2_SMP2_Pos)                 /*!< 0x000001C0 */
+#define ADC_SMPR2_SMP2            ADC_SMPR2_SMP2_Msk                           /*!<SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define ADC_SMPR2_SMP2_0          (0x1UL << ADC_SMPR2_SMP2_Pos)                 /*!< 0x00000040 */
+#define ADC_SMPR2_SMP2_1          (0x2UL << ADC_SMPR2_SMP2_Pos)                 /*!< 0x00000080 */
+#define ADC_SMPR2_SMP2_2          (0x4UL << ADC_SMPR2_SMP2_Pos)                 /*!< 0x00000100 */
+#define ADC_SMPR2_SMP3_Pos        (9U)                                         
+#define ADC_SMPR2_SMP3_Msk        (0x7UL << ADC_SMPR2_SMP3_Pos)                 /*!< 0x00000E00 */
+#define ADC_SMPR2_SMP3            ADC_SMPR2_SMP3_Msk                           /*!<SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define ADC_SMPR2_SMP3_0          (0x1UL << ADC_SMPR2_SMP3_Pos)                 /*!< 0x00000200 */
+#define ADC_SMPR2_SMP3_1          (0x2UL << ADC_SMPR2_SMP3_Pos)                 /*!< 0x00000400 */
+#define ADC_SMPR2_SMP3_2          (0x4UL << ADC_SMPR2_SMP3_Pos)                 /*!< 0x00000800 */
+#define ADC_SMPR2_SMP4_Pos        (12U)                                        
+#define ADC_SMPR2_SMP4_Msk        (0x7UL << ADC_SMPR2_SMP4_Pos)                 /*!< 0x00007000 */
+#define ADC_SMPR2_SMP4            ADC_SMPR2_SMP4_Msk                           /*!<SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define ADC_SMPR2_SMP4_0          (0x1UL << ADC_SMPR2_SMP4_Pos)                 /*!< 0x00001000 */
+#define ADC_SMPR2_SMP4_1          (0x2UL << ADC_SMPR2_SMP4_Pos)                 /*!< 0x00002000 */
+#define ADC_SMPR2_SMP4_2          (0x4UL << ADC_SMPR2_SMP4_Pos)                 /*!< 0x00004000 */
+#define ADC_SMPR2_SMP5_Pos        (15U)                                        
+#define ADC_SMPR2_SMP5_Msk        (0x7UL << ADC_SMPR2_SMP5_Pos)                 /*!< 0x00038000 */
+#define ADC_SMPR2_SMP5            ADC_SMPR2_SMP5_Msk                           /*!<SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define ADC_SMPR2_SMP5_0          (0x1UL << ADC_SMPR2_SMP5_Pos)                 /*!< 0x00008000 */
+#define ADC_SMPR2_SMP5_1          (0x2UL << ADC_SMPR2_SMP5_Pos)                 /*!< 0x00010000 */
+#define ADC_SMPR2_SMP5_2          (0x4UL << ADC_SMPR2_SMP5_Pos)                 /*!< 0x00020000 */
+#define ADC_SMPR2_SMP6_Pos        (18U)                                        
+#define ADC_SMPR2_SMP6_Msk        (0x7UL << ADC_SMPR2_SMP6_Pos)                 /*!< 0x001C0000 */
+#define ADC_SMPR2_SMP6            ADC_SMPR2_SMP6_Msk                           /*!<SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define ADC_SMPR2_SMP6_0          (0x1UL << ADC_SMPR2_SMP6_Pos)                 /*!< 0x00040000 */
+#define ADC_SMPR2_SMP6_1          (0x2UL << ADC_SMPR2_SMP6_Pos)                 /*!< 0x00080000 */
+#define ADC_SMPR2_SMP6_2          (0x4UL << ADC_SMPR2_SMP6_Pos)                 /*!< 0x00100000 */
+#define ADC_SMPR2_SMP7_Pos        (21U)                                        
+#define ADC_SMPR2_SMP7_Msk        (0x7UL << ADC_SMPR2_SMP7_Pos)                 /*!< 0x00E00000 */
+#define ADC_SMPR2_SMP7            ADC_SMPR2_SMP7_Msk                           /*!<SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define ADC_SMPR2_SMP7_0          (0x1UL << ADC_SMPR2_SMP7_Pos)                 /*!< 0x00200000 */
+#define ADC_SMPR2_SMP7_1          (0x2UL << ADC_SMPR2_SMP7_Pos)                 /*!< 0x00400000 */
+#define ADC_SMPR2_SMP7_2          (0x4UL << ADC_SMPR2_SMP7_Pos)                 /*!< 0x00800000 */
+#define ADC_SMPR2_SMP8_Pos        (24U)                                        
+#define ADC_SMPR2_SMP8_Msk        (0x7UL << ADC_SMPR2_SMP8_Pos)                 /*!< 0x07000000 */
+#define ADC_SMPR2_SMP8            ADC_SMPR2_SMP8_Msk                           /*!<SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define ADC_SMPR2_SMP8_0          (0x1UL << ADC_SMPR2_SMP8_Pos)                 /*!< 0x01000000 */
+#define ADC_SMPR2_SMP8_1          (0x2UL << ADC_SMPR2_SMP8_Pos)                 /*!< 0x02000000 */
+#define ADC_SMPR2_SMP8_2          (0x4UL << ADC_SMPR2_SMP8_Pos)                 /*!< 0x04000000 */
+#define ADC_SMPR2_SMP9_Pos        (27U)                                        
+#define ADC_SMPR2_SMP9_Msk        (0x7UL << ADC_SMPR2_SMP9_Pos)                 /*!< 0x38000000 */
+#define ADC_SMPR2_SMP9            ADC_SMPR2_SMP9_Msk                           /*!<SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define ADC_SMPR2_SMP9_0          (0x1UL << ADC_SMPR2_SMP9_Pos)                 /*!< 0x08000000 */
+#define ADC_SMPR2_SMP9_1          (0x2UL << ADC_SMPR2_SMP9_Pos)                 /*!< 0x10000000 */
+#define ADC_SMPR2_SMP9_2          (0x4UL << ADC_SMPR2_SMP9_Pos)                 /*!< 0x20000000 */
+
+/******************  Bit definition for ADC_JOFR1 register  *******************/
+#define ADC_JOFR1_JOFFSET1_Pos    (0U)                                         
+#define ADC_JOFR1_JOFFSET1_Msk    (0xFFFUL << ADC_JOFR1_JOFFSET1_Pos)           /*!< 0x00000FFF */
+#define ADC_JOFR1_JOFFSET1        ADC_JOFR1_JOFFSET1_Msk                       /*!<Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_JOFR2 register  *******************/
+#define ADC_JOFR2_JOFFSET2_Pos    (0U)                                         
+#define ADC_JOFR2_JOFFSET2_Msk    (0xFFFUL << ADC_JOFR2_JOFFSET2_Pos)           /*!< 0x00000FFF */
+#define ADC_JOFR2_JOFFSET2        ADC_JOFR2_JOFFSET2_Msk                       /*!<Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_JOFR3 register  *******************/
+#define ADC_JOFR3_JOFFSET3_Pos    (0U)                                         
+#define ADC_JOFR3_JOFFSET3_Msk    (0xFFFUL << ADC_JOFR3_JOFFSET3_Pos)           /*!< 0x00000FFF */
+#define ADC_JOFR3_JOFFSET3        ADC_JOFR3_JOFFSET3_Msk                       /*!<Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_JOFR4 register  *******************/
+#define ADC_JOFR4_JOFFSET4_Pos    (0U)                                         
+#define ADC_JOFR4_JOFFSET4_Msk    (0xFFFUL << ADC_JOFR4_JOFFSET4_Pos)           /*!< 0x00000FFF */
+#define ADC_JOFR4_JOFFSET4        ADC_JOFR4_JOFFSET4_Msk                       /*!<Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_HTR register  ********************/
+#define ADC_HTR_HT_Pos            (0U)                                         
+#define ADC_HTR_HT_Msk            (0xFFFUL << ADC_HTR_HT_Pos)                   /*!< 0x00000FFF */
+#define ADC_HTR_HT                ADC_HTR_HT_Msk                               /*!<Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_LTR register  ********************/
+#define ADC_LTR_LT_Pos            (0U)                                         
+#define ADC_LTR_LT_Msk            (0xFFFUL << ADC_LTR_LT_Pos)                   /*!< 0x00000FFF */
+#define ADC_LTR_LT                ADC_LTR_LT_Msk                               /*!<Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_SQR1 register  *******************/
+#define ADC_SQR1_SQ13_Pos         (0U)                                         
+#define ADC_SQR1_SQ13_Msk         (0x1FUL << ADC_SQR1_SQ13_Pos)                 /*!< 0x0000001F */
+#define ADC_SQR1_SQ13             ADC_SQR1_SQ13_Msk                            /*!<SQ13[4:0] bits (13th conversion in regular sequence) */
+#define ADC_SQR1_SQ13_0           (0x01UL << ADC_SQR1_SQ13_Pos)                 /*!< 0x00000001 */
+#define ADC_SQR1_SQ13_1           (0x02UL << ADC_SQR1_SQ13_Pos)                 /*!< 0x00000002 */
+#define ADC_SQR1_SQ13_2           (0x04UL << ADC_SQR1_SQ13_Pos)                 /*!< 0x00000004 */
+#define ADC_SQR1_SQ13_3           (0x08UL << ADC_SQR1_SQ13_Pos)                 /*!< 0x00000008 */
+#define ADC_SQR1_SQ13_4           (0x10UL << ADC_SQR1_SQ13_Pos)                 /*!< 0x00000010 */
+#define ADC_SQR1_SQ14_Pos         (5U)                                         
+#define ADC_SQR1_SQ14_Msk         (0x1FUL << ADC_SQR1_SQ14_Pos)                 /*!< 0x000003E0 */
+#define ADC_SQR1_SQ14             ADC_SQR1_SQ14_Msk                            /*!<SQ14[4:0] bits (14th conversion in regular sequence) */
+#define ADC_SQR1_SQ14_0           (0x01UL << ADC_SQR1_SQ14_Pos)                 /*!< 0x00000020 */
+#define ADC_SQR1_SQ14_1           (0x02UL << ADC_SQR1_SQ14_Pos)                 /*!< 0x00000040 */
+#define ADC_SQR1_SQ14_2           (0x04UL << ADC_SQR1_SQ14_Pos)                 /*!< 0x00000080 */
+#define ADC_SQR1_SQ14_3           (0x08UL << ADC_SQR1_SQ14_Pos)                 /*!< 0x00000100 */
+#define ADC_SQR1_SQ14_4           (0x10UL << ADC_SQR1_SQ14_Pos)                 /*!< 0x00000200 */
+#define ADC_SQR1_SQ15_Pos         (10U)                                        
+#define ADC_SQR1_SQ15_Msk         (0x1FUL << ADC_SQR1_SQ15_Pos)                 /*!< 0x00007C00 */
+#define ADC_SQR1_SQ15             ADC_SQR1_SQ15_Msk                            /*!<SQ15[4:0] bits (15th conversion in regular sequence) */
+#define ADC_SQR1_SQ15_0           (0x01UL << ADC_SQR1_SQ15_Pos)                 /*!< 0x00000400 */
+#define ADC_SQR1_SQ15_1           (0x02UL << ADC_SQR1_SQ15_Pos)                 /*!< 0x00000800 */
+#define ADC_SQR1_SQ15_2           (0x04UL << ADC_SQR1_SQ15_Pos)                 /*!< 0x00001000 */
+#define ADC_SQR1_SQ15_3           (0x08UL << ADC_SQR1_SQ15_Pos)                 /*!< 0x00002000 */
+#define ADC_SQR1_SQ15_4           (0x10UL << ADC_SQR1_SQ15_Pos)                 /*!< 0x00004000 */
+#define ADC_SQR1_SQ16_Pos         (15U)                                        
+#define ADC_SQR1_SQ16_Msk         (0x1FUL << ADC_SQR1_SQ16_Pos)                 /*!< 0x000F8000 */
+#define ADC_SQR1_SQ16             ADC_SQR1_SQ16_Msk                            /*!<SQ16[4:0] bits (16th conversion in regular sequence) */
+#define ADC_SQR1_SQ16_0           (0x01UL << ADC_SQR1_SQ16_Pos)                 /*!< 0x00008000 */
+#define ADC_SQR1_SQ16_1           (0x02UL << ADC_SQR1_SQ16_Pos)                 /*!< 0x00010000 */
+#define ADC_SQR1_SQ16_2           (0x04UL << ADC_SQR1_SQ16_Pos)                 /*!< 0x00020000 */
+#define ADC_SQR1_SQ16_3           (0x08UL << ADC_SQR1_SQ16_Pos)                 /*!< 0x00040000 */
+#define ADC_SQR1_SQ16_4           (0x10UL << ADC_SQR1_SQ16_Pos)                 /*!< 0x00080000 */
+#define ADC_SQR1_L_Pos            (20U)                                        
+#define ADC_SQR1_L_Msk            (0xFUL << ADC_SQR1_L_Pos)                     /*!< 0x00F00000 */
+#define ADC_SQR1_L                ADC_SQR1_L_Msk                               /*!<L[3:0] bits (Regular channel sequence length) */
+#define ADC_SQR1_L_0              (0x1UL << ADC_SQR1_L_Pos)                     /*!< 0x00100000 */
+#define ADC_SQR1_L_1              (0x2UL << ADC_SQR1_L_Pos)                     /*!< 0x00200000 */
+#define ADC_SQR1_L_2              (0x4UL << ADC_SQR1_L_Pos)                     /*!< 0x00400000 */
+#define ADC_SQR1_L_3              (0x8UL << ADC_SQR1_L_Pos)                     /*!< 0x00800000 */
+
+/*******************  Bit definition for ADC_SQR2 register  *******************/
+#define ADC_SQR2_SQ7_Pos          (0U)                                         
+#define ADC_SQR2_SQ7_Msk          (0x1FUL << ADC_SQR2_SQ7_Pos)                  /*!< 0x0000001F */
+#define ADC_SQR2_SQ7              ADC_SQR2_SQ7_Msk                             /*!<SQ7[4:0] bits (7th conversion in regular sequence) */
+#define ADC_SQR2_SQ7_0            (0x01UL << ADC_SQR2_SQ7_Pos)                  /*!< 0x00000001 */
+#define ADC_SQR2_SQ7_1            (0x02UL << ADC_SQR2_SQ7_Pos)                  /*!< 0x00000002 */
+#define ADC_SQR2_SQ7_2            (0x04UL << ADC_SQR2_SQ7_Pos)                  /*!< 0x00000004 */
+#define ADC_SQR2_SQ7_3            (0x08UL << ADC_SQR2_SQ7_Pos)                  /*!< 0x00000008 */
+#define ADC_SQR2_SQ7_4            (0x10UL << ADC_SQR2_SQ7_Pos)                  /*!< 0x00000010 */
+#define ADC_SQR2_SQ8_Pos          (5U)                                         
+#define ADC_SQR2_SQ8_Msk          (0x1FUL << ADC_SQR2_SQ8_Pos)                  /*!< 0x000003E0 */
+#define ADC_SQR2_SQ8              ADC_SQR2_SQ8_Msk                             /*!<SQ8[4:0] bits (8th conversion in regular sequence) */
+#define ADC_SQR2_SQ8_0            (0x01UL << ADC_SQR2_SQ8_Pos)                  /*!< 0x00000020 */
+#define ADC_SQR2_SQ8_1            (0x02UL << ADC_SQR2_SQ8_Pos)                  /*!< 0x00000040 */
+#define ADC_SQR2_SQ8_2            (0x04UL << ADC_SQR2_SQ8_Pos)                  /*!< 0x00000080 */
+#define ADC_SQR2_SQ8_3            (0x08UL << ADC_SQR2_SQ8_Pos)                  /*!< 0x00000100 */
+#define ADC_SQR2_SQ8_4            (0x10UL << ADC_SQR2_SQ8_Pos)                  /*!< 0x00000200 */
+#define ADC_SQR2_SQ9_Pos          (10U)                                        
+#define ADC_SQR2_SQ9_Msk          (0x1FUL << ADC_SQR2_SQ9_Pos)                  /*!< 0x00007C00 */
+#define ADC_SQR2_SQ9              ADC_SQR2_SQ9_Msk                             /*!<SQ9[4:0] bits (9th conversion in regular sequence) */
+#define ADC_SQR2_SQ9_0            (0x01UL << ADC_SQR2_SQ9_Pos)                  /*!< 0x00000400 */
+#define ADC_SQR2_SQ9_1            (0x02UL << ADC_SQR2_SQ9_Pos)                  /*!< 0x00000800 */
+#define ADC_SQR2_SQ9_2            (0x04UL << ADC_SQR2_SQ9_Pos)                  /*!< 0x00001000 */
+#define ADC_SQR2_SQ9_3            (0x08UL << ADC_SQR2_SQ9_Pos)                  /*!< 0x00002000 */
+#define ADC_SQR2_SQ9_4            (0x10UL << ADC_SQR2_SQ9_Pos)                  /*!< 0x00004000 */
+#define ADC_SQR2_SQ10_Pos         (15U)                                        
+#define ADC_SQR2_SQ10_Msk         (0x1FUL << ADC_SQR2_SQ10_Pos)                 /*!< 0x000F8000 */
+#define ADC_SQR2_SQ10             ADC_SQR2_SQ10_Msk                            /*!<SQ10[4:0] bits (10th conversion in regular sequence) */
+#define ADC_SQR2_SQ10_0           (0x01UL << ADC_SQR2_SQ10_Pos)                 /*!< 0x00008000 */
+#define ADC_SQR2_SQ10_1           (0x02UL << ADC_SQR2_SQ10_Pos)                 /*!< 0x00010000 */
+#define ADC_SQR2_SQ10_2           (0x04UL << ADC_SQR2_SQ10_Pos)                 /*!< 0x00020000 */
+#define ADC_SQR2_SQ10_3           (0x08UL << ADC_SQR2_SQ10_Pos)                 /*!< 0x00040000 */
+#define ADC_SQR2_SQ10_4           (0x10UL << ADC_SQR2_SQ10_Pos)                 /*!< 0x00080000 */
+#define ADC_SQR2_SQ11_Pos         (20U)                                        
+#define ADC_SQR2_SQ11_Msk         (0x1FUL << ADC_SQR2_SQ11_Pos)                 /*!< 0x01F00000 */
+#define ADC_SQR2_SQ11             ADC_SQR2_SQ11_Msk                            /*!<SQ11[4:0] bits (11th conversion in regular sequence) */
+#define ADC_SQR2_SQ11_0           (0x01UL << ADC_SQR2_SQ11_Pos)                 /*!< 0x00100000 */
+#define ADC_SQR2_SQ11_1           (0x02UL << ADC_SQR2_SQ11_Pos)                 /*!< 0x00200000 */
+#define ADC_SQR2_SQ11_2           (0x04UL << ADC_SQR2_SQ11_Pos)                 /*!< 0x00400000 */
+#define ADC_SQR2_SQ11_3           (0x08UL << ADC_SQR2_SQ11_Pos)                 /*!< 0x00800000 */
+#define ADC_SQR2_SQ11_4           (0x10UL << ADC_SQR2_SQ11_Pos)                 /*!< 0x01000000 */
+#define ADC_SQR2_SQ12_Pos         (25U)                                        
+#define ADC_SQR2_SQ12_Msk         (0x1FUL << ADC_SQR2_SQ12_Pos)                 /*!< 0x3E000000 */
+#define ADC_SQR2_SQ12             ADC_SQR2_SQ12_Msk                            /*!<SQ12[4:0] bits (12th conversion in regular sequence) */
+#define ADC_SQR2_SQ12_0           (0x01UL << ADC_SQR2_SQ12_Pos)                 /*!< 0x02000000 */
+#define ADC_SQR2_SQ12_1           (0x02UL << ADC_SQR2_SQ12_Pos)                 /*!< 0x04000000 */
+#define ADC_SQR2_SQ12_2           (0x04UL << ADC_SQR2_SQ12_Pos)                 /*!< 0x08000000 */
+#define ADC_SQR2_SQ12_3           (0x08UL << ADC_SQR2_SQ12_Pos)                 /*!< 0x10000000 */
+#define ADC_SQR2_SQ12_4           (0x10UL << ADC_SQR2_SQ12_Pos)                 /*!< 0x20000000 */
+
+/*******************  Bit definition for ADC_SQR3 register  *******************/
+#define ADC_SQR3_SQ1_Pos          (0U)                                         
+#define ADC_SQR3_SQ1_Msk          (0x1FUL << ADC_SQR3_SQ1_Pos)                  /*!< 0x0000001F */
+#define ADC_SQR3_SQ1              ADC_SQR3_SQ1_Msk                             /*!<SQ1[4:0] bits (1st conversion in regular sequence) */
+#define ADC_SQR3_SQ1_0            (0x01UL << ADC_SQR3_SQ1_Pos)                  /*!< 0x00000001 */
+#define ADC_SQR3_SQ1_1            (0x02UL << ADC_SQR3_SQ1_Pos)                  /*!< 0x00000002 */
+#define ADC_SQR3_SQ1_2            (0x04UL << ADC_SQR3_SQ1_Pos)                  /*!< 0x00000004 */
+#define ADC_SQR3_SQ1_3            (0x08UL << ADC_SQR3_SQ1_Pos)                  /*!< 0x00000008 */
+#define ADC_SQR3_SQ1_4            (0x10UL << ADC_SQR3_SQ1_Pos)                  /*!< 0x00000010 */
+#define ADC_SQR3_SQ2_Pos          (5U)                                         
+#define ADC_SQR3_SQ2_Msk          (0x1FUL << ADC_SQR3_SQ2_Pos)                  /*!< 0x000003E0 */
+#define ADC_SQR3_SQ2              ADC_SQR3_SQ2_Msk                             /*!<SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define ADC_SQR3_SQ2_0            (0x01UL << ADC_SQR3_SQ2_Pos)                  /*!< 0x00000020 */
+#define ADC_SQR3_SQ2_1            (0x02UL << ADC_SQR3_SQ2_Pos)                  /*!< 0x00000040 */
+#define ADC_SQR3_SQ2_2            (0x04UL << ADC_SQR3_SQ2_Pos)                  /*!< 0x00000080 */
+#define ADC_SQR3_SQ2_3            (0x08UL << ADC_SQR3_SQ2_Pos)                  /*!< 0x00000100 */
+#define ADC_SQR3_SQ2_4            (0x10UL << ADC_SQR3_SQ2_Pos)                  /*!< 0x00000200 */
+#define ADC_SQR3_SQ3_Pos          (10U)                                        
+#define ADC_SQR3_SQ3_Msk          (0x1FUL << ADC_SQR3_SQ3_Pos)                  /*!< 0x00007C00 */
+#define ADC_SQR3_SQ3              ADC_SQR3_SQ3_Msk                             /*!<SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define ADC_SQR3_SQ3_0            (0x01UL << ADC_SQR3_SQ3_Pos)                  /*!< 0x00000400 */
+#define ADC_SQR3_SQ3_1            (0x02UL << ADC_SQR3_SQ3_Pos)                  /*!< 0x00000800 */
+#define ADC_SQR3_SQ3_2            (0x04UL << ADC_SQR3_SQ3_Pos)                  /*!< 0x00001000 */
+#define ADC_SQR3_SQ3_3            (0x08UL << ADC_SQR3_SQ3_Pos)                  /*!< 0x00002000 */
+#define ADC_SQR3_SQ3_4            (0x10UL << ADC_SQR3_SQ3_Pos)                  /*!< 0x00004000 */
+#define ADC_SQR3_SQ4_Pos          (15U)                                        
+#define ADC_SQR3_SQ4_Msk          (0x1FUL << ADC_SQR3_SQ4_Pos)                  /*!< 0x000F8000 */
+#define ADC_SQR3_SQ4              ADC_SQR3_SQ4_Msk                             /*!<SQ4[4:0] bits (4th conversion in regular sequence) */
+#define ADC_SQR3_SQ4_0            (0x01UL << ADC_SQR3_SQ4_Pos)                  /*!< 0x00008000 */
+#define ADC_SQR3_SQ4_1            (0x02UL << ADC_SQR3_SQ4_Pos)                  /*!< 0x00010000 */
+#define ADC_SQR3_SQ4_2            (0x04UL << ADC_SQR3_SQ4_Pos)                  /*!< 0x00020000 */
+#define ADC_SQR3_SQ4_3            (0x08UL << ADC_SQR3_SQ4_Pos)                  /*!< 0x00040000 */
+#define ADC_SQR3_SQ4_4            (0x10UL << ADC_SQR3_SQ4_Pos)                  /*!< 0x00080000 */
+#define ADC_SQR3_SQ5_Pos          (20U)                                        
+#define ADC_SQR3_SQ5_Msk          (0x1FUL << ADC_SQR3_SQ5_Pos)                  /*!< 0x01F00000 */
+#define ADC_SQR3_SQ5              ADC_SQR3_SQ5_Msk                             /*!<SQ5[4:0] bits (5th conversion in regular sequence) */
+#define ADC_SQR3_SQ5_0            (0x01UL << ADC_SQR3_SQ5_Pos)                  /*!< 0x00100000 */
+#define ADC_SQR3_SQ5_1            (0x02UL << ADC_SQR3_SQ5_Pos)                  /*!< 0x00200000 */
+#define ADC_SQR3_SQ5_2            (0x04UL << ADC_SQR3_SQ5_Pos)                  /*!< 0x00400000 */
+#define ADC_SQR3_SQ5_3            (0x08UL << ADC_SQR3_SQ5_Pos)                  /*!< 0x00800000 */
+#define ADC_SQR3_SQ5_4            (0x10UL << ADC_SQR3_SQ5_Pos)                  /*!< 0x01000000 */
+#define ADC_SQR3_SQ6_Pos          (25U)                                        
+#define ADC_SQR3_SQ6_Msk          (0x1FUL << ADC_SQR3_SQ6_Pos)                  /*!< 0x3E000000 */
+#define ADC_SQR3_SQ6              ADC_SQR3_SQ6_Msk                             /*!<SQ6[4:0] bits (6th conversion in regular sequence) */
+#define ADC_SQR3_SQ6_0            (0x01UL << ADC_SQR3_SQ6_Pos)                  /*!< 0x02000000 */
+#define ADC_SQR3_SQ6_1            (0x02UL << ADC_SQR3_SQ6_Pos)                  /*!< 0x04000000 */
+#define ADC_SQR3_SQ6_2            (0x04UL << ADC_SQR3_SQ6_Pos)                  /*!< 0x08000000 */
+#define ADC_SQR3_SQ6_3            (0x08UL << ADC_SQR3_SQ6_Pos)                  /*!< 0x10000000 */
+#define ADC_SQR3_SQ6_4            (0x10UL << ADC_SQR3_SQ6_Pos)                  /*!< 0x20000000 */
+
+/*******************  Bit definition for ADC_JSQR register  *******************/
+#define ADC_JSQR_JSQ1_Pos         (0U)                                         
+#define ADC_JSQR_JSQ1_Msk         (0x1FUL << ADC_JSQR_JSQ1_Pos)                 /*!< 0x0000001F */
+#define ADC_JSQR_JSQ1             ADC_JSQR_JSQ1_Msk                            /*!<JSQ1[4:0] bits (1st conversion in injected sequence) */  
+#define ADC_JSQR_JSQ1_0           (0x01UL << ADC_JSQR_JSQ1_Pos)                 /*!< 0x00000001 */
+#define ADC_JSQR_JSQ1_1           (0x02UL << ADC_JSQR_JSQ1_Pos)                 /*!< 0x00000002 */
+#define ADC_JSQR_JSQ1_2           (0x04UL << ADC_JSQR_JSQ1_Pos)                 /*!< 0x00000004 */
+#define ADC_JSQR_JSQ1_3           (0x08UL << ADC_JSQR_JSQ1_Pos)                 /*!< 0x00000008 */
+#define ADC_JSQR_JSQ1_4           (0x10UL << ADC_JSQR_JSQ1_Pos)                 /*!< 0x00000010 */
+#define ADC_JSQR_JSQ2_Pos         (5U)                                         
+#define ADC_JSQR_JSQ2_Msk         (0x1FUL << ADC_JSQR_JSQ2_Pos)                 /*!< 0x000003E0 */
+#define ADC_JSQR_JSQ2             ADC_JSQR_JSQ2_Msk                            /*!<JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define ADC_JSQR_JSQ2_0           (0x01UL << ADC_JSQR_JSQ2_Pos)                 /*!< 0x00000020 */
+#define ADC_JSQR_JSQ2_1           (0x02UL << ADC_JSQR_JSQ2_Pos)                 /*!< 0x00000040 */
+#define ADC_JSQR_JSQ2_2           (0x04UL << ADC_JSQR_JSQ2_Pos)                 /*!< 0x00000080 */
+#define ADC_JSQR_JSQ2_3           (0x08UL << ADC_JSQR_JSQ2_Pos)                 /*!< 0x00000100 */
+#define ADC_JSQR_JSQ2_4           (0x10UL << ADC_JSQR_JSQ2_Pos)                 /*!< 0x00000200 */
+#define ADC_JSQR_JSQ3_Pos         (10U)                                        
+#define ADC_JSQR_JSQ3_Msk         (0x1FUL << ADC_JSQR_JSQ3_Pos)                 /*!< 0x00007C00 */
+#define ADC_JSQR_JSQ3             ADC_JSQR_JSQ3_Msk                            /*!<JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define ADC_JSQR_JSQ3_0           (0x01UL << ADC_JSQR_JSQ3_Pos)                 /*!< 0x00000400 */
+#define ADC_JSQR_JSQ3_1           (0x02UL << ADC_JSQR_JSQ3_Pos)                 /*!< 0x00000800 */
+#define ADC_JSQR_JSQ3_2           (0x04UL << ADC_JSQR_JSQ3_Pos)                 /*!< 0x00001000 */
+#define ADC_JSQR_JSQ3_3           (0x08UL << ADC_JSQR_JSQ3_Pos)                 /*!< 0x00002000 */
+#define ADC_JSQR_JSQ3_4           (0x10UL << ADC_JSQR_JSQ3_Pos)                 /*!< 0x00004000 */
+#define ADC_JSQR_JSQ4_Pos         (15U)                                        
+#define ADC_JSQR_JSQ4_Msk         (0x1FUL << ADC_JSQR_JSQ4_Pos)                 /*!< 0x000F8000 */
+#define ADC_JSQR_JSQ4             ADC_JSQR_JSQ4_Msk                            /*!<JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define ADC_JSQR_JSQ4_0           (0x01UL << ADC_JSQR_JSQ4_Pos)                 /*!< 0x00008000 */
+#define ADC_JSQR_JSQ4_1           (0x02UL << ADC_JSQR_JSQ4_Pos)                 /*!< 0x00010000 */
+#define ADC_JSQR_JSQ4_2           (0x04UL << ADC_JSQR_JSQ4_Pos)                 /*!< 0x00020000 */
+#define ADC_JSQR_JSQ4_3           (0x08UL << ADC_JSQR_JSQ4_Pos)                 /*!< 0x00040000 */
+#define ADC_JSQR_JSQ4_4           (0x10UL << ADC_JSQR_JSQ4_Pos)                 /*!< 0x00080000 */
+#define ADC_JSQR_JL_Pos           (20U)                                        
+#define ADC_JSQR_JL_Msk           (0x3UL << ADC_JSQR_JL_Pos)                    /*!< 0x00300000 */
+#define ADC_JSQR_JL               ADC_JSQR_JL_Msk                              /*!<JL[1:0] bits (Injected Sequence length) */
+#define ADC_JSQR_JL_0             (0x1UL << ADC_JSQR_JL_Pos)                    /*!< 0x00100000 */
+#define ADC_JSQR_JL_1             (0x2UL << ADC_JSQR_JL_Pos)                    /*!< 0x00200000 */
+
+/*******************  Bit definition for ADC_JDR1 register  *******************/
+#define ADC_JDR1_JDATA_Pos        (0U)                                         
+#define ADC_JDR1_JDATA_Msk        (0xFFFFUL << ADC_JDR1_JDATA_Pos)              /*!< 0x0000FFFF */
+#define ADC_JDR1_JDATA            ADC_JDR1_JDATA_Msk                           /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR2 register  *******************/
+#define ADC_JDR2_JDATA_Pos        (0U)                                         
+#define ADC_JDR2_JDATA_Msk        (0xFFFFUL << ADC_JDR2_JDATA_Pos)              /*!< 0x0000FFFF */
+#define ADC_JDR2_JDATA            ADC_JDR2_JDATA_Msk                           /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR3 register  *******************/
+#define ADC_JDR3_JDATA_Pos        (0U)                                         
+#define ADC_JDR3_JDATA_Msk        (0xFFFFUL << ADC_JDR3_JDATA_Pos)              /*!< 0x0000FFFF */
+#define ADC_JDR3_JDATA            ADC_JDR3_JDATA_Msk                           /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR4 register  *******************/
+#define ADC_JDR4_JDATA_Pos        (0U)                                         
+#define ADC_JDR4_JDATA_Msk        (0xFFFFUL << ADC_JDR4_JDATA_Pos)              /*!< 0x0000FFFF */
+#define ADC_JDR4_JDATA            ADC_JDR4_JDATA_Msk                           /*!<Injected data */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos           (0U)                                         
+#define ADC_DR_DATA_Msk           (0xFFFFUL << ADC_DR_DATA_Pos)                 /*!< 0x0000FFFF */
+#define ADC_DR_DATA               ADC_DR_DATA_Msk                              /*!<Regular data */
+#define ADC_DR_ADC2DATA_Pos       (16U)                                        
+#define ADC_DR_ADC2DATA_Msk       (0xFFFFUL << ADC_DR_ADC2DATA_Pos)             /*!< 0xFFFF0000 */
+#define ADC_DR_ADC2DATA           ADC_DR_ADC2DATA_Msk                          /*!<ADC2 data */
+
+/*******************  Bit definition for ADC_CSR register  ********************/
+#define ADC_CSR_AWD1_Pos          (0U)                                         
+#define ADC_CSR_AWD1_Msk          (0x1UL << ADC_CSR_AWD1_Pos)                   /*!< 0x00000001 */
+#define ADC_CSR_AWD1              ADC_CSR_AWD1_Msk                             /*!<ADC1 Analog watchdog flag */
+#define ADC_CSR_EOC1_Pos          (1U)                                         
+#define ADC_CSR_EOC1_Msk          (0x1UL << ADC_CSR_EOC1_Pos)                   /*!< 0x00000002 */
+#define ADC_CSR_EOC1              ADC_CSR_EOC1_Msk                             /*!<ADC1 End of conversion */
+#define ADC_CSR_JEOC1_Pos         (2U)                                         
+#define ADC_CSR_JEOC1_Msk         (0x1UL << ADC_CSR_JEOC1_Pos)                  /*!< 0x00000004 */
+#define ADC_CSR_JEOC1             ADC_CSR_JEOC1_Msk                            /*!<ADC1 Injected channel end of conversion */
+#define ADC_CSR_JSTRT1_Pos        (3U)                                         
+#define ADC_CSR_JSTRT1_Msk        (0x1UL << ADC_CSR_JSTRT1_Pos)                 /*!< 0x00000008 */
+#define ADC_CSR_JSTRT1            ADC_CSR_JSTRT1_Msk                           /*!<ADC1 Injected channel Start flag */
+#define ADC_CSR_STRT1_Pos         (4U)                                         
+#define ADC_CSR_STRT1_Msk         (0x1UL << ADC_CSR_STRT1_Pos)                  /*!< 0x00000010 */
+#define ADC_CSR_STRT1             ADC_CSR_STRT1_Msk                            /*!<ADC1 Regular channel Start flag */
+#define ADC_CSR_OVR1_Pos          (5U)                                         
+#define ADC_CSR_OVR1_Msk          (0x1UL << ADC_CSR_OVR1_Pos)                   /*!< 0x00000020 */
+#define ADC_CSR_OVR1              ADC_CSR_OVR1_Msk                             /*!<ADC1 DMA overrun  flag */
+
+/* Legacy defines */
+#define  ADC_CSR_DOVR1                        ADC_CSR_OVR1
+
+/*******************  Bit definition for ADC_CCR register  ********************/
+#define ADC_CCR_MULTI_Pos         (0U)                                         
+#define ADC_CCR_MULTI_Msk         (0x1FUL << ADC_CCR_MULTI_Pos)                 /*!< 0x0000001F */
+#define ADC_CCR_MULTI             ADC_CCR_MULTI_Msk                            /*!<MULTI[4:0] bits (Multi-ADC mode selection) */  
+#define ADC_CCR_MULTI_0           (0x01UL << ADC_CCR_MULTI_Pos)                 /*!< 0x00000001 */
+#define ADC_CCR_MULTI_1           (0x02UL << ADC_CCR_MULTI_Pos)                 /*!< 0x00000002 */
+#define ADC_CCR_MULTI_2           (0x04UL << ADC_CCR_MULTI_Pos)                 /*!< 0x00000004 */
+#define ADC_CCR_MULTI_3           (0x08UL << ADC_CCR_MULTI_Pos)                 /*!< 0x00000008 */
+#define ADC_CCR_MULTI_4           (0x10UL << ADC_CCR_MULTI_Pos)                 /*!< 0x00000010 */
+#define ADC_CCR_DELAY_Pos         (8U)                                         
+#define ADC_CCR_DELAY_Msk         (0xFUL << ADC_CCR_DELAY_Pos)                  /*!< 0x00000F00 */
+#define ADC_CCR_DELAY             ADC_CCR_DELAY_Msk                            /*!<DELAY[3:0] bits (Delay between 2 sampling phases) */  
+#define ADC_CCR_DELAY_0           (0x1UL << ADC_CCR_DELAY_Pos)                  /*!< 0x00000100 */
+#define ADC_CCR_DELAY_1           (0x2UL << ADC_CCR_DELAY_Pos)                  /*!< 0x00000200 */
+#define ADC_CCR_DELAY_2           (0x4UL << ADC_CCR_DELAY_Pos)                  /*!< 0x00000400 */
+#define ADC_CCR_DELAY_3           (0x8UL << ADC_CCR_DELAY_Pos)                  /*!< 0x00000800 */
+#define ADC_CCR_DDS_Pos           (13U)                                        
+#define ADC_CCR_DDS_Msk           (0x1UL << ADC_CCR_DDS_Pos)                    /*!< 0x00002000 */
+#define ADC_CCR_DDS               ADC_CCR_DDS_Msk                              /*!<DMA disable selection (Multi-ADC mode) */
+#define ADC_CCR_DMA_Pos           (14U)                                        
+#define ADC_CCR_DMA_Msk           (0x3UL << ADC_CCR_DMA_Pos)                    /*!< 0x0000C000 */
+#define ADC_CCR_DMA               ADC_CCR_DMA_Msk                              /*!<DMA[1:0] bits (Direct Memory Access mode for multimode) */  
+#define ADC_CCR_DMA_0             (0x1UL << ADC_CCR_DMA_Pos)                    /*!< 0x00004000 */
+#define ADC_CCR_DMA_1             (0x2UL << ADC_CCR_DMA_Pos)                    /*!< 0x00008000 */
+#define ADC_CCR_ADCPRE_Pos        (16U)                                        
+#define ADC_CCR_ADCPRE_Msk        (0x3UL << ADC_CCR_ADCPRE_Pos)                 /*!< 0x00030000 */
+#define ADC_CCR_ADCPRE            ADC_CCR_ADCPRE_Msk                           /*!<ADCPRE[1:0] bits (ADC prescaler) */  
+#define ADC_CCR_ADCPRE_0          (0x1UL << ADC_CCR_ADCPRE_Pos)                 /*!< 0x00010000 */
+#define ADC_CCR_ADCPRE_1          (0x2UL << ADC_CCR_ADCPRE_Pos)                 /*!< 0x00020000 */
+#define ADC_CCR_VBATE_Pos         (22U)                                        
+#define ADC_CCR_VBATE_Msk         (0x1UL << ADC_CCR_VBATE_Pos)                  /*!< 0x00400000 */
+#define ADC_CCR_VBATE             ADC_CCR_VBATE_Msk                            /*!<VBAT Enable */
+#define ADC_CCR_TSVREFE_Pos       (23U)                                        
+#define ADC_CCR_TSVREFE_Msk       (0x1UL << ADC_CCR_TSVREFE_Pos)                /*!< 0x00800000 */
+#define ADC_CCR_TSVREFE           ADC_CCR_TSVREFE_Msk                          /*!<Temperature Sensor and VREFINT Enable */
+
+/*******************  Bit definition for ADC_CDR register  ********************/
+#define ADC_CDR_DATA1_Pos         (0U)                                         
+#define ADC_CDR_DATA1_Msk         (0xFFFFUL << ADC_CDR_DATA1_Pos)               /*!< 0x0000FFFF */
+#define ADC_CDR_DATA1             ADC_CDR_DATA1_Msk                            /*!<1st data of a pair of regular conversions */
+#define ADC_CDR_DATA2_Pos         (16U)                                        
+#define ADC_CDR_DATA2_Msk         (0xFFFFUL << ADC_CDR_DATA2_Pos)               /*!< 0xFFFF0000 */
+#define ADC_CDR_DATA2             ADC_CDR_DATA2_Msk                            /*!<2nd data of a pair of regular conversions */
+
+/* Legacy defines */
+#define ADC_CDR_RDATA_MST         ADC_CDR_DATA1
+#define ADC_CDR_RDATA_SLV         ADC_CDR_DATA2
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos       (0U)                                               
+#define CRC_DR_DR_Msk       (0xFFFFFFFFUL << CRC_DR_DR_Pos)                     /*!< 0xFFFFFFFF */
+#define CRC_DR_DR           CRC_DR_DR_Msk                                      /*!< Data register bits */
+
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos     (0U)                                               
+#define CRC_IDR_IDR_Msk     (0xFFUL << CRC_IDR_IDR_Pos)                         /*!< 0x000000FF */
+#define CRC_IDR_IDR         CRC_IDR_IDR_Msk                                    /*!< General-purpose 8-bit data register bits */
+
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos    (0U)                                               
+#define CRC_CR_RESET_Msk    (0x1UL << CRC_CR_RESET_Pos)                         /*!< 0x00000001 */
+#define CRC_CR_RESET        CRC_CR_RESET_Msk                                   /*!< RESET bit */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMA Controller                                 */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMA_SxCR register  *****************/
+#define DMA_SxCR_CHSEL_Pos       (25U)                                         
+#define DMA_SxCR_CHSEL_Msk       (0x7UL << DMA_SxCR_CHSEL_Pos)                  /*!< 0x0E000000 */
+#define DMA_SxCR_CHSEL           DMA_SxCR_CHSEL_Msk                            
+#define DMA_SxCR_CHSEL_0         0x02000000U                                   
+#define DMA_SxCR_CHSEL_1         0x04000000U                                   
+#define DMA_SxCR_CHSEL_2         0x08000000U                                   
+#define DMA_SxCR_MBURST_Pos      (23U)                                         
+#define DMA_SxCR_MBURST_Msk      (0x3UL << DMA_SxCR_MBURST_Pos)                 /*!< 0x01800000 */
+#define DMA_SxCR_MBURST          DMA_SxCR_MBURST_Msk                           
+#define DMA_SxCR_MBURST_0        (0x1UL << DMA_SxCR_MBURST_Pos)                 /*!< 0x00800000 */
+#define DMA_SxCR_MBURST_1        (0x2UL << DMA_SxCR_MBURST_Pos)                 /*!< 0x01000000 */
+#define DMA_SxCR_PBURST_Pos      (21U)                                         
+#define DMA_SxCR_PBURST_Msk      (0x3UL << DMA_SxCR_PBURST_Pos)                 /*!< 0x00600000 */
+#define DMA_SxCR_PBURST          DMA_SxCR_PBURST_Msk                           
+#define DMA_SxCR_PBURST_0        (0x1UL << DMA_SxCR_PBURST_Pos)                 /*!< 0x00200000 */
+#define DMA_SxCR_PBURST_1        (0x2UL << DMA_SxCR_PBURST_Pos)                 /*!< 0x00400000 */
+#define DMA_SxCR_CT_Pos          (19U)                                         
+#define DMA_SxCR_CT_Msk          (0x1UL << DMA_SxCR_CT_Pos)                     /*!< 0x00080000 */
+#define DMA_SxCR_CT              DMA_SxCR_CT_Msk                               
+#define DMA_SxCR_DBM_Pos         (18U)                                         
+#define DMA_SxCR_DBM_Msk         (0x1UL << DMA_SxCR_DBM_Pos)                    /*!< 0x00040000 */
+#define DMA_SxCR_DBM             DMA_SxCR_DBM_Msk                              
+#define DMA_SxCR_PL_Pos          (16U)                                         
+#define DMA_SxCR_PL_Msk          (0x3UL << DMA_SxCR_PL_Pos)                     /*!< 0x00030000 */
+#define DMA_SxCR_PL              DMA_SxCR_PL_Msk                               
+#define DMA_SxCR_PL_0            (0x1UL << DMA_SxCR_PL_Pos)                     /*!< 0x00010000 */
+#define DMA_SxCR_PL_1            (0x2UL << DMA_SxCR_PL_Pos)                     /*!< 0x00020000 */
+#define DMA_SxCR_PINCOS_Pos      (15U)                                         
+#define DMA_SxCR_PINCOS_Msk      (0x1UL << DMA_SxCR_PINCOS_Pos)                 /*!< 0x00008000 */
+#define DMA_SxCR_PINCOS          DMA_SxCR_PINCOS_Msk                           
+#define DMA_SxCR_MSIZE_Pos       (13U)                                         
+#define DMA_SxCR_MSIZE_Msk       (0x3UL << DMA_SxCR_MSIZE_Pos)                  /*!< 0x00006000 */
+#define DMA_SxCR_MSIZE           DMA_SxCR_MSIZE_Msk                            
+#define DMA_SxCR_MSIZE_0         (0x1UL << DMA_SxCR_MSIZE_Pos)                  /*!< 0x00002000 */
+#define DMA_SxCR_MSIZE_1         (0x2UL << DMA_SxCR_MSIZE_Pos)                  /*!< 0x00004000 */
+#define DMA_SxCR_PSIZE_Pos       (11U)                                         
+#define DMA_SxCR_PSIZE_Msk       (0x3UL << DMA_SxCR_PSIZE_Pos)                  /*!< 0x00001800 */
+#define DMA_SxCR_PSIZE           DMA_SxCR_PSIZE_Msk                            
+#define DMA_SxCR_PSIZE_0         (0x1UL << DMA_SxCR_PSIZE_Pos)                  /*!< 0x00000800 */
+#define DMA_SxCR_PSIZE_1         (0x2UL << DMA_SxCR_PSIZE_Pos)                  /*!< 0x00001000 */
+#define DMA_SxCR_MINC_Pos        (10U)                                         
+#define DMA_SxCR_MINC_Msk        (0x1UL << DMA_SxCR_MINC_Pos)                   /*!< 0x00000400 */
+#define DMA_SxCR_MINC            DMA_SxCR_MINC_Msk                             
+#define DMA_SxCR_PINC_Pos        (9U)                                          
+#define DMA_SxCR_PINC_Msk        (0x1UL << DMA_SxCR_PINC_Pos)                   /*!< 0x00000200 */
+#define DMA_SxCR_PINC            DMA_SxCR_PINC_Msk                             
+#define DMA_SxCR_CIRC_Pos        (8U)                                          
+#define DMA_SxCR_CIRC_Msk        (0x1UL << DMA_SxCR_CIRC_Pos)                   /*!< 0x00000100 */
+#define DMA_SxCR_CIRC            DMA_SxCR_CIRC_Msk                             
+#define DMA_SxCR_DIR_Pos         (6U)                                          
+#define DMA_SxCR_DIR_Msk         (0x3UL << DMA_SxCR_DIR_Pos)                    /*!< 0x000000C0 */
+#define DMA_SxCR_DIR             DMA_SxCR_DIR_Msk                              
+#define DMA_SxCR_DIR_0           (0x1UL << DMA_SxCR_DIR_Pos)                    /*!< 0x00000040 */
+#define DMA_SxCR_DIR_1           (0x2UL << DMA_SxCR_DIR_Pos)                    /*!< 0x00000080 */
+#define DMA_SxCR_PFCTRL_Pos      (5U)                                          
+#define DMA_SxCR_PFCTRL_Msk      (0x1UL << DMA_SxCR_PFCTRL_Pos)                 /*!< 0x00000020 */
+#define DMA_SxCR_PFCTRL          DMA_SxCR_PFCTRL_Msk                           
+#define DMA_SxCR_TCIE_Pos        (4U)                                          
+#define DMA_SxCR_TCIE_Msk        (0x1UL << DMA_SxCR_TCIE_Pos)                   /*!< 0x00000010 */
+#define DMA_SxCR_TCIE            DMA_SxCR_TCIE_Msk                             
+#define DMA_SxCR_HTIE_Pos        (3U)                                          
+#define DMA_SxCR_HTIE_Msk        (0x1UL << DMA_SxCR_HTIE_Pos)                   /*!< 0x00000008 */
+#define DMA_SxCR_HTIE            DMA_SxCR_HTIE_Msk                             
+#define DMA_SxCR_TEIE_Pos        (2U)                                          
+#define DMA_SxCR_TEIE_Msk        (0x1UL << DMA_SxCR_TEIE_Pos)                   /*!< 0x00000004 */
+#define DMA_SxCR_TEIE            DMA_SxCR_TEIE_Msk                             
+#define DMA_SxCR_DMEIE_Pos       (1U)                                          
+#define DMA_SxCR_DMEIE_Msk       (0x1UL << DMA_SxCR_DMEIE_Pos)                  /*!< 0x00000002 */
+#define DMA_SxCR_DMEIE           DMA_SxCR_DMEIE_Msk                            
+#define DMA_SxCR_EN_Pos          (0U)                                          
+#define DMA_SxCR_EN_Msk          (0x1UL << DMA_SxCR_EN_Pos)                     /*!< 0x00000001 */
+#define DMA_SxCR_EN              DMA_SxCR_EN_Msk                               
+
+/* Legacy defines */
+#define DMA_SxCR_ACK_Pos         (20U)                                         
+#define DMA_SxCR_ACK_Msk         (0x1UL << DMA_SxCR_ACK_Pos)                    /*!< 0x00100000 */
+#define DMA_SxCR_ACK             DMA_SxCR_ACK_Msk                              
+
+/********************  Bits definition for DMA_SxCNDTR register  **************/
+#define DMA_SxNDT_Pos            (0U)                                          
+#define DMA_SxNDT_Msk            (0xFFFFUL << DMA_SxNDT_Pos)                    /*!< 0x0000FFFF */
+#define DMA_SxNDT                DMA_SxNDT_Msk                                 
+#define DMA_SxNDT_0              (0x0001UL << DMA_SxNDT_Pos)                    /*!< 0x00000001 */
+#define DMA_SxNDT_1              (0x0002UL << DMA_SxNDT_Pos)                    /*!< 0x00000002 */
+#define DMA_SxNDT_2              (0x0004UL << DMA_SxNDT_Pos)                    /*!< 0x00000004 */
+#define DMA_SxNDT_3              (0x0008UL << DMA_SxNDT_Pos)                    /*!< 0x00000008 */
+#define DMA_SxNDT_4              (0x0010UL << DMA_SxNDT_Pos)                    /*!< 0x00000010 */
+#define DMA_SxNDT_5              (0x0020UL << DMA_SxNDT_Pos)                    /*!< 0x00000020 */
+#define DMA_SxNDT_6              (0x0040UL << DMA_SxNDT_Pos)                    /*!< 0x00000040 */
+#define DMA_SxNDT_7              (0x0080UL << DMA_SxNDT_Pos)                    /*!< 0x00000080 */
+#define DMA_SxNDT_8              (0x0100UL << DMA_SxNDT_Pos)                    /*!< 0x00000100 */
+#define DMA_SxNDT_9              (0x0200UL << DMA_SxNDT_Pos)                    /*!< 0x00000200 */
+#define DMA_SxNDT_10             (0x0400UL << DMA_SxNDT_Pos)                    /*!< 0x00000400 */
+#define DMA_SxNDT_11             (0x0800UL << DMA_SxNDT_Pos)                    /*!< 0x00000800 */
+#define DMA_SxNDT_12             (0x1000UL << DMA_SxNDT_Pos)                    /*!< 0x00001000 */
+#define DMA_SxNDT_13             (0x2000UL << DMA_SxNDT_Pos)                    /*!< 0x00002000 */
+#define DMA_SxNDT_14             (0x4000UL << DMA_SxNDT_Pos)                    /*!< 0x00004000 */
+#define DMA_SxNDT_15             (0x8000UL << DMA_SxNDT_Pos)                    /*!< 0x00008000 */
+
+/********************  Bits definition for DMA_SxFCR register  ****************/ 
+#define DMA_SxFCR_FEIE_Pos       (7U)                                          
+#define DMA_SxFCR_FEIE_Msk       (0x1UL << DMA_SxFCR_FEIE_Pos)                  /*!< 0x00000080 */
+#define DMA_SxFCR_FEIE           DMA_SxFCR_FEIE_Msk                            
+#define DMA_SxFCR_FS_Pos         (3U)                                          
+#define DMA_SxFCR_FS_Msk         (0x7UL << DMA_SxFCR_FS_Pos)                    /*!< 0x00000038 */
+#define DMA_SxFCR_FS             DMA_SxFCR_FS_Msk                              
+#define DMA_SxFCR_FS_0           (0x1UL << DMA_SxFCR_FS_Pos)                    /*!< 0x00000008 */
+#define DMA_SxFCR_FS_1           (0x2UL << DMA_SxFCR_FS_Pos)                    /*!< 0x00000010 */
+#define DMA_SxFCR_FS_2           (0x4UL << DMA_SxFCR_FS_Pos)                    /*!< 0x00000020 */
+#define DMA_SxFCR_DMDIS_Pos      (2U)                                          
+#define DMA_SxFCR_DMDIS_Msk      (0x1UL << DMA_SxFCR_DMDIS_Pos)                 /*!< 0x00000004 */
+#define DMA_SxFCR_DMDIS          DMA_SxFCR_DMDIS_Msk                           
+#define DMA_SxFCR_FTH_Pos        (0U)                                          
+#define DMA_SxFCR_FTH_Msk        (0x3UL << DMA_SxFCR_FTH_Pos)                   /*!< 0x00000003 */
+#define DMA_SxFCR_FTH            DMA_SxFCR_FTH_Msk                             
+#define DMA_SxFCR_FTH_0          (0x1UL << DMA_SxFCR_FTH_Pos)                   /*!< 0x00000001 */
+#define DMA_SxFCR_FTH_1          (0x2UL << DMA_SxFCR_FTH_Pos)                   /*!< 0x00000002 */
+
+/********************  Bits definition for DMA_LISR register  *****************/ 
+#define DMA_LISR_TCIF3_Pos       (27U)                                         
+#define DMA_LISR_TCIF3_Msk       (0x1UL << DMA_LISR_TCIF3_Pos)                  /*!< 0x08000000 */
+#define DMA_LISR_TCIF3           DMA_LISR_TCIF3_Msk                            
+#define DMA_LISR_HTIF3_Pos       (26U)                                         
+#define DMA_LISR_HTIF3_Msk       (0x1UL << DMA_LISR_HTIF3_Pos)                  /*!< 0x04000000 */
+#define DMA_LISR_HTIF3           DMA_LISR_HTIF3_Msk                            
+#define DMA_LISR_TEIF3_Pos       (25U)                                         
+#define DMA_LISR_TEIF3_Msk       (0x1UL << DMA_LISR_TEIF3_Pos)                  /*!< 0x02000000 */
+#define DMA_LISR_TEIF3           DMA_LISR_TEIF3_Msk                            
+#define DMA_LISR_DMEIF3_Pos      (24U)                                         
+#define DMA_LISR_DMEIF3_Msk      (0x1UL << DMA_LISR_DMEIF3_Pos)                 /*!< 0x01000000 */
+#define DMA_LISR_DMEIF3          DMA_LISR_DMEIF3_Msk                           
+#define DMA_LISR_FEIF3_Pos       (22U)                                         
+#define DMA_LISR_FEIF3_Msk       (0x1UL << DMA_LISR_FEIF3_Pos)                  /*!< 0x00400000 */
+#define DMA_LISR_FEIF3           DMA_LISR_FEIF3_Msk                            
+#define DMA_LISR_TCIF2_Pos       (21U)                                         
+#define DMA_LISR_TCIF2_Msk       (0x1UL << DMA_LISR_TCIF2_Pos)                  /*!< 0x00200000 */
+#define DMA_LISR_TCIF2           DMA_LISR_TCIF2_Msk                            
+#define DMA_LISR_HTIF2_Pos       (20U)                                         
+#define DMA_LISR_HTIF2_Msk       (0x1UL << DMA_LISR_HTIF2_Pos)                  /*!< 0x00100000 */
+#define DMA_LISR_HTIF2           DMA_LISR_HTIF2_Msk                            
+#define DMA_LISR_TEIF2_Pos       (19U)                                         
+#define DMA_LISR_TEIF2_Msk       (0x1UL << DMA_LISR_TEIF2_Pos)                  /*!< 0x00080000 */
+#define DMA_LISR_TEIF2           DMA_LISR_TEIF2_Msk                            
+#define DMA_LISR_DMEIF2_Pos      (18U)                                         
+#define DMA_LISR_DMEIF2_Msk      (0x1UL << DMA_LISR_DMEIF2_Pos)                 /*!< 0x00040000 */
+#define DMA_LISR_DMEIF2          DMA_LISR_DMEIF2_Msk                           
+#define DMA_LISR_FEIF2_Pos       (16U)                                         
+#define DMA_LISR_FEIF2_Msk       (0x1UL << DMA_LISR_FEIF2_Pos)                  /*!< 0x00010000 */
+#define DMA_LISR_FEIF2           DMA_LISR_FEIF2_Msk                            
+#define DMA_LISR_TCIF1_Pos       (11U)                                         
+#define DMA_LISR_TCIF1_Msk       (0x1UL << DMA_LISR_TCIF1_Pos)                  /*!< 0x00000800 */
+#define DMA_LISR_TCIF1           DMA_LISR_TCIF1_Msk                            
+#define DMA_LISR_HTIF1_Pos       (10U)                                         
+#define DMA_LISR_HTIF1_Msk       (0x1UL << DMA_LISR_HTIF1_Pos)                  /*!< 0x00000400 */
+#define DMA_LISR_HTIF1           DMA_LISR_HTIF1_Msk                            
+#define DMA_LISR_TEIF1_Pos       (9U)                                          
+#define DMA_LISR_TEIF1_Msk       (0x1UL << DMA_LISR_TEIF1_Pos)                  /*!< 0x00000200 */
+#define DMA_LISR_TEIF1           DMA_LISR_TEIF1_Msk                            
+#define DMA_LISR_DMEIF1_Pos      (8U)                                          
+#define DMA_LISR_DMEIF1_Msk      (0x1UL << DMA_LISR_DMEIF1_Pos)                 /*!< 0x00000100 */
+#define DMA_LISR_DMEIF1          DMA_LISR_DMEIF1_Msk                           
+#define DMA_LISR_FEIF1_Pos       (6U)                                          
+#define DMA_LISR_FEIF1_Msk       (0x1UL << DMA_LISR_FEIF1_Pos)                  /*!< 0x00000040 */
+#define DMA_LISR_FEIF1           DMA_LISR_FEIF1_Msk                            
+#define DMA_LISR_TCIF0_Pos       (5U)                                          
+#define DMA_LISR_TCIF0_Msk       (0x1UL << DMA_LISR_TCIF0_Pos)                  /*!< 0x00000020 */
+#define DMA_LISR_TCIF0           DMA_LISR_TCIF0_Msk                            
+#define DMA_LISR_HTIF0_Pos       (4U)                                          
+#define DMA_LISR_HTIF0_Msk       (0x1UL << DMA_LISR_HTIF0_Pos)                  /*!< 0x00000010 */
+#define DMA_LISR_HTIF0           DMA_LISR_HTIF0_Msk                            
+#define DMA_LISR_TEIF0_Pos       (3U)                                          
+#define DMA_LISR_TEIF0_Msk       (0x1UL << DMA_LISR_TEIF0_Pos)                  /*!< 0x00000008 */
+#define DMA_LISR_TEIF0           DMA_LISR_TEIF0_Msk                            
+#define DMA_LISR_DMEIF0_Pos      (2U)                                          
+#define DMA_LISR_DMEIF0_Msk      (0x1UL << DMA_LISR_DMEIF0_Pos)                 /*!< 0x00000004 */
+#define DMA_LISR_DMEIF0          DMA_LISR_DMEIF0_Msk                           
+#define DMA_LISR_FEIF0_Pos       (0U)                                          
+#define DMA_LISR_FEIF0_Msk       (0x1UL << DMA_LISR_FEIF0_Pos)                  /*!< 0x00000001 */
+#define DMA_LISR_FEIF0           DMA_LISR_FEIF0_Msk                            
+
+/********************  Bits definition for DMA_HISR register  *****************/ 
+#define DMA_HISR_TCIF7_Pos       (27U)                                         
+#define DMA_HISR_TCIF7_Msk       (0x1UL << DMA_HISR_TCIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_HISR_TCIF7           DMA_HISR_TCIF7_Msk                            
+#define DMA_HISR_HTIF7_Pos       (26U)                                         
+#define DMA_HISR_HTIF7_Msk       (0x1UL << DMA_HISR_HTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_HISR_HTIF7           DMA_HISR_HTIF7_Msk                            
+#define DMA_HISR_TEIF7_Pos       (25U)                                         
+#define DMA_HISR_TEIF7_Msk       (0x1UL << DMA_HISR_TEIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_HISR_TEIF7           DMA_HISR_TEIF7_Msk                            
+#define DMA_HISR_DMEIF7_Pos      (24U)                                         
+#define DMA_HISR_DMEIF7_Msk      (0x1UL << DMA_HISR_DMEIF7_Pos)                 /*!< 0x01000000 */
+#define DMA_HISR_DMEIF7          DMA_HISR_DMEIF7_Msk                           
+#define DMA_HISR_FEIF7_Pos       (22U)                                         
+#define DMA_HISR_FEIF7_Msk       (0x1UL << DMA_HISR_FEIF7_Pos)                  /*!< 0x00400000 */
+#define DMA_HISR_FEIF7           DMA_HISR_FEIF7_Msk                            
+#define DMA_HISR_TCIF6_Pos       (21U)                                         
+#define DMA_HISR_TCIF6_Msk       (0x1UL << DMA_HISR_TCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_HISR_TCIF6           DMA_HISR_TCIF6_Msk                            
+#define DMA_HISR_HTIF6_Pos       (20U)                                         
+#define DMA_HISR_HTIF6_Msk       (0x1UL << DMA_HISR_HTIF6_Pos)                  /*!< 0x00100000 */
+#define DMA_HISR_HTIF6           DMA_HISR_HTIF6_Msk                            
+#define DMA_HISR_TEIF6_Pos       (19U)                                         
+#define DMA_HISR_TEIF6_Msk       (0x1UL << DMA_HISR_TEIF6_Pos)                  /*!< 0x00080000 */
+#define DMA_HISR_TEIF6           DMA_HISR_TEIF6_Msk                            
+#define DMA_HISR_DMEIF6_Pos      (18U)                                         
+#define DMA_HISR_DMEIF6_Msk      (0x1UL << DMA_HISR_DMEIF6_Pos)                 /*!< 0x00040000 */
+#define DMA_HISR_DMEIF6          DMA_HISR_DMEIF6_Msk                           
+#define DMA_HISR_FEIF6_Pos       (16U)                                         
+#define DMA_HISR_FEIF6_Msk       (0x1UL << DMA_HISR_FEIF6_Pos)                  /*!< 0x00010000 */
+#define DMA_HISR_FEIF6           DMA_HISR_FEIF6_Msk                            
+#define DMA_HISR_TCIF5_Pos       (11U)                                         
+#define DMA_HISR_TCIF5_Msk       (0x1UL << DMA_HISR_TCIF5_Pos)                  /*!< 0x00000800 */
+#define DMA_HISR_TCIF5           DMA_HISR_TCIF5_Msk                            
+#define DMA_HISR_HTIF5_Pos       (10U)                                         
+#define DMA_HISR_HTIF5_Msk       (0x1UL << DMA_HISR_HTIF5_Pos)                  /*!< 0x00000400 */
+#define DMA_HISR_HTIF5           DMA_HISR_HTIF5_Msk                            
+#define DMA_HISR_TEIF5_Pos       (9U)                                          
+#define DMA_HISR_TEIF5_Msk       (0x1UL << DMA_HISR_TEIF5_Pos)                  /*!< 0x00000200 */
+#define DMA_HISR_TEIF5           DMA_HISR_TEIF5_Msk                            
+#define DMA_HISR_DMEIF5_Pos      (8U)                                          
+#define DMA_HISR_DMEIF5_Msk      (0x1UL << DMA_HISR_DMEIF5_Pos)                 /*!< 0x00000100 */
+#define DMA_HISR_DMEIF5          DMA_HISR_DMEIF5_Msk                           
+#define DMA_HISR_FEIF5_Pos       (6U)                                          
+#define DMA_HISR_FEIF5_Msk       (0x1UL << DMA_HISR_FEIF5_Pos)                  /*!< 0x00000040 */
+#define DMA_HISR_FEIF5           DMA_HISR_FEIF5_Msk                            
+#define DMA_HISR_TCIF4_Pos       (5U)                                          
+#define DMA_HISR_TCIF4_Msk       (0x1UL << DMA_HISR_TCIF4_Pos)                  /*!< 0x00000020 */
+#define DMA_HISR_TCIF4           DMA_HISR_TCIF4_Msk                            
+#define DMA_HISR_HTIF4_Pos       (4U)                                          
+#define DMA_HISR_HTIF4_Msk       (0x1UL << DMA_HISR_HTIF4_Pos)                  /*!< 0x00000010 */
+#define DMA_HISR_HTIF4           DMA_HISR_HTIF4_Msk                            
+#define DMA_HISR_TEIF4_Pos       (3U)                                          
+#define DMA_HISR_TEIF4_Msk       (0x1UL << DMA_HISR_TEIF4_Pos)                  /*!< 0x00000008 */
+#define DMA_HISR_TEIF4           DMA_HISR_TEIF4_Msk                            
+#define DMA_HISR_DMEIF4_Pos      (2U)                                          
+#define DMA_HISR_DMEIF4_Msk      (0x1UL << DMA_HISR_DMEIF4_Pos)                 /*!< 0x00000004 */
+#define DMA_HISR_DMEIF4          DMA_HISR_DMEIF4_Msk                           
+#define DMA_HISR_FEIF4_Pos       (0U)                                          
+#define DMA_HISR_FEIF4_Msk       (0x1UL << DMA_HISR_FEIF4_Pos)                  /*!< 0x00000001 */
+#define DMA_HISR_FEIF4           DMA_HISR_FEIF4_Msk                            
+
+/********************  Bits definition for DMA_LIFCR register  ****************/ 
+#define DMA_LIFCR_CTCIF3_Pos     (27U)                                         
+#define DMA_LIFCR_CTCIF3_Msk     (0x1UL << DMA_LIFCR_CTCIF3_Pos)                /*!< 0x08000000 */
+#define DMA_LIFCR_CTCIF3         DMA_LIFCR_CTCIF3_Msk                          
+#define DMA_LIFCR_CHTIF3_Pos     (26U)                                         
+#define DMA_LIFCR_CHTIF3_Msk     (0x1UL << DMA_LIFCR_CHTIF3_Pos)                /*!< 0x04000000 */
+#define DMA_LIFCR_CHTIF3         DMA_LIFCR_CHTIF3_Msk                          
+#define DMA_LIFCR_CTEIF3_Pos     (25U)                                         
+#define DMA_LIFCR_CTEIF3_Msk     (0x1UL << DMA_LIFCR_CTEIF3_Pos)                /*!< 0x02000000 */
+#define DMA_LIFCR_CTEIF3         DMA_LIFCR_CTEIF3_Msk                          
+#define DMA_LIFCR_CDMEIF3_Pos    (24U)                                         
+#define DMA_LIFCR_CDMEIF3_Msk    (0x1UL << DMA_LIFCR_CDMEIF3_Pos)               /*!< 0x01000000 */
+#define DMA_LIFCR_CDMEIF3        DMA_LIFCR_CDMEIF3_Msk                         
+#define DMA_LIFCR_CFEIF3_Pos     (22U)                                         
+#define DMA_LIFCR_CFEIF3_Msk     (0x1UL << DMA_LIFCR_CFEIF3_Pos)                /*!< 0x00400000 */
+#define DMA_LIFCR_CFEIF3         DMA_LIFCR_CFEIF3_Msk                          
+#define DMA_LIFCR_CTCIF2_Pos     (21U)                                         
+#define DMA_LIFCR_CTCIF2_Msk     (0x1UL << DMA_LIFCR_CTCIF2_Pos)                /*!< 0x00200000 */
+#define DMA_LIFCR_CTCIF2         DMA_LIFCR_CTCIF2_Msk                          
+#define DMA_LIFCR_CHTIF2_Pos     (20U)                                         
+#define DMA_LIFCR_CHTIF2_Msk     (0x1UL << DMA_LIFCR_CHTIF2_Pos)                /*!< 0x00100000 */
+#define DMA_LIFCR_CHTIF2         DMA_LIFCR_CHTIF2_Msk                          
+#define DMA_LIFCR_CTEIF2_Pos     (19U)                                         
+#define DMA_LIFCR_CTEIF2_Msk     (0x1UL << DMA_LIFCR_CTEIF2_Pos)                /*!< 0x00080000 */
+#define DMA_LIFCR_CTEIF2         DMA_LIFCR_CTEIF2_Msk                          
+#define DMA_LIFCR_CDMEIF2_Pos    (18U)                                         
+#define DMA_LIFCR_CDMEIF2_Msk    (0x1UL << DMA_LIFCR_CDMEIF2_Pos)               /*!< 0x00040000 */
+#define DMA_LIFCR_CDMEIF2        DMA_LIFCR_CDMEIF2_Msk                         
+#define DMA_LIFCR_CFEIF2_Pos     (16U)                                         
+#define DMA_LIFCR_CFEIF2_Msk     (0x1UL << DMA_LIFCR_CFEIF2_Pos)                /*!< 0x00010000 */
+#define DMA_LIFCR_CFEIF2         DMA_LIFCR_CFEIF2_Msk                          
+#define DMA_LIFCR_CTCIF1_Pos     (11U)                                         
+#define DMA_LIFCR_CTCIF1_Msk     (0x1UL << DMA_LIFCR_CTCIF1_Pos)                /*!< 0x00000800 */
+#define DMA_LIFCR_CTCIF1         DMA_LIFCR_CTCIF1_Msk                          
+#define DMA_LIFCR_CHTIF1_Pos     (10U)                                         
+#define DMA_LIFCR_CHTIF1_Msk     (0x1UL << DMA_LIFCR_CHTIF1_Pos)                /*!< 0x00000400 */
+#define DMA_LIFCR_CHTIF1         DMA_LIFCR_CHTIF1_Msk                          
+#define DMA_LIFCR_CTEIF1_Pos     (9U)                                          
+#define DMA_LIFCR_CTEIF1_Msk     (0x1UL << DMA_LIFCR_CTEIF1_Pos)                /*!< 0x00000200 */
+#define DMA_LIFCR_CTEIF1         DMA_LIFCR_CTEIF1_Msk                          
+#define DMA_LIFCR_CDMEIF1_Pos    (8U)                                          
+#define DMA_LIFCR_CDMEIF1_Msk    (0x1UL << DMA_LIFCR_CDMEIF1_Pos)               /*!< 0x00000100 */
+#define DMA_LIFCR_CDMEIF1        DMA_LIFCR_CDMEIF1_Msk                         
+#define DMA_LIFCR_CFEIF1_Pos     (6U)                                          
+#define DMA_LIFCR_CFEIF1_Msk     (0x1UL << DMA_LIFCR_CFEIF1_Pos)                /*!< 0x00000040 */
+#define DMA_LIFCR_CFEIF1         DMA_LIFCR_CFEIF1_Msk                          
+#define DMA_LIFCR_CTCIF0_Pos     (5U)                                          
+#define DMA_LIFCR_CTCIF0_Msk     (0x1UL << DMA_LIFCR_CTCIF0_Pos)                /*!< 0x00000020 */
+#define DMA_LIFCR_CTCIF0         DMA_LIFCR_CTCIF0_Msk                          
+#define DMA_LIFCR_CHTIF0_Pos     (4U)                                          
+#define DMA_LIFCR_CHTIF0_Msk     (0x1UL << DMA_LIFCR_CHTIF0_Pos)                /*!< 0x00000010 */
+#define DMA_LIFCR_CHTIF0         DMA_LIFCR_CHTIF0_Msk                          
+#define DMA_LIFCR_CTEIF0_Pos     (3U)                                          
+#define DMA_LIFCR_CTEIF0_Msk     (0x1UL << DMA_LIFCR_CTEIF0_Pos)                /*!< 0x00000008 */
+#define DMA_LIFCR_CTEIF0         DMA_LIFCR_CTEIF0_Msk                          
+#define DMA_LIFCR_CDMEIF0_Pos    (2U)                                          
+#define DMA_LIFCR_CDMEIF0_Msk    (0x1UL << DMA_LIFCR_CDMEIF0_Pos)               /*!< 0x00000004 */
+#define DMA_LIFCR_CDMEIF0        DMA_LIFCR_CDMEIF0_Msk                         
+#define DMA_LIFCR_CFEIF0_Pos     (0U)                                          
+#define DMA_LIFCR_CFEIF0_Msk     (0x1UL << DMA_LIFCR_CFEIF0_Pos)                /*!< 0x00000001 */
+#define DMA_LIFCR_CFEIF0         DMA_LIFCR_CFEIF0_Msk                          
+
+/********************  Bits definition for DMA_HIFCR  register  ****************/ 
+#define DMA_HIFCR_CTCIF7_Pos     (27U)                                         
+#define DMA_HIFCR_CTCIF7_Msk     (0x1UL << DMA_HIFCR_CTCIF7_Pos)                /*!< 0x08000000 */
+#define DMA_HIFCR_CTCIF7         DMA_HIFCR_CTCIF7_Msk                          
+#define DMA_HIFCR_CHTIF7_Pos     (26U)                                         
+#define DMA_HIFCR_CHTIF7_Msk     (0x1UL << DMA_HIFCR_CHTIF7_Pos)                /*!< 0x04000000 */
+#define DMA_HIFCR_CHTIF7         DMA_HIFCR_CHTIF7_Msk                          
+#define DMA_HIFCR_CTEIF7_Pos     (25U)                                         
+#define DMA_HIFCR_CTEIF7_Msk     (0x1UL << DMA_HIFCR_CTEIF7_Pos)                /*!< 0x02000000 */
+#define DMA_HIFCR_CTEIF7         DMA_HIFCR_CTEIF7_Msk                          
+#define DMA_HIFCR_CDMEIF7_Pos    (24U)                                         
+#define DMA_HIFCR_CDMEIF7_Msk    (0x1UL << DMA_HIFCR_CDMEIF7_Pos)               /*!< 0x01000000 */
+#define DMA_HIFCR_CDMEIF7        DMA_HIFCR_CDMEIF7_Msk                         
+#define DMA_HIFCR_CFEIF7_Pos     (22U)                                         
+#define DMA_HIFCR_CFEIF7_Msk     (0x1UL << DMA_HIFCR_CFEIF7_Pos)                /*!< 0x00400000 */
+#define DMA_HIFCR_CFEIF7         DMA_HIFCR_CFEIF7_Msk                          
+#define DMA_HIFCR_CTCIF6_Pos     (21U)                                         
+#define DMA_HIFCR_CTCIF6_Msk     (0x1UL << DMA_HIFCR_CTCIF6_Pos)                /*!< 0x00200000 */
+#define DMA_HIFCR_CTCIF6         DMA_HIFCR_CTCIF6_Msk                          
+#define DMA_HIFCR_CHTIF6_Pos     (20U)                                         
+#define DMA_HIFCR_CHTIF6_Msk     (0x1UL << DMA_HIFCR_CHTIF6_Pos)                /*!< 0x00100000 */
+#define DMA_HIFCR_CHTIF6         DMA_HIFCR_CHTIF6_Msk                          
+#define DMA_HIFCR_CTEIF6_Pos     (19U)                                         
+#define DMA_HIFCR_CTEIF6_Msk     (0x1UL << DMA_HIFCR_CTEIF6_Pos)                /*!< 0x00080000 */
+#define DMA_HIFCR_CTEIF6         DMA_HIFCR_CTEIF6_Msk                          
+#define DMA_HIFCR_CDMEIF6_Pos    (18U)                                         
+#define DMA_HIFCR_CDMEIF6_Msk    (0x1UL << DMA_HIFCR_CDMEIF6_Pos)               /*!< 0x00040000 */
+#define DMA_HIFCR_CDMEIF6        DMA_HIFCR_CDMEIF6_Msk                         
+#define DMA_HIFCR_CFEIF6_Pos     (16U)                                         
+#define DMA_HIFCR_CFEIF6_Msk     (0x1UL << DMA_HIFCR_CFEIF6_Pos)                /*!< 0x00010000 */
+#define DMA_HIFCR_CFEIF6         DMA_HIFCR_CFEIF6_Msk                          
+#define DMA_HIFCR_CTCIF5_Pos     (11U)                                         
+#define DMA_HIFCR_CTCIF5_Msk     (0x1UL << DMA_HIFCR_CTCIF5_Pos)                /*!< 0x00000800 */
+#define DMA_HIFCR_CTCIF5         DMA_HIFCR_CTCIF5_Msk                          
+#define DMA_HIFCR_CHTIF5_Pos     (10U)                                         
+#define DMA_HIFCR_CHTIF5_Msk     (0x1UL << DMA_HIFCR_CHTIF5_Pos)                /*!< 0x00000400 */
+#define DMA_HIFCR_CHTIF5         DMA_HIFCR_CHTIF5_Msk                          
+#define DMA_HIFCR_CTEIF5_Pos     (9U)                                          
+#define DMA_HIFCR_CTEIF5_Msk     (0x1UL << DMA_HIFCR_CTEIF5_Pos)                /*!< 0x00000200 */
+#define DMA_HIFCR_CTEIF5         DMA_HIFCR_CTEIF5_Msk                          
+#define DMA_HIFCR_CDMEIF5_Pos    (8U)                                          
+#define DMA_HIFCR_CDMEIF5_Msk    (0x1UL << DMA_HIFCR_CDMEIF5_Pos)               /*!< 0x00000100 */
+#define DMA_HIFCR_CDMEIF5        DMA_HIFCR_CDMEIF5_Msk                         
+#define DMA_HIFCR_CFEIF5_Pos     (6U)                                          
+#define DMA_HIFCR_CFEIF5_Msk     (0x1UL << DMA_HIFCR_CFEIF5_Pos)                /*!< 0x00000040 */
+#define DMA_HIFCR_CFEIF5         DMA_HIFCR_CFEIF5_Msk                          
+#define DMA_HIFCR_CTCIF4_Pos     (5U)                                          
+#define DMA_HIFCR_CTCIF4_Msk     (0x1UL << DMA_HIFCR_CTCIF4_Pos)                /*!< 0x00000020 */
+#define DMA_HIFCR_CTCIF4         DMA_HIFCR_CTCIF4_Msk                          
+#define DMA_HIFCR_CHTIF4_Pos     (4U)                                          
+#define DMA_HIFCR_CHTIF4_Msk     (0x1UL << DMA_HIFCR_CHTIF4_Pos)                /*!< 0x00000010 */
+#define DMA_HIFCR_CHTIF4         DMA_HIFCR_CHTIF4_Msk                          
+#define DMA_HIFCR_CTEIF4_Pos     (3U)                                          
+#define DMA_HIFCR_CTEIF4_Msk     (0x1UL << DMA_HIFCR_CTEIF4_Pos)                /*!< 0x00000008 */
+#define DMA_HIFCR_CTEIF4         DMA_HIFCR_CTEIF4_Msk                          
+#define DMA_HIFCR_CDMEIF4_Pos    (2U)                                          
+#define DMA_HIFCR_CDMEIF4_Msk    (0x1UL << DMA_HIFCR_CDMEIF4_Pos)               /*!< 0x00000004 */
+#define DMA_HIFCR_CDMEIF4        DMA_HIFCR_CDMEIF4_Msk                         
+#define DMA_HIFCR_CFEIF4_Pos     (0U)                                          
+#define DMA_HIFCR_CFEIF4_Msk     (0x1UL << DMA_HIFCR_CFEIF4_Pos)                /*!< 0x00000001 */
+#define DMA_HIFCR_CFEIF4         DMA_HIFCR_CFEIF4_Msk                          
+
+/******************  Bit definition for DMA_SxPAR register  ********************/
+#define DMA_SxPAR_PA_Pos         (0U)                                          
+#define DMA_SxPAR_PA_Msk         (0xFFFFFFFFUL << DMA_SxPAR_PA_Pos)             /*!< 0xFFFFFFFF */
+#define DMA_SxPAR_PA             DMA_SxPAR_PA_Msk                              /*!< Peripheral Address */
+
+/******************  Bit definition for DMA_SxM0AR register  ********************/
+#define DMA_SxM0AR_M0A_Pos       (0U)                                          
+#define DMA_SxM0AR_M0A_Msk       (0xFFFFFFFFUL << DMA_SxM0AR_M0A_Pos)           /*!< 0xFFFFFFFF */
+#define DMA_SxM0AR_M0A           DMA_SxM0AR_M0A_Msk                            /*!< Memory Address */
+
+/******************  Bit definition for DMA_SxM1AR register  ********************/
+#define DMA_SxM1AR_M1A_Pos       (0U)                                          
+#define DMA_SxM1AR_M1A_Msk       (0xFFFFFFFFUL << DMA_SxM1AR_M1A_Pos)           /*!< 0xFFFFFFFF */
+#define DMA_SxM1AR_M1A           DMA_SxM1AR_M1A_Msk                            /*!< Memory Address */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for EXTI_IMR register  *******************/
+#define EXTI_IMR_MR0_Pos          (0U)                                         
+#define EXTI_IMR_MR0_Msk          (0x1UL << EXTI_IMR_MR0_Pos)                   /*!< 0x00000001 */
+#define EXTI_IMR_MR0              EXTI_IMR_MR0_Msk                             /*!< Interrupt Mask on line 0 */
+#define EXTI_IMR_MR1_Pos          (1U)                                         
+#define EXTI_IMR_MR1_Msk          (0x1UL << EXTI_IMR_MR1_Pos)                   /*!< 0x00000002 */
+#define EXTI_IMR_MR1              EXTI_IMR_MR1_Msk                             /*!< Interrupt Mask on line 1 */
+#define EXTI_IMR_MR2_Pos          (2U)                                         
+#define EXTI_IMR_MR2_Msk          (0x1UL << EXTI_IMR_MR2_Pos)                   /*!< 0x00000004 */
+#define EXTI_IMR_MR2              EXTI_IMR_MR2_Msk                             /*!< Interrupt Mask on line 2 */
+#define EXTI_IMR_MR3_Pos          (3U)                                         
+#define EXTI_IMR_MR3_Msk          (0x1UL << EXTI_IMR_MR3_Pos)                   /*!< 0x00000008 */
+#define EXTI_IMR_MR3              EXTI_IMR_MR3_Msk                             /*!< Interrupt Mask on line 3 */
+#define EXTI_IMR_MR4_Pos          (4U)                                         
+#define EXTI_IMR_MR4_Msk          (0x1UL << EXTI_IMR_MR4_Pos)                   /*!< 0x00000010 */
+#define EXTI_IMR_MR4              EXTI_IMR_MR4_Msk                             /*!< Interrupt Mask on line 4 */
+#define EXTI_IMR_MR5_Pos          (5U)                                         
+#define EXTI_IMR_MR5_Msk          (0x1UL << EXTI_IMR_MR5_Pos)                   /*!< 0x00000020 */
+#define EXTI_IMR_MR5              EXTI_IMR_MR5_Msk                             /*!< Interrupt Mask on line 5 */
+#define EXTI_IMR_MR6_Pos          (6U)                                         
+#define EXTI_IMR_MR6_Msk          (0x1UL << EXTI_IMR_MR6_Pos)                   /*!< 0x00000040 */
+#define EXTI_IMR_MR6              EXTI_IMR_MR6_Msk                             /*!< Interrupt Mask on line 6 */
+#define EXTI_IMR_MR7_Pos          (7U)                                         
+#define EXTI_IMR_MR7_Msk          (0x1UL << EXTI_IMR_MR7_Pos)                   /*!< 0x00000080 */
+#define EXTI_IMR_MR7              EXTI_IMR_MR7_Msk                             /*!< Interrupt Mask on line 7 */
+#define EXTI_IMR_MR8_Pos          (8U)                                         
+#define EXTI_IMR_MR8_Msk          (0x1UL << EXTI_IMR_MR8_Pos)                   /*!< 0x00000100 */
+#define EXTI_IMR_MR8              EXTI_IMR_MR8_Msk                             /*!< Interrupt Mask on line 8 */
+#define EXTI_IMR_MR9_Pos          (9U)                                         
+#define EXTI_IMR_MR9_Msk          (0x1UL << EXTI_IMR_MR9_Pos)                   /*!< 0x00000200 */
+#define EXTI_IMR_MR9              EXTI_IMR_MR9_Msk                             /*!< Interrupt Mask on line 9 */
+#define EXTI_IMR_MR10_Pos         (10U)                                        
+#define EXTI_IMR_MR10_Msk         (0x1UL << EXTI_IMR_MR10_Pos)                  /*!< 0x00000400 */
+#define EXTI_IMR_MR10             EXTI_IMR_MR10_Msk                            /*!< Interrupt Mask on line 10 */
+#define EXTI_IMR_MR11_Pos         (11U)                                        
+#define EXTI_IMR_MR11_Msk         (0x1UL << EXTI_IMR_MR11_Pos)                  /*!< 0x00000800 */
+#define EXTI_IMR_MR11             EXTI_IMR_MR11_Msk                            /*!< Interrupt Mask on line 11 */
+#define EXTI_IMR_MR12_Pos         (12U)                                        
+#define EXTI_IMR_MR12_Msk         (0x1UL << EXTI_IMR_MR12_Pos)                  /*!< 0x00001000 */
+#define EXTI_IMR_MR12             EXTI_IMR_MR12_Msk                            /*!< Interrupt Mask on line 12 */
+#define EXTI_IMR_MR13_Pos         (13U)                                        
+#define EXTI_IMR_MR13_Msk         (0x1UL << EXTI_IMR_MR13_Pos)                  /*!< 0x00002000 */
+#define EXTI_IMR_MR13             EXTI_IMR_MR13_Msk                            /*!< Interrupt Mask on line 13 */
+#define EXTI_IMR_MR14_Pos         (14U)                                        
+#define EXTI_IMR_MR14_Msk         (0x1UL << EXTI_IMR_MR14_Pos)                  /*!< 0x00004000 */
+#define EXTI_IMR_MR14             EXTI_IMR_MR14_Msk                            /*!< Interrupt Mask on line 14 */
+#define EXTI_IMR_MR15_Pos         (15U)                                        
+#define EXTI_IMR_MR15_Msk         (0x1UL << EXTI_IMR_MR15_Pos)                  /*!< 0x00008000 */
+#define EXTI_IMR_MR15             EXTI_IMR_MR15_Msk                            /*!< Interrupt Mask on line 15 */
+#define EXTI_IMR_MR16_Pos         (16U)                                        
+#define EXTI_IMR_MR16_Msk         (0x1UL << EXTI_IMR_MR16_Pos)                  /*!< 0x00010000 */
+#define EXTI_IMR_MR16             EXTI_IMR_MR16_Msk                            /*!< Interrupt Mask on line 16 */
+#define EXTI_IMR_MR17_Pos         (17U)                                        
+#define EXTI_IMR_MR17_Msk         (0x1UL << EXTI_IMR_MR17_Pos)                  /*!< 0x00020000 */
+#define EXTI_IMR_MR17             EXTI_IMR_MR17_Msk                            /*!< Interrupt Mask on line 17 */
+#define EXTI_IMR_MR18_Pos         (18U)                                        
+#define EXTI_IMR_MR18_Msk         (0x1UL << EXTI_IMR_MR18_Pos)                  /*!< 0x00040000 */
+#define EXTI_IMR_MR18             EXTI_IMR_MR18_Msk                            /*!< Interrupt Mask on line 18 */
+#define EXTI_IMR_MR19_Pos         (19U)                                        
+#define EXTI_IMR_MR19_Msk         (0x1UL << EXTI_IMR_MR19_Pos)                  /*!< 0x00080000 */
+#define EXTI_IMR_MR19             EXTI_IMR_MR19_Msk                            /*!< Interrupt Mask on line 19 */
+#define EXTI_IMR_MR20_Pos         (20U)                                        
+#define EXTI_IMR_MR20_Msk         (0x1UL << EXTI_IMR_MR20_Pos)                  /*!< 0x00100000 */
+#define EXTI_IMR_MR20             EXTI_IMR_MR20_Msk                            /*!< Interrupt Mask on line 20 */
+#define EXTI_IMR_MR21_Pos         (21U)                                        
+#define EXTI_IMR_MR21_Msk         (0x1UL << EXTI_IMR_MR21_Pos)                  /*!< 0x00200000 */
+#define EXTI_IMR_MR21             EXTI_IMR_MR21_Msk                            /*!< Interrupt Mask on line 21 */
+#define EXTI_IMR_MR22_Pos         (22U)                                        
+#define EXTI_IMR_MR22_Msk         (0x1UL << EXTI_IMR_MR22_Pos)                  /*!< 0x00400000 */
+#define EXTI_IMR_MR22             EXTI_IMR_MR22_Msk                            /*!< Interrupt Mask on line 22 */
+
+/* Reference Defines */
+#define  EXTI_IMR_IM0                        EXTI_IMR_MR0
+#define  EXTI_IMR_IM1                        EXTI_IMR_MR1
+#define  EXTI_IMR_IM2                        EXTI_IMR_MR2
+#define  EXTI_IMR_IM3                        EXTI_IMR_MR3
+#define  EXTI_IMR_IM4                        EXTI_IMR_MR4
+#define  EXTI_IMR_IM5                        EXTI_IMR_MR5
+#define  EXTI_IMR_IM6                        EXTI_IMR_MR6
+#define  EXTI_IMR_IM7                        EXTI_IMR_MR7
+#define  EXTI_IMR_IM8                        EXTI_IMR_MR8
+#define  EXTI_IMR_IM9                        EXTI_IMR_MR9
+#define  EXTI_IMR_IM10                       EXTI_IMR_MR10
+#define  EXTI_IMR_IM11                       EXTI_IMR_MR11
+#define  EXTI_IMR_IM12                       EXTI_IMR_MR12
+#define  EXTI_IMR_IM13                       EXTI_IMR_MR13
+#define  EXTI_IMR_IM14                       EXTI_IMR_MR14
+#define  EXTI_IMR_IM15                       EXTI_IMR_MR15
+#define  EXTI_IMR_IM16                       EXTI_IMR_MR16
+#define  EXTI_IMR_IM17                       EXTI_IMR_MR17
+#define  EXTI_IMR_IM18                       EXTI_IMR_MR18
+#define  EXTI_IMR_IM19                       EXTI_IMR_MR19
+#define  EXTI_IMR_IM20                       EXTI_IMR_MR20
+#define  EXTI_IMR_IM21                       EXTI_IMR_MR21
+#define  EXTI_IMR_IM22                       EXTI_IMR_MR22
+#define EXTI_IMR_IM_Pos           (0U)                                         
+#define EXTI_IMR_IM_Msk           (0x7FFFFFUL << EXTI_IMR_IM_Pos)               /*!< 0x007FFFFF */
+#define EXTI_IMR_IM               EXTI_IMR_IM_Msk                              /*!< Interrupt Mask All */
+
+/*******************  Bit definition for EXTI_EMR register  *******************/
+#define EXTI_EMR_MR0_Pos          (0U)                                         
+#define EXTI_EMR_MR0_Msk          (0x1UL << EXTI_EMR_MR0_Pos)                   /*!< 0x00000001 */
+#define EXTI_EMR_MR0              EXTI_EMR_MR0_Msk                             /*!< Event Mask on line 0 */
+#define EXTI_EMR_MR1_Pos          (1U)                                         
+#define EXTI_EMR_MR1_Msk          (0x1UL << EXTI_EMR_MR1_Pos)                   /*!< 0x00000002 */
+#define EXTI_EMR_MR1              EXTI_EMR_MR1_Msk                             /*!< Event Mask on line 1 */
+#define EXTI_EMR_MR2_Pos          (2U)                                         
+#define EXTI_EMR_MR2_Msk          (0x1UL << EXTI_EMR_MR2_Pos)                   /*!< 0x00000004 */
+#define EXTI_EMR_MR2              EXTI_EMR_MR2_Msk                             /*!< Event Mask on line 2 */
+#define EXTI_EMR_MR3_Pos          (3U)                                         
+#define EXTI_EMR_MR3_Msk          (0x1UL << EXTI_EMR_MR3_Pos)                   /*!< 0x00000008 */
+#define EXTI_EMR_MR3              EXTI_EMR_MR3_Msk                             /*!< Event Mask on line 3 */
+#define EXTI_EMR_MR4_Pos          (4U)                                         
+#define EXTI_EMR_MR4_Msk          (0x1UL << EXTI_EMR_MR4_Pos)                   /*!< 0x00000010 */
+#define EXTI_EMR_MR4              EXTI_EMR_MR4_Msk                             /*!< Event Mask on line 4 */
+#define EXTI_EMR_MR5_Pos          (5U)                                         
+#define EXTI_EMR_MR5_Msk          (0x1UL << EXTI_EMR_MR5_Pos)                   /*!< 0x00000020 */
+#define EXTI_EMR_MR5              EXTI_EMR_MR5_Msk                             /*!< Event Mask on line 5 */
+#define EXTI_EMR_MR6_Pos          (6U)                                         
+#define EXTI_EMR_MR6_Msk          (0x1UL << EXTI_EMR_MR6_Pos)                   /*!< 0x00000040 */
+#define EXTI_EMR_MR6              EXTI_EMR_MR6_Msk                             /*!< Event Mask on line 6 */
+#define EXTI_EMR_MR7_Pos          (7U)                                         
+#define EXTI_EMR_MR7_Msk          (0x1UL << EXTI_EMR_MR7_Pos)                   /*!< 0x00000080 */
+#define EXTI_EMR_MR7              EXTI_EMR_MR7_Msk                             /*!< Event Mask on line 7 */
+#define EXTI_EMR_MR8_Pos          (8U)                                         
+#define EXTI_EMR_MR8_Msk          (0x1UL << EXTI_EMR_MR8_Pos)                   /*!< 0x00000100 */
+#define EXTI_EMR_MR8              EXTI_EMR_MR8_Msk                             /*!< Event Mask on line 8 */
+#define EXTI_EMR_MR9_Pos          (9U)                                         
+#define EXTI_EMR_MR9_Msk          (0x1UL << EXTI_EMR_MR9_Pos)                   /*!< 0x00000200 */
+#define EXTI_EMR_MR9              EXTI_EMR_MR9_Msk                             /*!< Event Mask on line 9 */
+#define EXTI_EMR_MR10_Pos         (10U)                                        
+#define EXTI_EMR_MR10_Msk         (0x1UL << EXTI_EMR_MR10_Pos)                  /*!< 0x00000400 */
+#define EXTI_EMR_MR10             EXTI_EMR_MR10_Msk                            /*!< Event Mask on line 10 */
+#define EXTI_EMR_MR11_Pos         (11U)                                        
+#define EXTI_EMR_MR11_Msk         (0x1UL << EXTI_EMR_MR11_Pos)                  /*!< 0x00000800 */
+#define EXTI_EMR_MR11             EXTI_EMR_MR11_Msk                            /*!< Event Mask on line 11 */
+#define EXTI_EMR_MR12_Pos         (12U)                                        
+#define EXTI_EMR_MR12_Msk         (0x1UL << EXTI_EMR_MR12_Pos)                  /*!< 0x00001000 */
+#define EXTI_EMR_MR12             EXTI_EMR_MR12_Msk                            /*!< Event Mask on line 12 */
+#define EXTI_EMR_MR13_Pos         (13U)                                        
+#define EXTI_EMR_MR13_Msk         (0x1UL << EXTI_EMR_MR13_Pos)                  /*!< 0x00002000 */
+#define EXTI_EMR_MR13             EXTI_EMR_MR13_Msk                            /*!< Event Mask on line 13 */
+#define EXTI_EMR_MR14_Pos         (14U)                                        
+#define EXTI_EMR_MR14_Msk         (0x1UL << EXTI_EMR_MR14_Pos)                  /*!< 0x00004000 */
+#define EXTI_EMR_MR14             EXTI_EMR_MR14_Msk                            /*!< Event Mask on line 14 */
+#define EXTI_EMR_MR15_Pos         (15U)                                        
+#define EXTI_EMR_MR15_Msk         (0x1UL << EXTI_EMR_MR15_Pos)                  /*!< 0x00008000 */
+#define EXTI_EMR_MR15             EXTI_EMR_MR15_Msk                            /*!< Event Mask on line 15 */
+#define EXTI_EMR_MR16_Pos         (16U)                                        
+#define EXTI_EMR_MR16_Msk         (0x1UL << EXTI_EMR_MR16_Pos)                  /*!< 0x00010000 */
+#define EXTI_EMR_MR16             EXTI_EMR_MR16_Msk                            /*!< Event Mask on line 16 */
+#define EXTI_EMR_MR17_Pos         (17U)                                        
+#define EXTI_EMR_MR17_Msk         (0x1UL << EXTI_EMR_MR17_Pos)                  /*!< 0x00020000 */
+#define EXTI_EMR_MR17             EXTI_EMR_MR17_Msk                            /*!< Event Mask on line 17 */
+#define EXTI_EMR_MR18_Pos         (18U)                                        
+#define EXTI_EMR_MR18_Msk         (0x1UL << EXTI_EMR_MR18_Pos)                  /*!< 0x00040000 */
+#define EXTI_EMR_MR18             EXTI_EMR_MR18_Msk                            /*!< Event Mask on line 18 */
+#define EXTI_EMR_MR19_Pos         (19U)                                        
+#define EXTI_EMR_MR19_Msk         (0x1UL << EXTI_EMR_MR19_Pos)                  /*!< 0x00080000 */
+#define EXTI_EMR_MR19             EXTI_EMR_MR19_Msk                            /*!< Event Mask on line 19 */
+#define EXTI_EMR_MR20_Pos         (20U)                                        
+#define EXTI_EMR_MR20_Msk         (0x1UL << EXTI_EMR_MR20_Pos)                  /*!< 0x00100000 */
+#define EXTI_EMR_MR20             EXTI_EMR_MR20_Msk                            /*!< Event Mask on line 20 */
+#define EXTI_EMR_MR21_Pos         (21U)                                        
+#define EXTI_EMR_MR21_Msk         (0x1UL << EXTI_EMR_MR21_Pos)                  /*!< 0x00200000 */
+#define EXTI_EMR_MR21             EXTI_EMR_MR21_Msk                            /*!< Event Mask on line 21 */
+#define EXTI_EMR_MR22_Pos         (22U)                                        
+#define EXTI_EMR_MR22_Msk         (0x1UL << EXTI_EMR_MR22_Pos)                  /*!< 0x00400000 */
+#define EXTI_EMR_MR22             EXTI_EMR_MR22_Msk                            /*!< Event Mask on line 22 */
+
+/* Reference Defines */
+#define  EXTI_EMR_EM0                        EXTI_EMR_MR0
+#define  EXTI_EMR_EM1                        EXTI_EMR_MR1
+#define  EXTI_EMR_EM2                        EXTI_EMR_MR2
+#define  EXTI_EMR_EM3                        EXTI_EMR_MR3
+#define  EXTI_EMR_EM4                        EXTI_EMR_MR4
+#define  EXTI_EMR_EM5                        EXTI_EMR_MR5
+#define  EXTI_EMR_EM6                        EXTI_EMR_MR6
+#define  EXTI_EMR_EM7                        EXTI_EMR_MR7
+#define  EXTI_EMR_EM8                        EXTI_EMR_MR8
+#define  EXTI_EMR_EM9                        EXTI_EMR_MR9
+#define  EXTI_EMR_EM10                       EXTI_EMR_MR10
+#define  EXTI_EMR_EM11                       EXTI_EMR_MR11
+#define  EXTI_EMR_EM12                       EXTI_EMR_MR12
+#define  EXTI_EMR_EM13                       EXTI_EMR_MR13
+#define  EXTI_EMR_EM14                       EXTI_EMR_MR14
+#define  EXTI_EMR_EM15                       EXTI_EMR_MR15
+#define  EXTI_EMR_EM16                       EXTI_EMR_MR16
+#define  EXTI_EMR_EM17                       EXTI_EMR_MR17
+#define  EXTI_EMR_EM18                       EXTI_EMR_MR18
+#define  EXTI_EMR_EM19                       EXTI_EMR_MR19
+#define  EXTI_EMR_EM20                       EXTI_EMR_MR20
+#define  EXTI_EMR_EM21                       EXTI_EMR_MR21
+#define  EXTI_EMR_EM22                       EXTI_EMR_MR22
+
+/******************  Bit definition for EXTI_RTSR register  *******************/
+#define EXTI_RTSR_TR0_Pos         (0U)                                         
+#define EXTI_RTSR_TR0_Msk         (0x1UL << EXTI_RTSR_TR0_Pos)                  /*!< 0x00000001 */
+#define EXTI_RTSR_TR0             EXTI_RTSR_TR0_Msk                            /*!< Rising trigger event configuration bit of line 0 */
+#define EXTI_RTSR_TR1_Pos         (1U)                                         
+#define EXTI_RTSR_TR1_Msk         (0x1UL << EXTI_RTSR_TR1_Pos)                  /*!< 0x00000002 */
+#define EXTI_RTSR_TR1             EXTI_RTSR_TR1_Msk                            /*!< Rising trigger event configuration bit of line 1 */
+#define EXTI_RTSR_TR2_Pos         (2U)                                         
+#define EXTI_RTSR_TR2_Msk         (0x1UL << EXTI_RTSR_TR2_Pos)                  /*!< 0x00000004 */
+#define EXTI_RTSR_TR2             EXTI_RTSR_TR2_Msk                            /*!< Rising trigger event configuration bit of line 2 */
+#define EXTI_RTSR_TR3_Pos         (3U)                                         
+#define EXTI_RTSR_TR3_Msk         (0x1UL << EXTI_RTSR_TR3_Pos)                  /*!< 0x00000008 */
+#define EXTI_RTSR_TR3             EXTI_RTSR_TR3_Msk                            /*!< Rising trigger event configuration bit of line 3 */
+#define EXTI_RTSR_TR4_Pos         (4U)                                         
+#define EXTI_RTSR_TR4_Msk         (0x1UL << EXTI_RTSR_TR4_Pos)                  /*!< 0x00000010 */
+#define EXTI_RTSR_TR4             EXTI_RTSR_TR4_Msk                            /*!< Rising trigger event configuration bit of line 4 */
+#define EXTI_RTSR_TR5_Pos         (5U)                                         
+#define EXTI_RTSR_TR5_Msk         (0x1UL << EXTI_RTSR_TR5_Pos)                  /*!< 0x00000020 */
+#define EXTI_RTSR_TR5             EXTI_RTSR_TR5_Msk                            /*!< Rising trigger event configuration bit of line 5 */
+#define EXTI_RTSR_TR6_Pos         (6U)                                         
+#define EXTI_RTSR_TR6_Msk         (0x1UL << EXTI_RTSR_TR6_Pos)                  /*!< 0x00000040 */
+#define EXTI_RTSR_TR6             EXTI_RTSR_TR6_Msk                            /*!< Rising trigger event configuration bit of line 6 */
+#define EXTI_RTSR_TR7_Pos         (7U)                                         
+#define EXTI_RTSR_TR7_Msk         (0x1UL << EXTI_RTSR_TR7_Pos)                  /*!< 0x00000080 */
+#define EXTI_RTSR_TR7             EXTI_RTSR_TR7_Msk                            /*!< Rising trigger event configuration bit of line 7 */
+#define EXTI_RTSR_TR8_Pos         (8U)                                         
+#define EXTI_RTSR_TR8_Msk         (0x1UL << EXTI_RTSR_TR8_Pos)                  /*!< 0x00000100 */
+#define EXTI_RTSR_TR8             EXTI_RTSR_TR8_Msk                            /*!< Rising trigger event configuration bit of line 8 */
+#define EXTI_RTSR_TR9_Pos         (9U)                                         
+#define EXTI_RTSR_TR9_Msk         (0x1UL << EXTI_RTSR_TR9_Pos)                  /*!< 0x00000200 */
+#define EXTI_RTSR_TR9             EXTI_RTSR_TR9_Msk                            /*!< Rising trigger event configuration bit of line 9 */
+#define EXTI_RTSR_TR10_Pos        (10U)                                        
+#define EXTI_RTSR_TR10_Msk        (0x1UL << EXTI_RTSR_TR10_Pos)                 /*!< 0x00000400 */
+#define EXTI_RTSR_TR10            EXTI_RTSR_TR10_Msk                           /*!< Rising trigger event configuration bit of line 10 */
+#define EXTI_RTSR_TR11_Pos        (11U)                                        
+#define EXTI_RTSR_TR11_Msk        (0x1UL << EXTI_RTSR_TR11_Pos)                 /*!< 0x00000800 */
+#define EXTI_RTSR_TR11            EXTI_RTSR_TR11_Msk                           /*!< Rising trigger event configuration bit of line 11 */
+#define EXTI_RTSR_TR12_Pos        (12U)                                        
+#define EXTI_RTSR_TR12_Msk        (0x1UL << EXTI_RTSR_TR12_Pos)                 /*!< 0x00001000 */
+#define EXTI_RTSR_TR12            EXTI_RTSR_TR12_Msk                           /*!< Rising trigger event configuration bit of line 12 */
+#define EXTI_RTSR_TR13_Pos        (13U)                                        
+#define EXTI_RTSR_TR13_Msk        (0x1UL << EXTI_RTSR_TR13_Pos)                 /*!< 0x00002000 */
+#define EXTI_RTSR_TR13            EXTI_RTSR_TR13_Msk                           /*!< Rising trigger event configuration bit of line 13 */
+#define EXTI_RTSR_TR14_Pos        (14U)                                        
+#define EXTI_RTSR_TR14_Msk        (0x1UL << EXTI_RTSR_TR14_Pos)                 /*!< 0x00004000 */
+#define EXTI_RTSR_TR14            EXTI_RTSR_TR14_Msk                           /*!< Rising trigger event configuration bit of line 14 */
+#define EXTI_RTSR_TR15_Pos        (15U)                                        
+#define EXTI_RTSR_TR15_Msk        (0x1UL << EXTI_RTSR_TR15_Pos)                 /*!< 0x00008000 */
+#define EXTI_RTSR_TR15            EXTI_RTSR_TR15_Msk                           /*!< Rising trigger event configuration bit of line 15 */
+#define EXTI_RTSR_TR16_Pos        (16U)                                        
+#define EXTI_RTSR_TR16_Msk        (0x1UL << EXTI_RTSR_TR16_Pos)                 /*!< 0x00010000 */
+#define EXTI_RTSR_TR16            EXTI_RTSR_TR16_Msk                           /*!< Rising trigger event configuration bit of line 16 */
+#define EXTI_RTSR_TR17_Pos        (17U)                                        
+#define EXTI_RTSR_TR17_Msk        (0x1UL << EXTI_RTSR_TR17_Pos)                 /*!< 0x00020000 */
+#define EXTI_RTSR_TR17            EXTI_RTSR_TR17_Msk                           /*!< Rising trigger event configuration bit of line 17 */
+#define EXTI_RTSR_TR18_Pos        (18U)                                        
+#define EXTI_RTSR_TR18_Msk        (0x1UL << EXTI_RTSR_TR18_Pos)                 /*!< 0x00040000 */
+#define EXTI_RTSR_TR18            EXTI_RTSR_TR18_Msk                           /*!< Rising trigger event configuration bit of line 18 */
+#define EXTI_RTSR_TR19_Pos        (19U)                                        
+#define EXTI_RTSR_TR19_Msk        (0x1UL << EXTI_RTSR_TR19_Pos)                 /*!< 0x00080000 */
+#define EXTI_RTSR_TR19            EXTI_RTSR_TR19_Msk                           /*!< Rising trigger event configuration bit of line 19 */
+#define EXTI_RTSR_TR20_Pos        (20U)                                        
+#define EXTI_RTSR_TR20_Msk        (0x1UL << EXTI_RTSR_TR20_Pos)                 /*!< 0x00100000 */
+#define EXTI_RTSR_TR20            EXTI_RTSR_TR20_Msk                           /*!< Rising trigger event configuration bit of line 20 */
+#define EXTI_RTSR_TR21_Pos        (21U)                                        
+#define EXTI_RTSR_TR21_Msk        (0x1UL << EXTI_RTSR_TR21_Pos)                 /*!< 0x00200000 */
+#define EXTI_RTSR_TR21            EXTI_RTSR_TR21_Msk                           /*!< Rising trigger event configuration bit of line 21 */
+#define EXTI_RTSR_TR22_Pos        (22U)                                        
+#define EXTI_RTSR_TR22_Msk        (0x1UL << EXTI_RTSR_TR22_Pos)                 /*!< 0x00400000 */
+#define EXTI_RTSR_TR22            EXTI_RTSR_TR22_Msk                           /*!< Rising trigger event configuration bit of line 22 */
+
+/******************  Bit definition for EXTI_FTSR register  *******************/
+#define EXTI_FTSR_TR0_Pos         (0U)                                         
+#define EXTI_FTSR_TR0_Msk         (0x1UL << EXTI_FTSR_TR0_Pos)                  /*!< 0x00000001 */
+#define EXTI_FTSR_TR0             EXTI_FTSR_TR0_Msk                            /*!< Falling trigger event configuration bit of line 0 */
+#define EXTI_FTSR_TR1_Pos         (1U)                                         
+#define EXTI_FTSR_TR1_Msk         (0x1UL << EXTI_FTSR_TR1_Pos)                  /*!< 0x00000002 */
+#define EXTI_FTSR_TR1             EXTI_FTSR_TR1_Msk                            /*!< Falling trigger event configuration bit of line 1 */
+#define EXTI_FTSR_TR2_Pos         (2U)                                         
+#define EXTI_FTSR_TR2_Msk         (0x1UL << EXTI_FTSR_TR2_Pos)                  /*!< 0x00000004 */
+#define EXTI_FTSR_TR2             EXTI_FTSR_TR2_Msk                            /*!< Falling trigger event configuration bit of line 2 */
+#define EXTI_FTSR_TR3_Pos         (3U)                                         
+#define EXTI_FTSR_TR3_Msk         (0x1UL << EXTI_FTSR_TR3_Pos)                  /*!< 0x00000008 */
+#define EXTI_FTSR_TR3             EXTI_FTSR_TR3_Msk                            /*!< Falling trigger event configuration bit of line 3 */
+#define EXTI_FTSR_TR4_Pos         (4U)                                         
+#define EXTI_FTSR_TR4_Msk         (0x1UL << EXTI_FTSR_TR4_Pos)                  /*!< 0x00000010 */
+#define EXTI_FTSR_TR4             EXTI_FTSR_TR4_Msk                            /*!< Falling trigger event configuration bit of line 4 */
+#define EXTI_FTSR_TR5_Pos         (5U)                                         
+#define EXTI_FTSR_TR5_Msk         (0x1UL << EXTI_FTSR_TR5_Pos)                  /*!< 0x00000020 */
+#define EXTI_FTSR_TR5             EXTI_FTSR_TR5_Msk                            /*!< Falling trigger event configuration bit of line 5 */
+#define EXTI_FTSR_TR6_Pos         (6U)                                         
+#define EXTI_FTSR_TR6_Msk         (0x1UL << EXTI_FTSR_TR6_Pos)                  /*!< 0x00000040 */
+#define EXTI_FTSR_TR6             EXTI_FTSR_TR6_Msk                            /*!< Falling trigger event configuration bit of line 6 */
+#define EXTI_FTSR_TR7_Pos         (7U)                                         
+#define EXTI_FTSR_TR7_Msk         (0x1UL << EXTI_FTSR_TR7_Pos)                  /*!< 0x00000080 */
+#define EXTI_FTSR_TR7             EXTI_FTSR_TR7_Msk                            /*!< Falling trigger event configuration bit of line 7 */
+#define EXTI_FTSR_TR8_Pos         (8U)                                         
+#define EXTI_FTSR_TR8_Msk         (0x1UL << EXTI_FTSR_TR8_Pos)                  /*!< 0x00000100 */
+#define EXTI_FTSR_TR8             EXTI_FTSR_TR8_Msk                            /*!< Falling trigger event configuration bit of line 8 */
+#define EXTI_FTSR_TR9_Pos         (9U)                                         
+#define EXTI_FTSR_TR9_Msk         (0x1UL << EXTI_FTSR_TR9_Pos)                  /*!< 0x00000200 */
+#define EXTI_FTSR_TR9             EXTI_FTSR_TR9_Msk                            /*!< Falling trigger event configuration bit of line 9 */
+#define EXTI_FTSR_TR10_Pos        (10U)                                        
+#define EXTI_FTSR_TR10_Msk        (0x1UL << EXTI_FTSR_TR10_Pos)                 /*!< 0x00000400 */
+#define EXTI_FTSR_TR10            EXTI_FTSR_TR10_Msk                           /*!< Falling trigger event configuration bit of line 10 */
+#define EXTI_FTSR_TR11_Pos        (11U)                                        
+#define EXTI_FTSR_TR11_Msk        (0x1UL << EXTI_FTSR_TR11_Pos)                 /*!< 0x00000800 */
+#define EXTI_FTSR_TR11            EXTI_FTSR_TR11_Msk                           /*!< Falling trigger event configuration bit of line 11 */
+#define EXTI_FTSR_TR12_Pos        (12U)                                        
+#define EXTI_FTSR_TR12_Msk        (0x1UL << EXTI_FTSR_TR12_Pos)                 /*!< 0x00001000 */
+#define EXTI_FTSR_TR12            EXTI_FTSR_TR12_Msk                           /*!< Falling trigger event configuration bit of line 12 */
+#define EXTI_FTSR_TR13_Pos        (13U)                                        
+#define EXTI_FTSR_TR13_Msk        (0x1UL << EXTI_FTSR_TR13_Pos)                 /*!< 0x00002000 */
+#define EXTI_FTSR_TR13            EXTI_FTSR_TR13_Msk                           /*!< Falling trigger event configuration bit of line 13 */
+#define EXTI_FTSR_TR14_Pos        (14U)                                        
+#define EXTI_FTSR_TR14_Msk        (0x1UL << EXTI_FTSR_TR14_Pos)                 /*!< 0x00004000 */
+#define EXTI_FTSR_TR14            EXTI_FTSR_TR14_Msk                           /*!< Falling trigger event configuration bit of line 14 */
+#define EXTI_FTSR_TR15_Pos        (15U)                                        
+#define EXTI_FTSR_TR15_Msk        (0x1UL << EXTI_FTSR_TR15_Pos)                 /*!< 0x00008000 */
+#define EXTI_FTSR_TR15            EXTI_FTSR_TR15_Msk                           /*!< Falling trigger event configuration bit of line 15 */
+#define EXTI_FTSR_TR16_Pos        (16U)                                        
+#define EXTI_FTSR_TR16_Msk        (0x1UL << EXTI_FTSR_TR16_Pos)                 /*!< 0x00010000 */
+#define EXTI_FTSR_TR16            EXTI_FTSR_TR16_Msk                           /*!< Falling trigger event configuration bit of line 16 */
+#define EXTI_FTSR_TR17_Pos        (17U)                                        
+#define EXTI_FTSR_TR17_Msk        (0x1UL << EXTI_FTSR_TR17_Pos)                 /*!< 0x00020000 */
+#define EXTI_FTSR_TR17            EXTI_FTSR_TR17_Msk                           /*!< Falling trigger event configuration bit of line 17 */
+#define EXTI_FTSR_TR18_Pos        (18U)                                        
+#define EXTI_FTSR_TR18_Msk        (0x1UL << EXTI_FTSR_TR18_Pos)                 /*!< 0x00040000 */
+#define EXTI_FTSR_TR18            EXTI_FTSR_TR18_Msk                           /*!< Falling trigger event configuration bit of line 18 */
+#define EXTI_FTSR_TR19_Pos        (19U)                                        
+#define EXTI_FTSR_TR19_Msk        (0x1UL << EXTI_FTSR_TR19_Pos)                 /*!< 0x00080000 */
+#define EXTI_FTSR_TR19            EXTI_FTSR_TR19_Msk                           /*!< Falling trigger event configuration bit of line 19 */
+#define EXTI_FTSR_TR20_Pos        (20U)                                        
+#define EXTI_FTSR_TR20_Msk        (0x1UL << EXTI_FTSR_TR20_Pos)                 /*!< 0x00100000 */
+#define EXTI_FTSR_TR20            EXTI_FTSR_TR20_Msk                           /*!< Falling trigger event configuration bit of line 20 */
+#define EXTI_FTSR_TR21_Pos        (21U)                                        
+#define EXTI_FTSR_TR21_Msk        (0x1UL << EXTI_FTSR_TR21_Pos)                 /*!< 0x00200000 */
+#define EXTI_FTSR_TR21            EXTI_FTSR_TR21_Msk                           /*!< Falling trigger event configuration bit of line 21 */
+#define EXTI_FTSR_TR22_Pos        (22U)                                        
+#define EXTI_FTSR_TR22_Msk        (0x1UL << EXTI_FTSR_TR22_Pos)                 /*!< 0x00400000 */
+#define EXTI_FTSR_TR22            EXTI_FTSR_TR22_Msk                           /*!< Falling trigger event configuration bit of line 22 */
+
+/******************  Bit definition for EXTI_SWIER register  ******************/
+#define EXTI_SWIER_SWIER0_Pos     (0U)                                         
+#define EXTI_SWIER_SWIER0_Msk     (0x1UL << EXTI_SWIER_SWIER0_Pos)              /*!< 0x00000001 */
+#define EXTI_SWIER_SWIER0         EXTI_SWIER_SWIER0_Msk                        /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER_SWIER1_Pos     (1U)                                         
+#define EXTI_SWIER_SWIER1_Msk     (0x1UL << EXTI_SWIER_SWIER1_Pos)              /*!< 0x00000002 */
+#define EXTI_SWIER_SWIER1         EXTI_SWIER_SWIER1_Msk                        /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER_SWIER2_Pos     (2U)                                         
+#define EXTI_SWIER_SWIER2_Msk     (0x1UL << EXTI_SWIER_SWIER2_Pos)              /*!< 0x00000004 */
+#define EXTI_SWIER_SWIER2         EXTI_SWIER_SWIER2_Msk                        /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER_SWIER3_Pos     (3U)                                         
+#define EXTI_SWIER_SWIER3_Msk     (0x1UL << EXTI_SWIER_SWIER3_Pos)              /*!< 0x00000008 */
+#define EXTI_SWIER_SWIER3         EXTI_SWIER_SWIER3_Msk                        /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER_SWIER4_Pos     (4U)                                         
+#define EXTI_SWIER_SWIER4_Msk     (0x1UL << EXTI_SWIER_SWIER4_Pos)              /*!< 0x00000010 */
+#define EXTI_SWIER_SWIER4         EXTI_SWIER_SWIER4_Msk                        /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER_SWIER5_Pos     (5U)                                         
+#define EXTI_SWIER_SWIER5_Msk     (0x1UL << EXTI_SWIER_SWIER5_Pos)              /*!< 0x00000020 */
+#define EXTI_SWIER_SWIER5         EXTI_SWIER_SWIER5_Msk                        /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER_SWIER6_Pos     (6U)                                         
+#define EXTI_SWIER_SWIER6_Msk     (0x1UL << EXTI_SWIER_SWIER6_Pos)              /*!< 0x00000040 */
+#define EXTI_SWIER_SWIER6         EXTI_SWIER_SWIER6_Msk                        /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER_SWIER7_Pos     (7U)                                         
+#define EXTI_SWIER_SWIER7_Msk     (0x1UL << EXTI_SWIER_SWIER7_Pos)              /*!< 0x00000080 */
+#define EXTI_SWIER_SWIER7         EXTI_SWIER_SWIER7_Msk                        /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER_SWIER8_Pos     (8U)                                         
+#define EXTI_SWIER_SWIER8_Msk     (0x1UL << EXTI_SWIER_SWIER8_Pos)              /*!< 0x00000100 */
+#define EXTI_SWIER_SWIER8         EXTI_SWIER_SWIER8_Msk                        /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER_SWIER9_Pos     (9U)                                         
+#define EXTI_SWIER_SWIER9_Msk     (0x1UL << EXTI_SWIER_SWIER9_Pos)              /*!< 0x00000200 */
+#define EXTI_SWIER_SWIER9         EXTI_SWIER_SWIER9_Msk                        /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER_SWIER10_Pos    (10U)                                        
+#define EXTI_SWIER_SWIER10_Msk    (0x1UL << EXTI_SWIER_SWIER10_Pos)             /*!< 0x00000400 */
+#define EXTI_SWIER_SWIER10        EXTI_SWIER_SWIER10_Msk                       /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER_SWIER11_Pos    (11U)                                        
+#define EXTI_SWIER_SWIER11_Msk    (0x1UL << EXTI_SWIER_SWIER11_Pos)             /*!< 0x00000800 */
+#define EXTI_SWIER_SWIER11        EXTI_SWIER_SWIER11_Msk                       /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER_SWIER12_Pos    (12U)                                        
+#define EXTI_SWIER_SWIER12_Msk    (0x1UL << EXTI_SWIER_SWIER12_Pos)             /*!< 0x00001000 */
+#define EXTI_SWIER_SWIER12        EXTI_SWIER_SWIER12_Msk                       /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER_SWIER13_Pos    (13U)                                        
+#define EXTI_SWIER_SWIER13_Msk    (0x1UL << EXTI_SWIER_SWIER13_Pos)             /*!< 0x00002000 */
+#define EXTI_SWIER_SWIER13        EXTI_SWIER_SWIER13_Msk                       /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER_SWIER14_Pos    (14U)                                        
+#define EXTI_SWIER_SWIER14_Msk    (0x1UL << EXTI_SWIER_SWIER14_Pos)             /*!< 0x00004000 */
+#define EXTI_SWIER_SWIER14        EXTI_SWIER_SWIER14_Msk                       /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER_SWIER15_Pos    (15U)                                        
+#define EXTI_SWIER_SWIER15_Msk    (0x1UL << EXTI_SWIER_SWIER15_Pos)             /*!< 0x00008000 */
+#define EXTI_SWIER_SWIER15        EXTI_SWIER_SWIER15_Msk                       /*!< Software Interrupt on line 15 */
+#define EXTI_SWIER_SWIER16_Pos    (16U)                                        
+#define EXTI_SWIER_SWIER16_Msk    (0x1UL << EXTI_SWIER_SWIER16_Pos)             /*!< 0x00010000 */
+#define EXTI_SWIER_SWIER16        EXTI_SWIER_SWIER16_Msk                       /*!< Software Interrupt on line 16 */
+#define EXTI_SWIER_SWIER17_Pos    (17U)                                        
+#define EXTI_SWIER_SWIER17_Msk    (0x1UL << EXTI_SWIER_SWIER17_Pos)             /*!< 0x00020000 */
+#define EXTI_SWIER_SWIER17        EXTI_SWIER_SWIER17_Msk                       /*!< Software Interrupt on line 17 */
+#define EXTI_SWIER_SWIER18_Pos    (18U)                                        
+#define EXTI_SWIER_SWIER18_Msk    (0x1UL << EXTI_SWIER_SWIER18_Pos)             /*!< 0x00040000 */
+#define EXTI_SWIER_SWIER18        EXTI_SWIER_SWIER18_Msk                       /*!< Software Interrupt on line 18 */
+#define EXTI_SWIER_SWIER19_Pos    (19U)                                        
+#define EXTI_SWIER_SWIER19_Msk    (0x1UL << EXTI_SWIER_SWIER19_Pos)             /*!< 0x00080000 */
+#define EXTI_SWIER_SWIER19        EXTI_SWIER_SWIER19_Msk                       /*!< Software Interrupt on line 19 */
+#define EXTI_SWIER_SWIER20_Pos    (20U)                                        
+#define EXTI_SWIER_SWIER20_Msk    (0x1UL << EXTI_SWIER_SWIER20_Pos)             /*!< 0x00100000 */
+#define EXTI_SWIER_SWIER20        EXTI_SWIER_SWIER20_Msk                       /*!< Software Interrupt on line 20 */
+#define EXTI_SWIER_SWIER21_Pos    (21U)                                        
+#define EXTI_SWIER_SWIER21_Msk    (0x1UL << EXTI_SWIER_SWIER21_Pos)             /*!< 0x00200000 */
+#define EXTI_SWIER_SWIER21        EXTI_SWIER_SWIER21_Msk                       /*!< Software Interrupt on line 21 */
+#define EXTI_SWIER_SWIER22_Pos    (22U)                                        
+#define EXTI_SWIER_SWIER22_Msk    (0x1UL << EXTI_SWIER_SWIER22_Pos)             /*!< 0x00400000 */
+#define EXTI_SWIER_SWIER22        EXTI_SWIER_SWIER22_Msk                       /*!< Software Interrupt on line 22 */
+
+/*******************  Bit definition for EXTI_PR register  ********************/
+#define EXTI_PR_PR0_Pos           (0U)                                         
+#define EXTI_PR_PR0_Msk           (0x1UL << EXTI_PR_PR0_Pos)                    /*!< 0x00000001 */
+#define EXTI_PR_PR0               EXTI_PR_PR0_Msk                              /*!< Pending bit for line 0 */
+#define EXTI_PR_PR1_Pos           (1U)                                         
+#define EXTI_PR_PR1_Msk           (0x1UL << EXTI_PR_PR1_Pos)                    /*!< 0x00000002 */
+#define EXTI_PR_PR1               EXTI_PR_PR1_Msk                              /*!< Pending bit for line 1 */
+#define EXTI_PR_PR2_Pos           (2U)                                         
+#define EXTI_PR_PR2_Msk           (0x1UL << EXTI_PR_PR2_Pos)                    /*!< 0x00000004 */
+#define EXTI_PR_PR2               EXTI_PR_PR2_Msk                              /*!< Pending bit for line 2 */
+#define EXTI_PR_PR3_Pos           (3U)                                         
+#define EXTI_PR_PR3_Msk           (0x1UL << EXTI_PR_PR3_Pos)                    /*!< 0x00000008 */
+#define EXTI_PR_PR3               EXTI_PR_PR3_Msk                              /*!< Pending bit for line 3 */
+#define EXTI_PR_PR4_Pos           (4U)                                         
+#define EXTI_PR_PR4_Msk           (0x1UL << EXTI_PR_PR4_Pos)                    /*!< 0x00000010 */
+#define EXTI_PR_PR4               EXTI_PR_PR4_Msk                              /*!< Pending bit for line 4 */
+#define EXTI_PR_PR5_Pos           (5U)                                         
+#define EXTI_PR_PR5_Msk           (0x1UL << EXTI_PR_PR5_Pos)                    /*!< 0x00000020 */
+#define EXTI_PR_PR5               EXTI_PR_PR5_Msk                              /*!< Pending bit for line 5 */
+#define EXTI_PR_PR6_Pos           (6U)                                         
+#define EXTI_PR_PR6_Msk           (0x1UL << EXTI_PR_PR6_Pos)                    /*!< 0x00000040 */
+#define EXTI_PR_PR6               EXTI_PR_PR6_Msk                              /*!< Pending bit for line 6 */
+#define EXTI_PR_PR7_Pos           (7U)                                         
+#define EXTI_PR_PR7_Msk           (0x1UL << EXTI_PR_PR7_Pos)                    /*!< 0x00000080 */
+#define EXTI_PR_PR7               EXTI_PR_PR7_Msk                              /*!< Pending bit for line 7 */
+#define EXTI_PR_PR8_Pos           (8U)                                         
+#define EXTI_PR_PR8_Msk           (0x1UL << EXTI_PR_PR8_Pos)                    /*!< 0x00000100 */
+#define EXTI_PR_PR8               EXTI_PR_PR8_Msk                              /*!< Pending bit for line 8 */
+#define EXTI_PR_PR9_Pos           (9U)                                         
+#define EXTI_PR_PR9_Msk           (0x1UL << EXTI_PR_PR9_Pos)                    /*!< 0x00000200 */
+#define EXTI_PR_PR9               EXTI_PR_PR9_Msk                              /*!< Pending bit for line 9 */
+#define EXTI_PR_PR10_Pos          (10U)                                        
+#define EXTI_PR_PR10_Msk          (0x1UL << EXTI_PR_PR10_Pos)                   /*!< 0x00000400 */
+#define EXTI_PR_PR10              EXTI_PR_PR10_Msk                             /*!< Pending bit for line 10 */
+#define EXTI_PR_PR11_Pos          (11U)                                        
+#define EXTI_PR_PR11_Msk          (0x1UL << EXTI_PR_PR11_Pos)                   /*!< 0x00000800 */
+#define EXTI_PR_PR11              EXTI_PR_PR11_Msk                             /*!< Pending bit for line 11 */
+#define EXTI_PR_PR12_Pos          (12U)                                        
+#define EXTI_PR_PR12_Msk          (0x1UL << EXTI_PR_PR12_Pos)                   /*!< 0x00001000 */
+#define EXTI_PR_PR12              EXTI_PR_PR12_Msk                             /*!< Pending bit for line 12 */
+#define EXTI_PR_PR13_Pos          (13U)                                        
+#define EXTI_PR_PR13_Msk          (0x1UL << EXTI_PR_PR13_Pos)                   /*!< 0x00002000 */
+#define EXTI_PR_PR13              EXTI_PR_PR13_Msk                             /*!< Pending bit for line 13 */
+#define EXTI_PR_PR14_Pos          (14U)                                        
+#define EXTI_PR_PR14_Msk          (0x1UL << EXTI_PR_PR14_Pos)                   /*!< 0x00004000 */
+#define EXTI_PR_PR14              EXTI_PR_PR14_Msk                             /*!< Pending bit for line 14 */
+#define EXTI_PR_PR15_Pos          (15U)                                        
+#define EXTI_PR_PR15_Msk          (0x1UL << EXTI_PR_PR15_Pos)                   /*!< 0x00008000 */
+#define EXTI_PR_PR15              EXTI_PR_PR15_Msk                             /*!< Pending bit for line 15 */
+#define EXTI_PR_PR16_Pos          (16U)                                        
+#define EXTI_PR_PR16_Msk          (0x1UL << EXTI_PR_PR16_Pos)                   /*!< 0x00010000 */
+#define EXTI_PR_PR16              EXTI_PR_PR16_Msk                             /*!< Pending bit for line 16 */
+#define EXTI_PR_PR17_Pos          (17U)                                        
+#define EXTI_PR_PR17_Msk          (0x1UL << EXTI_PR_PR17_Pos)                   /*!< 0x00020000 */
+#define EXTI_PR_PR17              EXTI_PR_PR17_Msk                             /*!< Pending bit for line 17 */
+#define EXTI_PR_PR18_Pos          (18U)                                        
+#define EXTI_PR_PR18_Msk          (0x1UL << EXTI_PR_PR18_Pos)                   /*!< 0x00040000 */
+#define EXTI_PR_PR18              EXTI_PR_PR18_Msk                             /*!< Pending bit for line 18 */
+#define EXTI_PR_PR19_Pos          (19U)                                        
+#define EXTI_PR_PR19_Msk          (0x1UL << EXTI_PR_PR19_Pos)                   /*!< 0x00080000 */
+#define EXTI_PR_PR19              EXTI_PR_PR19_Msk                             /*!< Pending bit for line 19 */
+#define EXTI_PR_PR20_Pos          (20U)                                        
+#define EXTI_PR_PR20_Msk          (0x1UL << EXTI_PR_PR20_Pos)                   /*!< 0x00100000 */
+#define EXTI_PR_PR20              EXTI_PR_PR20_Msk                             /*!< Pending bit for line 20 */
+#define EXTI_PR_PR21_Pos          (21U)                                        
+#define EXTI_PR_PR21_Msk          (0x1UL << EXTI_PR_PR21_Pos)                   /*!< 0x00200000 */
+#define EXTI_PR_PR21              EXTI_PR_PR21_Msk                             /*!< Pending bit for line 21 */
+#define EXTI_PR_PR22_Pos          (22U)                                        
+#define EXTI_PR_PR22_Msk          (0x1UL << EXTI_PR_PR22_Pos)                   /*!< 0x00400000 */
+#define EXTI_PR_PR22              EXTI_PR_PR22_Msk                             /*!< Pending bit for line 22 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos          (0U)
+#define FLASH_ACR_LATENCY_Msk          (0x7UL << FLASH_ACR_LATENCY_Pos)         /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY              FLASH_ACR_LATENCY_Msk
+#define FLASH_ACR_LATENCY_0WS          0x00000000U
+#define FLASH_ACR_LATENCY_1WS          0x00000001U
+#define FLASH_ACR_LATENCY_2WS          0x00000002U
+#define FLASH_ACR_LATENCY_3WS          0x00000003U
+#define FLASH_ACR_LATENCY_4WS          0x00000004U
+#define FLASH_ACR_LATENCY_5WS          0x00000005U
+#define FLASH_ACR_LATENCY_6WS          0x00000006U
+#define FLASH_ACR_LATENCY_7WS          0x00000007U
+
+
+#define FLASH_ACR_PRFTEN_Pos           (8U)                                    
+#define FLASH_ACR_PRFTEN_Msk           (0x1UL << FLASH_ACR_PRFTEN_Pos)          /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN               FLASH_ACR_PRFTEN_Msk                    
+#define FLASH_ACR_ICEN_Pos             (9U)                                    
+#define FLASH_ACR_ICEN_Msk             (0x1UL << FLASH_ACR_ICEN_Pos)            /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                 FLASH_ACR_ICEN_Msk                      
+#define FLASH_ACR_DCEN_Pos             (10U)                                   
+#define FLASH_ACR_DCEN_Msk             (0x1UL << FLASH_ACR_DCEN_Pos)            /*!< 0x00000400 */
+#define FLASH_ACR_DCEN                 FLASH_ACR_DCEN_Msk                      
+#define FLASH_ACR_ICRST_Pos            (11U)                                   
+#define FLASH_ACR_ICRST_Msk            (0x1UL << FLASH_ACR_ICRST_Pos)           /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                FLASH_ACR_ICRST_Msk                     
+#define FLASH_ACR_DCRST_Pos            (12U)                                   
+#define FLASH_ACR_DCRST_Msk            (0x1UL << FLASH_ACR_DCRST_Pos)           /*!< 0x00001000 */
+#define FLASH_ACR_DCRST                FLASH_ACR_DCRST_Msk                     
+#define FLASH_ACR_BYTE0_ADDRESS_Pos    (10U)                                   
+#define FLASH_ACR_BYTE0_ADDRESS_Msk    (0x10008FUL << FLASH_ACR_BYTE0_ADDRESS_Pos) /*!< 0x40023C00 */
+#define FLASH_ACR_BYTE0_ADDRESS        FLASH_ACR_BYTE0_ADDRESS_Msk             
+#define FLASH_ACR_BYTE2_ADDRESS_Pos    (0U)                                    
+#define FLASH_ACR_BYTE2_ADDRESS_Msk    (0x40023C03UL << FLASH_ACR_BYTE2_ADDRESS_Pos) /*!< 0x40023C03 */
+#define FLASH_ACR_BYTE2_ADDRESS        FLASH_ACR_BYTE2_ADDRESS_Msk             
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos               (0U)                                    
+#define FLASH_SR_EOP_Msk               (0x1UL << FLASH_SR_EOP_Pos)              /*!< 0x00000001 */
+#define FLASH_SR_EOP                   FLASH_SR_EOP_Msk                        
+#define FLASH_SR_SOP_Pos               (1U)                                    
+#define FLASH_SR_SOP_Msk               (0x1UL << FLASH_SR_SOP_Pos)              /*!< 0x00000002 */
+#define FLASH_SR_SOP                   FLASH_SR_SOP_Msk                        
+#define FLASH_SR_WRPERR_Pos            (4U)                                    
+#define FLASH_SR_WRPERR_Msk            (0x1UL << FLASH_SR_WRPERR_Pos)           /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                FLASH_SR_WRPERR_Msk                     
+#define FLASH_SR_PGAERR_Pos            (5U)                                    
+#define FLASH_SR_PGAERR_Msk            (0x1UL << FLASH_SR_PGAERR_Pos)           /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                FLASH_SR_PGAERR_Msk                     
+#define FLASH_SR_PGPERR_Pos            (6U)                                    
+#define FLASH_SR_PGPERR_Msk            (0x1UL << FLASH_SR_PGPERR_Pos)           /*!< 0x00000040 */
+#define FLASH_SR_PGPERR                FLASH_SR_PGPERR_Msk                     
+#define FLASH_SR_PGSERR_Pos            (7U)                                    
+#define FLASH_SR_PGSERR_Msk            (0x1UL << FLASH_SR_PGSERR_Pos)           /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                FLASH_SR_PGSERR_Msk                     
+#define FLASH_SR_RDERR_Pos            (8U)                                    
+#define FLASH_SR_RDERR_Msk            (0x1UL << FLASH_SR_RDERR_Pos)             /*!< 0x00000100 */
+#define FLASH_SR_RDERR                FLASH_SR_RDERR_Msk                     
+#define FLASH_SR_BSY_Pos               (16U)                                   
+#define FLASH_SR_BSY_Msk               (0x1UL << FLASH_SR_BSY_Pos)              /*!< 0x00010000 */
+#define FLASH_SR_BSY                   FLASH_SR_BSY_Msk                        
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                (0U)                                    
+#define FLASH_CR_PG_Msk                (0x1UL << FLASH_CR_PG_Pos)               /*!< 0x00000001 */
+#define FLASH_CR_PG                    FLASH_CR_PG_Msk                         
+#define FLASH_CR_SER_Pos               (1U)                                    
+#define FLASH_CR_SER_Msk               (0x1UL << FLASH_CR_SER_Pos)              /*!< 0x00000002 */
+#define FLASH_CR_SER                   FLASH_CR_SER_Msk                        
+#define FLASH_CR_MER_Pos               (2U)                                    
+#define FLASH_CR_MER_Msk               (0x1UL << FLASH_CR_MER_Pos)              /*!< 0x00000004 */
+#define FLASH_CR_MER                   FLASH_CR_MER_Msk                        
+#define FLASH_CR_SNB_Pos               (3U)                                    
+#define FLASH_CR_SNB_Msk               (0x1FUL << FLASH_CR_SNB_Pos)             /*!< 0x000000F8 */
+#define FLASH_CR_SNB                   FLASH_CR_SNB_Msk                        
+#define FLASH_CR_SNB_0                 (0x01UL << FLASH_CR_SNB_Pos)             /*!< 0x00000008 */
+#define FLASH_CR_SNB_1                 (0x02UL << FLASH_CR_SNB_Pos)             /*!< 0x00000010 */
+#define FLASH_CR_SNB_2                 (0x04UL << FLASH_CR_SNB_Pos)             /*!< 0x00000020 */
+#define FLASH_CR_SNB_3                 (0x08UL << FLASH_CR_SNB_Pos)             /*!< 0x00000040 */
+#define FLASH_CR_SNB_4                 (0x10UL << FLASH_CR_SNB_Pos)             /*!< 0x00000080 */
+#define FLASH_CR_PSIZE_Pos             (8U)                                    
+#define FLASH_CR_PSIZE_Msk             (0x3UL << FLASH_CR_PSIZE_Pos)            /*!< 0x00000300 */
+#define FLASH_CR_PSIZE                 FLASH_CR_PSIZE_Msk                      
+#define FLASH_CR_PSIZE_0               (0x1UL << FLASH_CR_PSIZE_Pos)            /*!< 0x00000100 */
+#define FLASH_CR_PSIZE_1               (0x2UL << FLASH_CR_PSIZE_Pos)            /*!< 0x00000200 */
+#define FLASH_CR_STRT_Pos              (16U)                                   
+#define FLASH_CR_STRT_Msk              (0x1UL << FLASH_CR_STRT_Pos)             /*!< 0x00010000 */
+#define FLASH_CR_STRT                  FLASH_CR_STRT_Msk                       
+#define FLASH_CR_EOPIE_Pos             (24U)                                   
+#define FLASH_CR_EOPIE_Msk             (0x1UL << FLASH_CR_EOPIE_Pos)            /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                 FLASH_CR_EOPIE_Msk                      
+#define FLASH_CR_ERRIE_Pos             (25U)
+#define FLASH_CR_ERRIE_Msk             (0x1UL << FLASH_CR_ERRIE_Pos)
+#define FLASH_CR_ERRIE                 FLASH_CR_ERRIE_Msk
+#define FLASH_CR_LOCK_Pos              (31U)                                   
+#define FLASH_CR_LOCK_Msk              (0x1UL << FLASH_CR_LOCK_Pos)             /*!< 0x80000000 */
+#define FLASH_CR_LOCK                  FLASH_CR_LOCK_Msk                       
+
+/*******************  Bits definition for FLASH_OPTCR register  ***************/
+#define FLASH_OPTCR_OPTLOCK_Pos        (0U)                                    
+#define FLASH_OPTCR_OPTLOCK_Msk        (0x1UL << FLASH_OPTCR_OPTLOCK_Pos)       /*!< 0x00000001 */
+#define FLASH_OPTCR_OPTLOCK            FLASH_OPTCR_OPTLOCK_Msk                 
+#define FLASH_OPTCR_OPTSTRT_Pos        (1U)                                    
+#define FLASH_OPTCR_OPTSTRT_Msk        (0x1UL << FLASH_OPTCR_OPTSTRT_Pos)       /*!< 0x00000002 */
+#define FLASH_OPTCR_OPTSTRT            FLASH_OPTCR_OPTSTRT_Msk                 
+
+#define FLASH_OPTCR_BOR_LEV_0          0x00000004U                             
+#define FLASH_OPTCR_BOR_LEV_1          0x00000008U                             
+#define FLASH_OPTCR_BOR_LEV_Pos        (2U)                                    
+#define FLASH_OPTCR_BOR_LEV_Msk        (0x3UL << FLASH_OPTCR_BOR_LEV_Pos)       /*!< 0x0000000C */
+#define FLASH_OPTCR_BOR_LEV            FLASH_OPTCR_BOR_LEV_Msk                 
+#define FLASH_OPTCR_WDG_SW_Pos         (5U)                                    
+#define FLASH_OPTCR_WDG_SW_Msk         (0x1UL << FLASH_OPTCR_WDG_SW_Pos)        /*!< 0x00000020 */
+#define FLASH_OPTCR_WDG_SW             FLASH_OPTCR_WDG_SW_Msk                  
+#define FLASH_OPTCR_nRST_STOP_Pos      (6U)                                    
+#define FLASH_OPTCR_nRST_STOP_Msk      (0x1UL << FLASH_OPTCR_nRST_STOP_Pos)     /*!< 0x00000040 */
+#define FLASH_OPTCR_nRST_STOP          FLASH_OPTCR_nRST_STOP_Msk               
+#define FLASH_OPTCR_nRST_STDBY_Pos     (7U)                                    
+#define FLASH_OPTCR_nRST_STDBY_Msk     (0x1UL << FLASH_OPTCR_nRST_STDBY_Pos)    /*!< 0x00000080 */
+#define FLASH_OPTCR_nRST_STDBY         FLASH_OPTCR_nRST_STDBY_Msk              
+#define FLASH_OPTCR_RDP_Pos            (8U)                                    
+#define FLASH_OPTCR_RDP_Msk            (0xFFUL << FLASH_OPTCR_RDP_Pos)          /*!< 0x0000FF00 */
+#define FLASH_OPTCR_RDP                FLASH_OPTCR_RDP_Msk                     
+#define FLASH_OPTCR_RDP_0              (0x01UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00000100 */
+#define FLASH_OPTCR_RDP_1              (0x02UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00000200 */
+#define FLASH_OPTCR_RDP_2              (0x04UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00000400 */
+#define FLASH_OPTCR_RDP_3              (0x08UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00000800 */
+#define FLASH_OPTCR_RDP_4              (0x10UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00001000 */
+#define FLASH_OPTCR_RDP_5              (0x20UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00002000 */
+#define FLASH_OPTCR_RDP_6              (0x40UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00004000 */
+#define FLASH_OPTCR_RDP_7              (0x80UL << FLASH_OPTCR_RDP_Pos)          /*!< 0x00008000 */
+#define FLASH_OPTCR_nWRP_Pos           (16U)                                   
+#define FLASH_OPTCR_nWRP_Msk           (0xFFFUL << FLASH_OPTCR_nWRP_Pos)        /*!< 0x0FFF0000 */
+#define FLASH_OPTCR_nWRP               FLASH_OPTCR_nWRP_Msk                    
+#define FLASH_OPTCR_nWRP_0             0x00010000U                             
+#define FLASH_OPTCR_nWRP_1             0x00020000U                             
+#define FLASH_OPTCR_nWRP_2             0x00040000U                             
+#define FLASH_OPTCR_nWRP_3             0x00080000U                             
+#define FLASH_OPTCR_nWRP_4             0x00100000U                             
+#define FLASH_OPTCR_nWRP_5             0x00200000U                             
+#define FLASH_OPTCR_nWRP_6             0x00400000U                             
+#define FLASH_OPTCR_nWRP_7             0x00800000U                             
+#define FLASH_OPTCR_nWRP_8             0x01000000U                             
+#define FLASH_OPTCR_nWRP_9             0x02000000U                             
+#define FLASH_OPTCR_nWRP_10            0x04000000U                             
+#define FLASH_OPTCR_nWRP_11            0x08000000U                             
+                                             
+/******************  Bits definition for FLASH_OPTCR1 register  ***************/
+#define FLASH_OPTCR1_nWRP_Pos          (16U)                                   
+#define FLASH_OPTCR1_nWRP_Msk          (0xFFFUL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x0FFF0000 */
+#define FLASH_OPTCR1_nWRP              FLASH_OPTCR1_nWRP_Msk                   
+#define FLASH_OPTCR1_nWRP_0            (0x001UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00010000 */
+#define FLASH_OPTCR1_nWRP_1            (0x002UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00020000 */
+#define FLASH_OPTCR1_nWRP_2            (0x004UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00040000 */
+#define FLASH_OPTCR1_nWRP_3            (0x008UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00080000 */
+#define FLASH_OPTCR1_nWRP_4            (0x010UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00100000 */
+#define FLASH_OPTCR1_nWRP_5            (0x020UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00200000 */
+#define FLASH_OPTCR1_nWRP_6            (0x040UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00400000 */
+#define FLASH_OPTCR1_nWRP_7            (0x080UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x00800000 */
+#define FLASH_OPTCR1_nWRP_8            (0x100UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x01000000 */
+#define FLASH_OPTCR1_nWRP_9            (0x200UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x02000000 */
+#define FLASH_OPTCR1_nWRP_10           (0x400UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x04000000 */
+#define FLASH_OPTCR1_nWRP_11           (0x800UL << FLASH_OPTCR1_nWRP_Pos)       /*!< 0x08000000 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODER0_Pos            (0U)                                  
+#define GPIO_MODER_MODER0_Msk            (0x3UL << GPIO_MODER_MODER0_Pos)       /*!< 0x00000003 */
+#define GPIO_MODER_MODER0                GPIO_MODER_MODER0_Msk                 
+#define GPIO_MODER_MODER0_0              (0x1UL << GPIO_MODER_MODER0_Pos)       /*!< 0x00000001 */
+#define GPIO_MODER_MODER0_1              (0x2UL << GPIO_MODER_MODER0_Pos)       /*!< 0x00000002 */
+#define GPIO_MODER_MODER1_Pos            (2U)                                  
+#define GPIO_MODER_MODER1_Msk            (0x3UL << GPIO_MODER_MODER1_Pos)       /*!< 0x0000000C */
+#define GPIO_MODER_MODER1                GPIO_MODER_MODER1_Msk                 
+#define GPIO_MODER_MODER1_0              (0x1UL << GPIO_MODER_MODER1_Pos)       /*!< 0x00000004 */
+#define GPIO_MODER_MODER1_1              (0x2UL << GPIO_MODER_MODER1_Pos)       /*!< 0x00000008 */
+#define GPIO_MODER_MODER2_Pos            (4U)                                  
+#define GPIO_MODER_MODER2_Msk            (0x3UL << GPIO_MODER_MODER2_Pos)       /*!< 0x00000030 */
+#define GPIO_MODER_MODER2                GPIO_MODER_MODER2_Msk                 
+#define GPIO_MODER_MODER2_0              (0x1UL << GPIO_MODER_MODER2_Pos)       /*!< 0x00000010 */
+#define GPIO_MODER_MODER2_1              (0x2UL << GPIO_MODER_MODER2_Pos)       /*!< 0x00000020 */
+#define GPIO_MODER_MODER3_Pos            (6U)                                  
+#define GPIO_MODER_MODER3_Msk            (0x3UL << GPIO_MODER_MODER3_Pos)       /*!< 0x000000C0 */
+#define GPIO_MODER_MODER3                GPIO_MODER_MODER3_Msk                 
+#define GPIO_MODER_MODER3_0              (0x1UL << GPIO_MODER_MODER3_Pos)       /*!< 0x00000040 */
+#define GPIO_MODER_MODER3_1              (0x2UL << GPIO_MODER_MODER3_Pos)       /*!< 0x00000080 */
+#define GPIO_MODER_MODER4_Pos            (8U)                                  
+#define GPIO_MODER_MODER4_Msk            (0x3UL << GPIO_MODER_MODER4_Pos)       /*!< 0x00000300 */
+#define GPIO_MODER_MODER4                GPIO_MODER_MODER4_Msk                 
+#define GPIO_MODER_MODER4_0              (0x1UL << GPIO_MODER_MODER4_Pos)       /*!< 0x00000100 */
+#define GPIO_MODER_MODER4_1              (0x2UL << GPIO_MODER_MODER4_Pos)       /*!< 0x00000200 */
+#define GPIO_MODER_MODER5_Pos            (10U)                                 
+#define GPIO_MODER_MODER5_Msk            (0x3UL << GPIO_MODER_MODER5_Pos)       /*!< 0x00000C00 */
+#define GPIO_MODER_MODER5                GPIO_MODER_MODER5_Msk                 
+#define GPIO_MODER_MODER5_0              (0x1UL << GPIO_MODER_MODER5_Pos)       /*!< 0x00000400 */
+#define GPIO_MODER_MODER5_1              (0x2UL << GPIO_MODER_MODER5_Pos)       /*!< 0x00000800 */
+#define GPIO_MODER_MODER6_Pos            (12U)                                 
+#define GPIO_MODER_MODER6_Msk            (0x3UL << GPIO_MODER_MODER6_Pos)       /*!< 0x00003000 */
+#define GPIO_MODER_MODER6                GPIO_MODER_MODER6_Msk                 
+#define GPIO_MODER_MODER6_0              (0x1UL << GPIO_MODER_MODER6_Pos)       /*!< 0x00001000 */
+#define GPIO_MODER_MODER6_1              (0x2UL << GPIO_MODER_MODER6_Pos)       /*!< 0x00002000 */
+#define GPIO_MODER_MODER7_Pos            (14U)                                 
+#define GPIO_MODER_MODER7_Msk            (0x3UL << GPIO_MODER_MODER7_Pos)       /*!< 0x0000C000 */
+#define GPIO_MODER_MODER7                GPIO_MODER_MODER7_Msk                 
+#define GPIO_MODER_MODER7_0              (0x1UL << GPIO_MODER_MODER7_Pos)       /*!< 0x00004000 */
+#define GPIO_MODER_MODER7_1              (0x2UL << GPIO_MODER_MODER7_Pos)       /*!< 0x00008000 */
+#define GPIO_MODER_MODER8_Pos            (16U)                                 
+#define GPIO_MODER_MODER8_Msk            (0x3UL << GPIO_MODER_MODER8_Pos)       /*!< 0x00030000 */
+#define GPIO_MODER_MODER8                GPIO_MODER_MODER8_Msk                 
+#define GPIO_MODER_MODER8_0              (0x1UL << GPIO_MODER_MODER8_Pos)       /*!< 0x00010000 */
+#define GPIO_MODER_MODER8_1              (0x2UL << GPIO_MODER_MODER8_Pos)       /*!< 0x00020000 */
+#define GPIO_MODER_MODER9_Pos            (18U)                                 
+#define GPIO_MODER_MODER9_Msk            (0x3UL << GPIO_MODER_MODER9_Pos)       /*!< 0x000C0000 */
+#define GPIO_MODER_MODER9                GPIO_MODER_MODER9_Msk                 
+#define GPIO_MODER_MODER9_0              (0x1UL << GPIO_MODER_MODER9_Pos)       /*!< 0x00040000 */
+#define GPIO_MODER_MODER9_1              (0x2UL << GPIO_MODER_MODER9_Pos)       /*!< 0x00080000 */
+#define GPIO_MODER_MODER10_Pos           (20U)                                 
+#define GPIO_MODER_MODER10_Msk           (0x3UL << GPIO_MODER_MODER10_Pos)      /*!< 0x00300000 */
+#define GPIO_MODER_MODER10               GPIO_MODER_MODER10_Msk                
+#define GPIO_MODER_MODER10_0             (0x1UL << GPIO_MODER_MODER10_Pos)      /*!< 0x00100000 */
+#define GPIO_MODER_MODER10_1             (0x2UL << GPIO_MODER_MODER10_Pos)      /*!< 0x00200000 */
+#define GPIO_MODER_MODER11_Pos           (22U)                                 
+#define GPIO_MODER_MODER11_Msk           (0x3UL << GPIO_MODER_MODER11_Pos)      /*!< 0x00C00000 */
+#define GPIO_MODER_MODER11               GPIO_MODER_MODER11_Msk                
+#define GPIO_MODER_MODER11_0             (0x1UL << GPIO_MODER_MODER11_Pos)      /*!< 0x00400000 */
+#define GPIO_MODER_MODER11_1             (0x2UL << GPIO_MODER_MODER11_Pos)      /*!< 0x00800000 */
+#define GPIO_MODER_MODER12_Pos           (24U)                                 
+#define GPIO_MODER_MODER12_Msk           (0x3UL << GPIO_MODER_MODER12_Pos)      /*!< 0x03000000 */
+#define GPIO_MODER_MODER12               GPIO_MODER_MODER12_Msk                
+#define GPIO_MODER_MODER12_0             (0x1UL << GPIO_MODER_MODER12_Pos)      /*!< 0x01000000 */
+#define GPIO_MODER_MODER12_1             (0x2UL << GPIO_MODER_MODER12_Pos)      /*!< 0x02000000 */
+#define GPIO_MODER_MODER13_Pos           (26U)                                 
+#define GPIO_MODER_MODER13_Msk           (0x3UL << GPIO_MODER_MODER13_Pos)      /*!< 0x0C000000 */
+#define GPIO_MODER_MODER13               GPIO_MODER_MODER13_Msk                
+#define GPIO_MODER_MODER13_0             (0x1UL << GPIO_MODER_MODER13_Pos)      /*!< 0x04000000 */
+#define GPIO_MODER_MODER13_1             (0x2UL << GPIO_MODER_MODER13_Pos)      /*!< 0x08000000 */
+#define GPIO_MODER_MODER14_Pos           (28U)                                 
+#define GPIO_MODER_MODER14_Msk           (0x3UL << GPIO_MODER_MODER14_Pos)      /*!< 0x30000000 */
+#define GPIO_MODER_MODER14               GPIO_MODER_MODER14_Msk                
+#define GPIO_MODER_MODER14_0             (0x1UL << GPIO_MODER_MODER14_Pos)      /*!< 0x10000000 */
+#define GPIO_MODER_MODER14_1             (0x2UL << GPIO_MODER_MODER14_Pos)      /*!< 0x20000000 */
+#define GPIO_MODER_MODER15_Pos           (30U)                                 
+#define GPIO_MODER_MODER15_Msk           (0x3UL << GPIO_MODER_MODER15_Pos)      /*!< 0xC0000000 */
+#define GPIO_MODER_MODER15               GPIO_MODER_MODER15_Msk                
+#define GPIO_MODER_MODER15_0             (0x1UL << GPIO_MODER_MODER15_Pos)      /*!< 0x40000000 */
+#define GPIO_MODER_MODER15_1             (0x2UL << GPIO_MODER_MODER15_Pos)      /*!< 0x80000000 */
+
+/* Legacy defines */
+#define GPIO_MODER_MODE0_Pos             GPIO_MODER_MODER0_Pos                                  
+#define GPIO_MODER_MODE0_Msk             GPIO_MODER_MODER0_Msk
+#define GPIO_MODER_MODE0                 GPIO_MODER_MODER0                 
+#define GPIO_MODER_MODE0_0               GPIO_MODER_MODER0_0
+#define GPIO_MODER_MODE0_1               GPIO_MODER_MODER0_1
+#define GPIO_MODER_MODE1_Pos             GPIO_MODER_MODER1_Pos                                  
+#define GPIO_MODER_MODE1_Msk             GPIO_MODER_MODER1_Msk
+#define GPIO_MODER_MODE1                 GPIO_MODER_MODER1                  
+#define GPIO_MODER_MODE1_0               GPIO_MODER_MODER1_0
+#define GPIO_MODER_MODE1_1               GPIO_MODER_MODER1_1
+#define GPIO_MODER_MODE2_Pos             GPIO_MODER_MODER2_Pos
+#define GPIO_MODER_MODE2_Msk             GPIO_MODER_MODER2_Msk
+#define GPIO_MODER_MODE2                 GPIO_MODER_MODER2                 
+#define GPIO_MODER_MODE2_0               GPIO_MODER_MODER2_0
+#define GPIO_MODER_MODE2_1               GPIO_MODER_MODER2_1
+#define GPIO_MODER_MODE3_Pos             GPIO_MODER_MODER3_Pos                                
+#define GPIO_MODER_MODE3_Msk             GPIO_MODER_MODER3_Msk
+#define GPIO_MODER_MODE3                 GPIO_MODER_MODER3
+#define GPIO_MODER_MODE3_0               GPIO_MODER_MODER3_0
+#define GPIO_MODER_MODE3_1               GPIO_MODER_MODER3_1
+#define GPIO_MODER_MODE4_Pos             GPIO_MODER_MODER4_Pos
+#define GPIO_MODER_MODE4_Msk             GPIO_MODER_MODER4_Msk
+#define GPIO_MODER_MODE4                 GPIO_MODER_MODER4
+#define GPIO_MODER_MODE4_0               GPIO_MODER_MODER4_0
+#define GPIO_MODER_MODE4_1               GPIO_MODER_MODER4_1
+#define GPIO_MODER_MODE5_Pos             GPIO_MODER_MODER5_Pos
+#define GPIO_MODER_MODE5_Msk             GPIO_MODER_MODER5_Msk
+#define GPIO_MODER_MODE5                 GPIO_MODER_MODER5
+#define GPIO_MODER_MODE5_0               GPIO_MODER_MODER5_0
+#define GPIO_MODER_MODE5_1               GPIO_MODER_MODER5_1
+#define GPIO_MODER_MODE6_Pos             GPIO_MODER_MODER6_Pos
+#define GPIO_MODER_MODE6_Msk             GPIO_MODER_MODER6_Msk
+#define GPIO_MODER_MODE6                 GPIO_MODER_MODER6
+#define GPIO_MODER_MODE6_0               GPIO_MODER_MODER6_0
+#define GPIO_MODER_MODE6_1               GPIO_MODER_MODER6_1
+#define GPIO_MODER_MODE7_Pos             GPIO_MODER_MODER7_Pos
+#define GPIO_MODER_MODE7_Msk             GPIO_MODER_MODER7_Msk
+#define GPIO_MODER_MODE7                 GPIO_MODER_MODER7
+#define GPIO_MODER_MODE7_0               GPIO_MODER_MODER7_0
+#define GPIO_MODER_MODE7_1               GPIO_MODER_MODER7_1
+#define GPIO_MODER_MODE8_Pos             GPIO_MODER_MODER8_Pos
+#define GPIO_MODER_MODE8_Msk             GPIO_MODER_MODER8_Msk
+#define GPIO_MODER_MODE8                 GPIO_MODER_MODER8
+#define GPIO_MODER_MODE8_0               GPIO_MODER_MODER8_0
+#define GPIO_MODER_MODE8_1               GPIO_MODER_MODER8_1
+#define GPIO_MODER_MODE9_Pos             GPIO_MODER_MODER9_Pos
+#define GPIO_MODER_MODE9_Msk             GPIO_MODER_MODER9_Msk
+#define GPIO_MODER_MODE9                 GPIO_MODER_MODER9
+#define GPIO_MODER_MODE9_0               GPIO_MODER_MODER9_0
+#define GPIO_MODER_MODE9_1               GPIO_MODER_MODER9_1
+#define GPIO_MODER_MODE10_Pos            GPIO_MODER_MODER10_Pos
+#define GPIO_MODER_MODE10_Msk            GPIO_MODER_MODER10_Msk
+#define GPIO_MODER_MODE10                GPIO_MODER_MODER10
+#define GPIO_MODER_MODE10_0              GPIO_MODER_MODER10_0
+#define GPIO_MODER_MODE10_1              GPIO_MODER_MODER10_1
+#define GPIO_MODER_MODE11_Pos            GPIO_MODER_MODER11_Pos
+#define GPIO_MODER_MODE11_Msk            GPIO_MODER_MODER11_Msk
+#define GPIO_MODER_MODE11                GPIO_MODER_MODER11
+#define GPIO_MODER_MODE11_0              GPIO_MODER_MODER11_0
+#define GPIO_MODER_MODE11_1              GPIO_MODER_MODER11_1
+#define GPIO_MODER_MODE12_Pos            GPIO_MODER_MODER12_Pos
+#define GPIO_MODER_MODE12_Msk            GPIO_MODER_MODER12_Msk
+#define GPIO_MODER_MODE12                GPIO_MODER_MODER12
+#define GPIO_MODER_MODE12_0              GPIO_MODER_MODER12_0
+#define GPIO_MODER_MODE12_1              GPIO_MODER_MODER12_1
+#define GPIO_MODER_MODE13_Pos            GPIO_MODER_MODER13_Pos
+#define GPIO_MODER_MODE13_Msk            GPIO_MODER_MODER13_Msk
+#define GPIO_MODER_MODE13                GPIO_MODER_MODER13
+#define GPIO_MODER_MODE13_0              GPIO_MODER_MODER13_0
+#define GPIO_MODER_MODE13_1              GPIO_MODER_MODER13_1
+#define GPIO_MODER_MODE14_Pos            GPIO_MODER_MODER14_Pos
+#define GPIO_MODER_MODE14_Msk            GPIO_MODER_MODER14_Msk
+#define GPIO_MODER_MODE14                GPIO_MODER_MODER14
+#define GPIO_MODER_MODE14_0              GPIO_MODER_MODER14_0
+#define GPIO_MODER_MODE14_1              GPIO_MODER_MODER14_1
+#define GPIO_MODER_MODE15_Pos            GPIO_MODER_MODER15_Pos
+#define GPIO_MODER_MODE15_Msk            GPIO_MODER_MODER15_Msk
+#define GPIO_MODER_MODE15                GPIO_MODER_MODER15
+#define GPIO_MODER_MODE15_0              GPIO_MODER_MODER15_0
+#define GPIO_MODER_MODE15_1              GPIO_MODER_MODER15_1
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos              (0U)                                  
+#define GPIO_OTYPER_OT0_Msk              (0x1UL << GPIO_OTYPER_OT0_Pos)         /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                  GPIO_OTYPER_OT0_Msk                   
+#define GPIO_OTYPER_OT1_Pos              (1U)                                  
+#define GPIO_OTYPER_OT1_Msk              (0x1UL << GPIO_OTYPER_OT1_Pos)         /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                  GPIO_OTYPER_OT1_Msk                   
+#define GPIO_OTYPER_OT2_Pos              (2U)                                  
+#define GPIO_OTYPER_OT2_Msk              (0x1UL << GPIO_OTYPER_OT2_Pos)         /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                  GPIO_OTYPER_OT2_Msk                   
+#define GPIO_OTYPER_OT3_Pos              (3U)                                  
+#define GPIO_OTYPER_OT3_Msk              (0x1UL << GPIO_OTYPER_OT3_Pos)         /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                  GPIO_OTYPER_OT3_Msk                   
+#define GPIO_OTYPER_OT4_Pos              (4U)                                  
+#define GPIO_OTYPER_OT4_Msk              (0x1UL << GPIO_OTYPER_OT4_Pos)         /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                  GPIO_OTYPER_OT4_Msk                   
+#define GPIO_OTYPER_OT5_Pos              (5U)                                  
+#define GPIO_OTYPER_OT5_Msk              (0x1UL << GPIO_OTYPER_OT5_Pos)         /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                  GPIO_OTYPER_OT5_Msk                   
+#define GPIO_OTYPER_OT6_Pos              (6U)                                  
+#define GPIO_OTYPER_OT6_Msk              (0x1UL << GPIO_OTYPER_OT6_Pos)         /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                  GPIO_OTYPER_OT6_Msk                   
+#define GPIO_OTYPER_OT7_Pos              (7U)                                  
+#define GPIO_OTYPER_OT7_Msk              (0x1UL << GPIO_OTYPER_OT7_Pos)         /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                  GPIO_OTYPER_OT7_Msk                   
+#define GPIO_OTYPER_OT8_Pos              (8U)                                  
+#define GPIO_OTYPER_OT8_Msk              (0x1UL << GPIO_OTYPER_OT8_Pos)         /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                  GPIO_OTYPER_OT8_Msk                   
+#define GPIO_OTYPER_OT9_Pos              (9U)                                  
+#define GPIO_OTYPER_OT9_Msk              (0x1UL << GPIO_OTYPER_OT9_Pos)         /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                  GPIO_OTYPER_OT9_Msk                   
+#define GPIO_OTYPER_OT10_Pos             (10U)                                 
+#define GPIO_OTYPER_OT10_Msk             (0x1UL << GPIO_OTYPER_OT10_Pos)        /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10                 GPIO_OTYPER_OT10_Msk                  
+#define GPIO_OTYPER_OT11_Pos             (11U)                                 
+#define GPIO_OTYPER_OT11_Msk             (0x1UL << GPIO_OTYPER_OT11_Pos)        /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11                 GPIO_OTYPER_OT11_Msk                  
+#define GPIO_OTYPER_OT12_Pos             (12U)                                 
+#define GPIO_OTYPER_OT12_Msk             (0x1UL << GPIO_OTYPER_OT12_Pos)        /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12                 GPIO_OTYPER_OT12_Msk                  
+#define GPIO_OTYPER_OT13_Pos             (13U)                                 
+#define GPIO_OTYPER_OT13_Msk             (0x1UL << GPIO_OTYPER_OT13_Pos)        /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13                 GPIO_OTYPER_OT13_Msk                  
+#define GPIO_OTYPER_OT14_Pos             (14U)                                 
+#define GPIO_OTYPER_OT14_Msk             (0x1UL << GPIO_OTYPER_OT14_Pos)        /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14                 GPIO_OTYPER_OT14_Msk                  
+#define GPIO_OTYPER_OT15_Pos             (15U)                                 
+#define GPIO_OTYPER_OT15_Msk             (0x1UL << GPIO_OTYPER_OT15_Pos)        /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15                 GPIO_OTYPER_OT15_Msk                  
+
+/* Legacy defines */
+#define GPIO_OTYPER_OT_0                 GPIO_OTYPER_OT0
+#define GPIO_OTYPER_OT_1                 GPIO_OTYPER_OT1
+#define GPIO_OTYPER_OT_2                 GPIO_OTYPER_OT2
+#define GPIO_OTYPER_OT_3                 GPIO_OTYPER_OT3
+#define GPIO_OTYPER_OT_4                 GPIO_OTYPER_OT4
+#define GPIO_OTYPER_OT_5                 GPIO_OTYPER_OT5
+#define GPIO_OTYPER_OT_6                 GPIO_OTYPER_OT6
+#define GPIO_OTYPER_OT_7                 GPIO_OTYPER_OT7
+#define GPIO_OTYPER_OT_8                 GPIO_OTYPER_OT8
+#define GPIO_OTYPER_OT_9                 GPIO_OTYPER_OT9
+#define GPIO_OTYPER_OT_10                GPIO_OTYPER_OT10
+#define GPIO_OTYPER_OT_11                GPIO_OTYPER_OT11
+#define GPIO_OTYPER_OT_12                GPIO_OTYPER_OT12
+#define GPIO_OTYPER_OT_13                GPIO_OTYPER_OT13
+#define GPIO_OTYPER_OT_14                GPIO_OTYPER_OT14
+#define GPIO_OTYPER_OT_15                GPIO_OTYPER_OT15
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos         (0U)                                  
+#define GPIO_OSPEEDR_OSPEED0_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)    /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0             GPIO_OSPEEDR_OSPEED0_Msk              
+#define GPIO_OSPEEDR_OSPEED0_0           (0x1UL << GPIO_OSPEEDR_OSPEED0_Pos)    /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1           (0x2UL << GPIO_OSPEEDR_OSPEED0_Pos)    /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos         (2U)                                  
+#define GPIO_OSPEEDR_OSPEED1_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)    /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1             GPIO_OSPEEDR_OSPEED1_Msk              
+#define GPIO_OSPEEDR_OSPEED1_0           (0x1UL << GPIO_OSPEEDR_OSPEED1_Pos)    /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1           (0x2UL << GPIO_OSPEEDR_OSPEED1_Pos)    /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos         (4U)                                  
+#define GPIO_OSPEEDR_OSPEED2_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)    /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2             GPIO_OSPEEDR_OSPEED2_Msk              
+#define GPIO_OSPEEDR_OSPEED2_0           (0x1UL << GPIO_OSPEEDR_OSPEED2_Pos)    /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1           (0x2UL << GPIO_OSPEEDR_OSPEED2_Pos)    /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos         (6U)                                  
+#define GPIO_OSPEEDR_OSPEED3_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)    /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3             GPIO_OSPEEDR_OSPEED3_Msk              
+#define GPIO_OSPEEDR_OSPEED3_0           (0x1UL << GPIO_OSPEEDR_OSPEED3_Pos)    /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1           (0x2UL << GPIO_OSPEEDR_OSPEED3_Pos)    /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos         (8U)                                  
+#define GPIO_OSPEEDR_OSPEED4_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)    /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4             GPIO_OSPEEDR_OSPEED4_Msk              
+#define GPIO_OSPEEDR_OSPEED4_0           (0x1UL << GPIO_OSPEEDR_OSPEED4_Pos)    /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1           (0x2UL << GPIO_OSPEEDR_OSPEED4_Pos)    /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos         (10U)                                 
+#define GPIO_OSPEEDR_OSPEED5_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)    /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5             GPIO_OSPEEDR_OSPEED5_Msk              
+#define GPIO_OSPEEDR_OSPEED5_0           (0x1UL << GPIO_OSPEEDR_OSPEED5_Pos)    /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1           (0x2UL << GPIO_OSPEEDR_OSPEED5_Pos)    /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos         (12U)                                 
+#define GPIO_OSPEEDR_OSPEED6_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)    /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6             GPIO_OSPEEDR_OSPEED6_Msk              
+#define GPIO_OSPEEDR_OSPEED6_0           (0x1UL << GPIO_OSPEEDR_OSPEED6_Pos)    /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1           (0x2UL << GPIO_OSPEEDR_OSPEED6_Pos)    /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos         (14U)                                 
+#define GPIO_OSPEEDR_OSPEED7_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)    /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7             GPIO_OSPEEDR_OSPEED7_Msk              
+#define GPIO_OSPEEDR_OSPEED7_0           (0x1UL << GPIO_OSPEEDR_OSPEED7_Pos)    /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1           (0x2UL << GPIO_OSPEEDR_OSPEED7_Pos)    /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos         (16U)                                 
+#define GPIO_OSPEEDR_OSPEED8_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)    /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8             GPIO_OSPEEDR_OSPEED8_Msk              
+#define GPIO_OSPEEDR_OSPEED8_0           (0x1UL << GPIO_OSPEEDR_OSPEED8_Pos)    /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1           (0x2UL << GPIO_OSPEEDR_OSPEED8_Pos)    /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos         (18U)                                 
+#define GPIO_OSPEEDR_OSPEED9_Msk         (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)    /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9             GPIO_OSPEEDR_OSPEED9_Msk              
+#define GPIO_OSPEEDR_OSPEED9_0           (0x1UL << GPIO_OSPEEDR_OSPEED9_Pos)    /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1           (0x2UL << GPIO_OSPEEDR_OSPEED9_Pos)    /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos        (20U)                                 
+#define GPIO_OSPEEDR_OSPEED10_Msk        (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)   /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10            GPIO_OSPEEDR_OSPEED10_Msk             
+#define GPIO_OSPEEDR_OSPEED10_0          (0x1UL << GPIO_OSPEEDR_OSPEED10_Pos)   /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1          (0x2UL << GPIO_OSPEEDR_OSPEED10_Pos)   /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos        (22U)                                 
+#define GPIO_OSPEEDR_OSPEED11_Msk        (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)   /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11            GPIO_OSPEEDR_OSPEED11_Msk             
+#define GPIO_OSPEEDR_OSPEED11_0          (0x1UL << GPIO_OSPEEDR_OSPEED11_Pos)   /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1          (0x2UL << GPIO_OSPEEDR_OSPEED11_Pos)   /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos        (24U)                                 
+#define GPIO_OSPEEDR_OSPEED12_Msk        (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)   /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12            GPIO_OSPEEDR_OSPEED12_Msk             
+#define GPIO_OSPEEDR_OSPEED12_0          (0x1UL << GPIO_OSPEEDR_OSPEED12_Pos)   /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1          (0x2UL << GPIO_OSPEEDR_OSPEED12_Pos)   /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos        (26U)                                 
+#define GPIO_OSPEEDR_OSPEED13_Msk        (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)   /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13            GPIO_OSPEEDR_OSPEED13_Msk             
+#define GPIO_OSPEEDR_OSPEED13_0          (0x1UL << GPIO_OSPEEDR_OSPEED13_Pos)   /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1          (0x2UL << GPIO_OSPEEDR_OSPEED13_Pos)   /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos        (28U)                                 
+#define GPIO_OSPEEDR_OSPEED14_Msk        (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)   /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14            GPIO_OSPEEDR_OSPEED14_Msk             
+#define GPIO_OSPEEDR_OSPEED14_0          (0x1UL << GPIO_OSPEEDR_OSPEED14_Pos)   /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1          (0x2UL << GPIO_OSPEEDR_OSPEED14_Pos)   /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos        (30U)                                 
+#define GPIO_OSPEEDR_OSPEED15_Msk        (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)   /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15            GPIO_OSPEEDR_OSPEED15_Msk             
+#define GPIO_OSPEEDR_OSPEED15_0          (0x1UL << GPIO_OSPEEDR_OSPEED15_Pos)   /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1          (0x2UL << GPIO_OSPEEDR_OSPEED15_Pos)   /*!< 0x80000000 */
+
+/* Legacy defines */
+#define GPIO_OSPEEDER_OSPEEDR0           GPIO_OSPEEDR_OSPEED0
+#define GPIO_OSPEEDER_OSPEEDR0_0         GPIO_OSPEEDR_OSPEED0_0
+#define GPIO_OSPEEDER_OSPEEDR0_1         GPIO_OSPEEDR_OSPEED0_1
+#define GPIO_OSPEEDER_OSPEEDR1           GPIO_OSPEEDR_OSPEED1
+#define GPIO_OSPEEDER_OSPEEDR1_0         GPIO_OSPEEDR_OSPEED1_0
+#define GPIO_OSPEEDER_OSPEEDR1_1         GPIO_OSPEEDR_OSPEED1_1
+#define GPIO_OSPEEDER_OSPEEDR2           GPIO_OSPEEDR_OSPEED2
+#define GPIO_OSPEEDER_OSPEEDR2_0         GPIO_OSPEEDR_OSPEED2_0
+#define GPIO_OSPEEDER_OSPEEDR2_1         GPIO_OSPEEDR_OSPEED2_1
+#define GPIO_OSPEEDER_OSPEEDR3           GPIO_OSPEEDR_OSPEED3
+#define GPIO_OSPEEDER_OSPEEDR3_0         GPIO_OSPEEDR_OSPEED3_0
+#define GPIO_OSPEEDER_OSPEEDR3_1         GPIO_OSPEEDR_OSPEED3_1
+#define GPIO_OSPEEDER_OSPEEDR4           GPIO_OSPEEDR_OSPEED4
+#define GPIO_OSPEEDER_OSPEEDR4_0         GPIO_OSPEEDR_OSPEED4_0
+#define GPIO_OSPEEDER_OSPEEDR4_1         GPIO_OSPEEDR_OSPEED4_1
+#define GPIO_OSPEEDER_OSPEEDR5           GPIO_OSPEEDR_OSPEED5
+#define GPIO_OSPEEDER_OSPEEDR5_0         GPIO_OSPEEDR_OSPEED5_0
+#define GPIO_OSPEEDER_OSPEEDR5_1         GPIO_OSPEEDR_OSPEED5_1
+#define GPIO_OSPEEDER_OSPEEDR6           GPIO_OSPEEDR_OSPEED6
+#define GPIO_OSPEEDER_OSPEEDR6_0         GPIO_OSPEEDR_OSPEED6_0
+#define GPIO_OSPEEDER_OSPEEDR6_1         GPIO_OSPEEDR_OSPEED6_1
+#define GPIO_OSPEEDER_OSPEEDR7           GPIO_OSPEEDR_OSPEED7
+#define GPIO_OSPEEDER_OSPEEDR7_0         GPIO_OSPEEDR_OSPEED7_0
+#define GPIO_OSPEEDER_OSPEEDR7_1         GPIO_OSPEEDR_OSPEED7_1
+#define GPIO_OSPEEDER_OSPEEDR8           GPIO_OSPEEDR_OSPEED8
+#define GPIO_OSPEEDER_OSPEEDR8_0         GPIO_OSPEEDR_OSPEED8_0
+#define GPIO_OSPEEDER_OSPEEDR8_1         GPIO_OSPEEDR_OSPEED8_1
+#define GPIO_OSPEEDER_OSPEEDR9           GPIO_OSPEEDR_OSPEED9
+#define GPIO_OSPEEDER_OSPEEDR9_0         GPIO_OSPEEDR_OSPEED9_0
+#define GPIO_OSPEEDER_OSPEEDR9_1         GPIO_OSPEEDR_OSPEED9_1
+#define GPIO_OSPEEDER_OSPEEDR10          GPIO_OSPEEDR_OSPEED10
+#define GPIO_OSPEEDER_OSPEEDR10_0        GPIO_OSPEEDR_OSPEED10_0
+#define GPIO_OSPEEDER_OSPEEDR10_1        GPIO_OSPEEDR_OSPEED10_1
+#define GPIO_OSPEEDER_OSPEEDR11          GPIO_OSPEEDR_OSPEED11
+#define GPIO_OSPEEDER_OSPEEDR11_0        GPIO_OSPEEDR_OSPEED11_0
+#define GPIO_OSPEEDER_OSPEEDR11_1        GPIO_OSPEEDR_OSPEED11_1
+#define GPIO_OSPEEDER_OSPEEDR12          GPIO_OSPEEDR_OSPEED12
+#define GPIO_OSPEEDER_OSPEEDR12_0        GPIO_OSPEEDR_OSPEED12_0
+#define GPIO_OSPEEDER_OSPEEDR12_1        GPIO_OSPEEDR_OSPEED12_1
+#define GPIO_OSPEEDER_OSPEEDR13          GPIO_OSPEEDR_OSPEED13
+#define GPIO_OSPEEDER_OSPEEDR13_0        GPIO_OSPEEDR_OSPEED13_0
+#define GPIO_OSPEEDER_OSPEEDR13_1        GPIO_OSPEEDR_OSPEED13_1
+#define GPIO_OSPEEDER_OSPEEDR14          GPIO_OSPEEDR_OSPEED14
+#define GPIO_OSPEEDER_OSPEEDR14_0        GPIO_OSPEEDR_OSPEED14_0
+#define GPIO_OSPEEDER_OSPEEDR14_1        GPIO_OSPEEDR_OSPEED14_1
+#define GPIO_OSPEEDER_OSPEEDR15          GPIO_OSPEEDR_OSPEED15
+#define GPIO_OSPEEDER_OSPEEDR15_0        GPIO_OSPEEDR_OSPEED15_0
+#define GPIO_OSPEEDER_OSPEEDR15_1        GPIO_OSPEEDR_OSPEED15_1
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos             (0U)                                  
+#define GPIO_PUPDR_PUPD0_Msk             (0x3UL << GPIO_PUPDR_PUPD0_Pos)        /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0                 GPIO_PUPDR_PUPD0_Msk                  
+#define GPIO_PUPDR_PUPD0_0               (0x1UL << GPIO_PUPDR_PUPD0_Pos)        /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1               (0x2UL << GPIO_PUPDR_PUPD0_Pos)        /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos             (2U)                                  
+#define GPIO_PUPDR_PUPD1_Msk             (0x3UL << GPIO_PUPDR_PUPD1_Pos)        /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1                 GPIO_PUPDR_PUPD1_Msk                  
+#define GPIO_PUPDR_PUPD1_0               (0x1UL << GPIO_PUPDR_PUPD1_Pos)        /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1               (0x2UL << GPIO_PUPDR_PUPD1_Pos)        /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos             (4U)                                  
+#define GPIO_PUPDR_PUPD2_Msk             (0x3UL << GPIO_PUPDR_PUPD2_Pos)        /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2                 GPIO_PUPDR_PUPD2_Msk                  
+#define GPIO_PUPDR_PUPD2_0               (0x1UL << GPIO_PUPDR_PUPD2_Pos)        /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1               (0x2UL << GPIO_PUPDR_PUPD2_Pos)        /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos             (6U)                                  
+#define GPIO_PUPDR_PUPD3_Msk             (0x3UL << GPIO_PUPDR_PUPD3_Pos)        /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3                 GPIO_PUPDR_PUPD3_Msk                  
+#define GPIO_PUPDR_PUPD3_0               (0x1UL << GPIO_PUPDR_PUPD3_Pos)        /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1               (0x2UL << GPIO_PUPDR_PUPD3_Pos)        /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos             (8U)                                  
+#define GPIO_PUPDR_PUPD4_Msk             (0x3UL << GPIO_PUPDR_PUPD4_Pos)        /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4                 GPIO_PUPDR_PUPD4_Msk                  
+#define GPIO_PUPDR_PUPD4_0               (0x1UL << GPIO_PUPDR_PUPD4_Pos)        /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1               (0x2UL << GPIO_PUPDR_PUPD4_Pos)        /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos             (10U)                                 
+#define GPIO_PUPDR_PUPD5_Msk             (0x3UL << GPIO_PUPDR_PUPD5_Pos)        /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5                 GPIO_PUPDR_PUPD5_Msk                  
+#define GPIO_PUPDR_PUPD5_0               (0x1UL << GPIO_PUPDR_PUPD5_Pos)        /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1               (0x2UL << GPIO_PUPDR_PUPD5_Pos)        /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos             (12U)                                 
+#define GPIO_PUPDR_PUPD6_Msk             (0x3UL << GPIO_PUPDR_PUPD6_Pos)        /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6                 GPIO_PUPDR_PUPD6_Msk                  
+#define GPIO_PUPDR_PUPD6_0               (0x1UL << GPIO_PUPDR_PUPD6_Pos)        /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1               (0x2UL << GPIO_PUPDR_PUPD6_Pos)        /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos             (14U)                                 
+#define GPIO_PUPDR_PUPD7_Msk             (0x3UL << GPIO_PUPDR_PUPD7_Pos)        /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7                 GPIO_PUPDR_PUPD7_Msk                  
+#define GPIO_PUPDR_PUPD7_0               (0x1UL << GPIO_PUPDR_PUPD7_Pos)        /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1               (0x2UL << GPIO_PUPDR_PUPD7_Pos)        /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos             (16U)                                 
+#define GPIO_PUPDR_PUPD8_Msk             (0x3UL << GPIO_PUPDR_PUPD8_Pos)        /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8                 GPIO_PUPDR_PUPD8_Msk                  
+#define GPIO_PUPDR_PUPD8_0               (0x1UL << GPIO_PUPDR_PUPD8_Pos)        /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1               (0x2UL << GPIO_PUPDR_PUPD8_Pos)        /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos             (18U)                                 
+#define GPIO_PUPDR_PUPD9_Msk             (0x3UL << GPIO_PUPDR_PUPD9_Pos)        /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9                 GPIO_PUPDR_PUPD9_Msk                  
+#define GPIO_PUPDR_PUPD9_0               (0x1UL << GPIO_PUPDR_PUPD9_Pos)        /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1               (0x2UL << GPIO_PUPDR_PUPD9_Pos)        /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos            (20U)                                 
+#define GPIO_PUPDR_PUPD10_Msk            (0x3UL << GPIO_PUPDR_PUPD10_Pos)       /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10                GPIO_PUPDR_PUPD10_Msk                 
+#define GPIO_PUPDR_PUPD10_0              (0x1UL << GPIO_PUPDR_PUPD10_Pos)       /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1              (0x2UL << GPIO_PUPDR_PUPD10_Pos)       /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos            (22U)                                 
+#define GPIO_PUPDR_PUPD11_Msk            (0x3UL << GPIO_PUPDR_PUPD11_Pos)       /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11                GPIO_PUPDR_PUPD11_Msk                 
+#define GPIO_PUPDR_PUPD11_0              (0x1UL << GPIO_PUPDR_PUPD11_Pos)       /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1              (0x2UL << GPIO_PUPDR_PUPD11_Pos)       /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos            (24U)                                 
+#define GPIO_PUPDR_PUPD12_Msk            (0x3UL << GPIO_PUPDR_PUPD12_Pos)       /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12                GPIO_PUPDR_PUPD12_Msk                 
+#define GPIO_PUPDR_PUPD12_0              (0x1UL << GPIO_PUPDR_PUPD12_Pos)       /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1              (0x2UL << GPIO_PUPDR_PUPD12_Pos)       /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos            (26U)                                 
+#define GPIO_PUPDR_PUPD13_Msk            (0x3UL << GPIO_PUPDR_PUPD13_Pos)       /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13                GPIO_PUPDR_PUPD13_Msk                 
+#define GPIO_PUPDR_PUPD13_0              (0x1UL << GPIO_PUPDR_PUPD13_Pos)       /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1              (0x2UL << GPIO_PUPDR_PUPD13_Pos)       /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos            (28U)                                 
+#define GPIO_PUPDR_PUPD14_Msk            (0x3UL << GPIO_PUPDR_PUPD14_Pos)       /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14                GPIO_PUPDR_PUPD14_Msk                 
+#define GPIO_PUPDR_PUPD14_0              (0x1UL << GPIO_PUPDR_PUPD14_Pos)       /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1              (0x2UL << GPIO_PUPDR_PUPD14_Pos)       /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos            (30U)                                 
+#define GPIO_PUPDR_PUPD15_Msk            (0x3UL << GPIO_PUPDR_PUPD15_Pos)       /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15                GPIO_PUPDR_PUPD15_Msk                 
+#define GPIO_PUPDR_PUPD15_0              (0x1UL << GPIO_PUPDR_PUPD15_Pos)       /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1              (0x2UL << GPIO_PUPDR_PUPD15_Pos)       /*!< 0x80000000 */
+
+/* Legacy defines */
+#define GPIO_PUPDR_PUPDR0                GPIO_PUPDR_PUPD0
+#define GPIO_PUPDR_PUPDR0_0              GPIO_PUPDR_PUPD0_0
+#define GPIO_PUPDR_PUPDR0_1              GPIO_PUPDR_PUPD0_1
+#define GPIO_PUPDR_PUPDR1                GPIO_PUPDR_PUPD1
+#define GPIO_PUPDR_PUPDR1_0              GPIO_PUPDR_PUPD1_0
+#define GPIO_PUPDR_PUPDR1_1              GPIO_PUPDR_PUPD1_1
+#define GPIO_PUPDR_PUPDR2                GPIO_PUPDR_PUPD2
+#define GPIO_PUPDR_PUPDR2_0              GPIO_PUPDR_PUPD2_0
+#define GPIO_PUPDR_PUPDR2_1              GPIO_PUPDR_PUPD2_1
+#define GPIO_PUPDR_PUPDR3                GPIO_PUPDR_PUPD3
+#define GPIO_PUPDR_PUPDR3_0              GPIO_PUPDR_PUPD3_0
+#define GPIO_PUPDR_PUPDR3_1              GPIO_PUPDR_PUPD3_1
+#define GPIO_PUPDR_PUPDR4                GPIO_PUPDR_PUPD4
+#define GPIO_PUPDR_PUPDR4_0              GPIO_PUPDR_PUPD4_0
+#define GPIO_PUPDR_PUPDR4_1              GPIO_PUPDR_PUPD4_1
+#define GPIO_PUPDR_PUPDR5                GPIO_PUPDR_PUPD5
+#define GPIO_PUPDR_PUPDR5_0              GPIO_PUPDR_PUPD5_0
+#define GPIO_PUPDR_PUPDR5_1              GPIO_PUPDR_PUPD5_1
+#define GPIO_PUPDR_PUPDR6                GPIO_PUPDR_PUPD6
+#define GPIO_PUPDR_PUPDR6_0              GPIO_PUPDR_PUPD6_0
+#define GPIO_PUPDR_PUPDR6_1              GPIO_PUPDR_PUPD6_1
+#define GPIO_PUPDR_PUPDR7                GPIO_PUPDR_PUPD7
+#define GPIO_PUPDR_PUPDR7_0              GPIO_PUPDR_PUPD7_0
+#define GPIO_PUPDR_PUPDR7_1              GPIO_PUPDR_PUPD7_1
+#define GPIO_PUPDR_PUPDR8                GPIO_PUPDR_PUPD8
+#define GPIO_PUPDR_PUPDR8_0              GPIO_PUPDR_PUPD8_0
+#define GPIO_PUPDR_PUPDR8_1              GPIO_PUPDR_PUPD8_1
+#define GPIO_PUPDR_PUPDR9                GPIO_PUPDR_PUPD9
+#define GPIO_PUPDR_PUPDR9_0              GPIO_PUPDR_PUPD9_0
+#define GPIO_PUPDR_PUPDR9_1              GPIO_PUPDR_PUPD9_1
+#define GPIO_PUPDR_PUPDR10               GPIO_PUPDR_PUPD10
+#define GPIO_PUPDR_PUPDR10_0             GPIO_PUPDR_PUPD10_0
+#define GPIO_PUPDR_PUPDR10_1             GPIO_PUPDR_PUPD10_1
+#define GPIO_PUPDR_PUPDR11               GPIO_PUPDR_PUPD11
+#define GPIO_PUPDR_PUPDR11_0             GPIO_PUPDR_PUPD11_0
+#define GPIO_PUPDR_PUPDR11_1             GPIO_PUPDR_PUPD11_1
+#define GPIO_PUPDR_PUPDR12               GPIO_PUPDR_PUPD12
+#define GPIO_PUPDR_PUPDR12_0             GPIO_PUPDR_PUPD12_0
+#define GPIO_PUPDR_PUPDR12_1             GPIO_PUPDR_PUPD12_1
+#define GPIO_PUPDR_PUPDR13               GPIO_PUPDR_PUPD13
+#define GPIO_PUPDR_PUPDR13_0             GPIO_PUPDR_PUPD13_0
+#define GPIO_PUPDR_PUPDR13_1             GPIO_PUPDR_PUPD13_1
+#define GPIO_PUPDR_PUPDR14               GPIO_PUPDR_PUPD14
+#define GPIO_PUPDR_PUPDR14_0             GPIO_PUPDR_PUPD14_0
+#define GPIO_PUPDR_PUPDR14_1             GPIO_PUPDR_PUPD14_1
+#define GPIO_PUPDR_PUPDR15               GPIO_PUPDR_PUPD15
+#define GPIO_PUPDR_PUPDR15_0             GPIO_PUPDR_PUPD15_0
+#define GPIO_PUPDR_PUPDR15_1             GPIO_PUPDR_PUPD15_1
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos                 (0U)                                  
+#define GPIO_IDR_ID0_Msk                 (0x1UL << GPIO_IDR_ID0_Pos)            /*!< 0x00000001 */
+#define GPIO_IDR_ID0                     GPIO_IDR_ID0_Msk                      
+#define GPIO_IDR_ID1_Pos                 (1U)                                  
+#define GPIO_IDR_ID1_Msk                 (0x1UL << GPIO_IDR_ID1_Pos)            /*!< 0x00000002 */
+#define GPIO_IDR_ID1                     GPIO_IDR_ID1_Msk                      
+#define GPIO_IDR_ID2_Pos                 (2U)                                  
+#define GPIO_IDR_ID2_Msk                 (0x1UL << GPIO_IDR_ID2_Pos)            /*!< 0x00000004 */
+#define GPIO_IDR_ID2                     GPIO_IDR_ID2_Msk                      
+#define GPIO_IDR_ID3_Pos                 (3U)                                  
+#define GPIO_IDR_ID3_Msk                 (0x1UL << GPIO_IDR_ID3_Pos)            /*!< 0x00000008 */
+#define GPIO_IDR_ID3                     GPIO_IDR_ID3_Msk                      
+#define GPIO_IDR_ID4_Pos                 (4U)                                  
+#define GPIO_IDR_ID4_Msk                 (0x1UL << GPIO_IDR_ID4_Pos)            /*!< 0x00000010 */
+#define GPIO_IDR_ID4                     GPIO_IDR_ID4_Msk                      
+#define GPIO_IDR_ID5_Pos                 (5U)                                  
+#define GPIO_IDR_ID5_Msk                 (0x1UL << GPIO_IDR_ID5_Pos)            /*!< 0x00000020 */
+#define GPIO_IDR_ID5                     GPIO_IDR_ID5_Msk                      
+#define GPIO_IDR_ID6_Pos                 (6U)                                  
+#define GPIO_IDR_ID6_Msk                 (0x1UL << GPIO_IDR_ID6_Pos)            /*!< 0x00000040 */
+#define GPIO_IDR_ID6                     GPIO_IDR_ID6_Msk                      
+#define GPIO_IDR_ID7_Pos                 (7U)                                  
+#define GPIO_IDR_ID7_Msk                 (0x1UL << GPIO_IDR_ID7_Pos)            /*!< 0x00000080 */
+#define GPIO_IDR_ID7                     GPIO_IDR_ID7_Msk                      
+#define GPIO_IDR_ID8_Pos                 (8U)                                  
+#define GPIO_IDR_ID8_Msk                 (0x1UL << GPIO_IDR_ID8_Pos)            /*!< 0x00000100 */
+#define GPIO_IDR_ID8                     GPIO_IDR_ID8_Msk                      
+#define GPIO_IDR_ID9_Pos                 (9U)                                  
+#define GPIO_IDR_ID9_Msk                 (0x1UL << GPIO_IDR_ID9_Pos)            /*!< 0x00000200 */
+#define GPIO_IDR_ID9                     GPIO_IDR_ID9_Msk                      
+#define GPIO_IDR_ID10_Pos                (10U)                                 
+#define GPIO_IDR_ID10_Msk                (0x1UL << GPIO_IDR_ID10_Pos)           /*!< 0x00000400 */
+#define GPIO_IDR_ID10                    GPIO_IDR_ID10_Msk                     
+#define GPIO_IDR_ID11_Pos                (11U)                                 
+#define GPIO_IDR_ID11_Msk                (0x1UL << GPIO_IDR_ID11_Pos)           /*!< 0x00000800 */
+#define GPIO_IDR_ID11                    GPIO_IDR_ID11_Msk                     
+#define GPIO_IDR_ID12_Pos                (12U)                                 
+#define GPIO_IDR_ID12_Msk                (0x1UL << GPIO_IDR_ID12_Pos)           /*!< 0x00001000 */
+#define GPIO_IDR_ID12                    GPIO_IDR_ID12_Msk                     
+#define GPIO_IDR_ID13_Pos                (13U)                                 
+#define GPIO_IDR_ID13_Msk                (0x1UL << GPIO_IDR_ID13_Pos)           /*!< 0x00002000 */
+#define GPIO_IDR_ID13                    GPIO_IDR_ID13_Msk                     
+#define GPIO_IDR_ID14_Pos                (14U)                                 
+#define GPIO_IDR_ID14_Msk                (0x1UL << GPIO_IDR_ID14_Pos)           /*!< 0x00004000 */
+#define GPIO_IDR_ID14                    GPIO_IDR_ID14_Msk                     
+#define GPIO_IDR_ID15_Pos                (15U)                                 
+#define GPIO_IDR_ID15_Msk                (0x1UL << GPIO_IDR_ID15_Pos)           /*!< 0x00008000 */
+#define GPIO_IDR_ID15                    GPIO_IDR_ID15_Msk                     
+
+/* Legacy defines */
+#define GPIO_IDR_IDR_0                   GPIO_IDR_ID0
+#define GPIO_IDR_IDR_1                   GPIO_IDR_ID1
+#define GPIO_IDR_IDR_2                   GPIO_IDR_ID2
+#define GPIO_IDR_IDR_3                   GPIO_IDR_ID3
+#define GPIO_IDR_IDR_4                   GPIO_IDR_ID4
+#define GPIO_IDR_IDR_5                   GPIO_IDR_ID5
+#define GPIO_IDR_IDR_6                   GPIO_IDR_ID6
+#define GPIO_IDR_IDR_7                   GPIO_IDR_ID7
+#define GPIO_IDR_IDR_8                   GPIO_IDR_ID8
+#define GPIO_IDR_IDR_9                   GPIO_IDR_ID9
+#define GPIO_IDR_IDR_10                  GPIO_IDR_ID10
+#define GPIO_IDR_IDR_11                  GPIO_IDR_ID11
+#define GPIO_IDR_IDR_12                  GPIO_IDR_ID12
+#define GPIO_IDR_IDR_13                  GPIO_IDR_ID13
+#define GPIO_IDR_IDR_14                  GPIO_IDR_ID14
+#define GPIO_IDR_IDR_15                  GPIO_IDR_ID15
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos                 (0U)                                  
+#define GPIO_ODR_OD0_Msk                 (0x1UL << GPIO_ODR_OD0_Pos)            /*!< 0x00000001 */
+#define GPIO_ODR_OD0                     GPIO_ODR_OD0_Msk                      
+#define GPIO_ODR_OD1_Pos                 (1U)                                  
+#define GPIO_ODR_OD1_Msk                 (0x1UL << GPIO_ODR_OD1_Pos)            /*!< 0x00000002 */
+#define GPIO_ODR_OD1                     GPIO_ODR_OD1_Msk                      
+#define GPIO_ODR_OD2_Pos                 (2U)                                  
+#define GPIO_ODR_OD2_Msk                 (0x1UL << GPIO_ODR_OD2_Pos)            /*!< 0x00000004 */
+#define GPIO_ODR_OD2                     GPIO_ODR_OD2_Msk                      
+#define GPIO_ODR_OD3_Pos                 (3U)                                  
+#define GPIO_ODR_OD3_Msk                 (0x1UL << GPIO_ODR_OD3_Pos)            /*!< 0x00000008 */
+#define GPIO_ODR_OD3                     GPIO_ODR_OD3_Msk                      
+#define GPIO_ODR_OD4_Pos                 (4U)                                  
+#define GPIO_ODR_OD4_Msk                 (0x1UL << GPIO_ODR_OD4_Pos)            /*!< 0x00000010 */
+#define GPIO_ODR_OD4                     GPIO_ODR_OD4_Msk                      
+#define GPIO_ODR_OD5_Pos                 (5U)                                  
+#define GPIO_ODR_OD5_Msk                 (0x1UL << GPIO_ODR_OD5_Pos)            /*!< 0x00000020 */
+#define GPIO_ODR_OD5                     GPIO_ODR_OD5_Msk                      
+#define GPIO_ODR_OD6_Pos                 (6U)                                  
+#define GPIO_ODR_OD6_Msk                 (0x1UL << GPIO_ODR_OD6_Pos)            /*!< 0x00000040 */
+#define GPIO_ODR_OD6                     GPIO_ODR_OD6_Msk                      
+#define GPIO_ODR_OD7_Pos                 (7U)                                  
+#define GPIO_ODR_OD7_Msk                 (0x1UL << GPIO_ODR_OD7_Pos)            /*!< 0x00000080 */
+#define GPIO_ODR_OD7                     GPIO_ODR_OD7_Msk                      
+#define GPIO_ODR_OD8_Pos                 (8U)                                  
+#define GPIO_ODR_OD8_Msk                 (0x1UL << GPIO_ODR_OD8_Pos)            /*!< 0x00000100 */
+#define GPIO_ODR_OD8                     GPIO_ODR_OD8_Msk                      
+#define GPIO_ODR_OD9_Pos                 (9U)                                  
+#define GPIO_ODR_OD9_Msk                 (0x1UL << GPIO_ODR_OD9_Pos)            /*!< 0x00000200 */
+#define GPIO_ODR_OD9                     GPIO_ODR_OD9_Msk                      
+#define GPIO_ODR_OD10_Pos                (10U)                                 
+#define GPIO_ODR_OD10_Msk                (0x1UL << GPIO_ODR_OD10_Pos)           /*!< 0x00000400 */
+#define GPIO_ODR_OD10                    GPIO_ODR_OD10_Msk                     
+#define GPIO_ODR_OD11_Pos                (11U)                                 
+#define GPIO_ODR_OD11_Msk                (0x1UL << GPIO_ODR_OD11_Pos)           /*!< 0x00000800 */
+#define GPIO_ODR_OD11                    GPIO_ODR_OD11_Msk                     
+#define GPIO_ODR_OD12_Pos                (12U)                                 
+#define GPIO_ODR_OD12_Msk                (0x1UL << GPIO_ODR_OD12_Pos)           /*!< 0x00001000 */
+#define GPIO_ODR_OD12                    GPIO_ODR_OD12_Msk                     
+#define GPIO_ODR_OD13_Pos                (13U)                                 
+#define GPIO_ODR_OD13_Msk                (0x1UL << GPIO_ODR_OD13_Pos)           /*!< 0x00002000 */
+#define GPIO_ODR_OD13                    GPIO_ODR_OD13_Msk                     
+#define GPIO_ODR_OD14_Pos                (14U)                                 
+#define GPIO_ODR_OD14_Msk                (0x1UL << GPIO_ODR_OD14_Pos)           /*!< 0x00004000 */
+#define GPIO_ODR_OD14                    GPIO_ODR_OD14_Msk                     
+#define GPIO_ODR_OD15_Pos                (15U)                                 
+#define GPIO_ODR_OD15_Msk                (0x1UL << GPIO_ODR_OD15_Pos)           /*!< 0x00008000 */
+#define GPIO_ODR_OD15                    GPIO_ODR_OD15_Msk                     
+/* Legacy defines */
+#define GPIO_ODR_ODR_0                   GPIO_ODR_OD0
+#define GPIO_ODR_ODR_1                   GPIO_ODR_OD1
+#define GPIO_ODR_ODR_2                   GPIO_ODR_OD2
+#define GPIO_ODR_ODR_3                   GPIO_ODR_OD3
+#define GPIO_ODR_ODR_4                   GPIO_ODR_OD4
+#define GPIO_ODR_ODR_5                   GPIO_ODR_OD5
+#define GPIO_ODR_ODR_6                   GPIO_ODR_OD6
+#define GPIO_ODR_ODR_7                   GPIO_ODR_OD7
+#define GPIO_ODR_ODR_8                   GPIO_ODR_OD8
+#define GPIO_ODR_ODR_9                   GPIO_ODR_OD9
+#define GPIO_ODR_ODR_10                  GPIO_ODR_OD10
+#define GPIO_ODR_ODR_11                  GPIO_ODR_OD11
+#define GPIO_ODR_ODR_12                  GPIO_ODR_OD12
+#define GPIO_ODR_ODR_13                  GPIO_ODR_OD13
+#define GPIO_ODR_ODR_14                  GPIO_ODR_OD14
+#define GPIO_ODR_ODR_15                  GPIO_ODR_OD15
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos                (0U)                                  
+#define GPIO_BSRR_BS0_Msk                (0x1UL << GPIO_BSRR_BS0_Pos)           /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                    GPIO_BSRR_BS0_Msk                     
+#define GPIO_BSRR_BS1_Pos                (1U)                                  
+#define GPIO_BSRR_BS1_Msk                (0x1UL << GPIO_BSRR_BS1_Pos)           /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                    GPIO_BSRR_BS1_Msk                     
+#define GPIO_BSRR_BS2_Pos                (2U)                                  
+#define GPIO_BSRR_BS2_Msk                (0x1UL << GPIO_BSRR_BS2_Pos)           /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                    GPIO_BSRR_BS2_Msk                     
+#define GPIO_BSRR_BS3_Pos                (3U)                                  
+#define GPIO_BSRR_BS3_Msk                (0x1UL << GPIO_BSRR_BS3_Pos)           /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                    GPIO_BSRR_BS3_Msk                     
+#define GPIO_BSRR_BS4_Pos                (4U)                                  
+#define GPIO_BSRR_BS4_Msk                (0x1UL << GPIO_BSRR_BS4_Pos)           /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                    GPIO_BSRR_BS4_Msk                     
+#define GPIO_BSRR_BS5_Pos                (5U)                                  
+#define GPIO_BSRR_BS5_Msk                (0x1UL << GPIO_BSRR_BS5_Pos)           /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                    GPIO_BSRR_BS5_Msk                     
+#define GPIO_BSRR_BS6_Pos                (6U)                                  
+#define GPIO_BSRR_BS6_Msk                (0x1UL << GPIO_BSRR_BS6_Pos)           /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                    GPIO_BSRR_BS6_Msk                     
+#define GPIO_BSRR_BS7_Pos                (7U)                                  
+#define GPIO_BSRR_BS7_Msk                (0x1UL << GPIO_BSRR_BS7_Pos)           /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                    GPIO_BSRR_BS7_Msk                     
+#define GPIO_BSRR_BS8_Pos                (8U)                                  
+#define GPIO_BSRR_BS8_Msk                (0x1UL << GPIO_BSRR_BS8_Pos)           /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                    GPIO_BSRR_BS8_Msk                     
+#define GPIO_BSRR_BS9_Pos                (9U)                                  
+#define GPIO_BSRR_BS9_Msk                (0x1UL << GPIO_BSRR_BS9_Pos)           /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                    GPIO_BSRR_BS9_Msk                     
+#define GPIO_BSRR_BS10_Pos               (10U)                                 
+#define GPIO_BSRR_BS10_Msk               (0x1UL << GPIO_BSRR_BS10_Pos)          /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                   GPIO_BSRR_BS10_Msk                    
+#define GPIO_BSRR_BS11_Pos               (11U)                                 
+#define GPIO_BSRR_BS11_Msk               (0x1UL << GPIO_BSRR_BS11_Pos)          /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                   GPIO_BSRR_BS11_Msk                    
+#define GPIO_BSRR_BS12_Pos               (12U)                                 
+#define GPIO_BSRR_BS12_Msk               (0x1UL << GPIO_BSRR_BS12_Pos)          /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                   GPIO_BSRR_BS12_Msk                    
+#define GPIO_BSRR_BS13_Pos               (13U)                                 
+#define GPIO_BSRR_BS13_Msk               (0x1UL << GPIO_BSRR_BS13_Pos)          /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                   GPIO_BSRR_BS13_Msk                    
+#define GPIO_BSRR_BS14_Pos               (14U)                                 
+#define GPIO_BSRR_BS14_Msk               (0x1UL << GPIO_BSRR_BS14_Pos)          /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                   GPIO_BSRR_BS14_Msk                    
+#define GPIO_BSRR_BS15_Pos               (15U)                                 
+#define GPIO_BSRR_BS15_Msk               (0x1UL << GPIO_BSRR_BS15_Pos)          /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                   GPIO_BSRR_BS15_Msk                    
+#define GPIO_BSRR_BR0_Pos                (16U)                                 
+#define GPIO_BSRR_BR0_Msk                (0x1UL << GPIO_BSRR_BR0_Pos)           /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                    GPIO_BSRR_BR0_Msk                     
+#define GPIO_BSRR_BR1_Pos                (17U)                                 
+#define GPIO_BSRR_BR1_Msk                (0x1UL << GPIO_BSRR_BR1_Pos)           /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                    GPIO_BSRR_BR1_Msk                     
+#define GPIO_BSRR_BR2_Pos                (18U)                                 
+#define GPIO_BSRR_BR2_Msk                (0x1UL << GPIO_BSRR_BR2_Pos)           /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                    GPIO_BSRR_BR2_Msk                     
+#define GPIO_BSRR_BR3_Pos                (19U)                                 
+#define GPIO_BSRR_BR3_Msk                (0x1UL << GPIO_BSRR_BR3_Pos)           /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                    GPIO_BSRR_BR3_Msk                     
+#define GPIO_BSRR_BR4_Pos                (20U)                                 
+#define GPIO_BSRR_BR4_Msk                (0x1UL << GPIO_BSRR_BR4_Pos)           /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                    GPIO_BSRR_BR4_Msk                     
+#define GPIO_BSRR_BR5_Pos                (21U)                                 
+#define GPIO_BSRR_BR5_Msk                (0x1UL << GPIO_BSRR_BR5_Pos)           /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                    GPIO_BSRR_BR5_Msk                     
+#define GPIO_BSRR_BR6_Pos                (22U)                                 
+#define GPIO_BSRR_BR6_Msk                (0x1UL << GPIO_BSRR_BR6_Pos)           /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                    GPIO_BSRR_BR6_Msk                     
+#define GPIO_BSRR_BR7_Pos                (23U)                                 
+#define GPIO_BSRR_BR7_Msk                (0x1UL << GPIO_BSRR_BR7_Pos)           /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                    GPIO_BSRR_BR7_Msk                     
+#define GPIO_BSRR_BR8_Pos                (24U)                                 
+#define GPIO_BSRR_BR8_Msk                (0x1UL << GPIO_BSRR_BR8_Pos)           /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                    GPIO_BSRR_BR8_Msk                     
+#define GPIO_BSRR_BR9_Pos                (25U)                                 
+#define GPIO_BSRR_BR9_Msk                (0x1UL << GPIO_BSRR_BR9_Pos)           /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                    GPIO_BSRR_BR9_Msk                     
+#define GPIO_BSRR_BR10_Pos               (26U)                                 
+#define GPIO_BSRR_BR10_Msk               (0x1UL << GPIO_BSRR_BR10_Pos)          /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                   GPIO_BSRR_BR10_Msk                    
+#define GPIO_BSRR_BR11_Pos               (27U)                                 
+#define GPIO_BSRR_BR11_Msk               (0x1UL << GPIO_BSRR_BR11_Pos)          /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                   GPIO_BSRR_BR11_Msk                    
+#define GPIO_BSRR_BR12_Pos               (28U)                                 
+#define GPIO_BSRR_BR12_Msk               (0x1UL << GPIO_BSRR_BR12_Pos)          /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                   GPIO_BSRR_BR12_Msk                    
+#define GPIO_BSRR_BR13_Pos               (29U)                                 
+#define GPIO_BSRR_BR13_Msk               (0x1UL << GPIO_BSRR_BR13_Pos)          /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                   GPIO_BSRR_BR13_Msk                    
+#define GPIO_BSRR_BR14_Pos               (30U)                                 
+#define GPIO_BSRR_BR14_Msk               (0x1UL << GPIO_BSRR_BR14_Pos)          /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                   GPIO_BSRR_BR14_Msk                    
+#define GPIO_BSRR_BR15_Pos               (31U)                                 
+#define GPIO_BSRR_BR15_Msk               (0x1UL << GPIO_BSRR_BR15_Pos)          /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                   GPIO_BSRR_BR15_Msk                    
+
+/* Legacy defines */
+#define GPIO_BSRR_BS_0                   GPIO_BSRR_BS0
+#define GPIO_BSRR_BS_1                   GPIO_BSRR_BS1
+#define GPIO_BSRR_BS_2                   GPIO_BSRR_BS2
+#define GPIO_BSRR_BS_3                   GPIO_BSRR_BS3
+#define GPIO_BSRR_BS_4                   GPIO_BSRR_BS4
+#define GPIO_BSRR_BS_5                   GPIO_BSRR_BS5
+#define GPIO_BSRR_BS_6                   GPIO_BSRR_BS6
+#define GPIO_BSRR_BS_7                   GPIO_BSRR_BS7
+#define GPIO_BSRR_BS_8                   GPIO_BSRR_BS8
+#define GPIO_BSRR_BS_9                   GPIO_BSRR_BS9
+#define GPIO_BSRR_BS_10                  GPIO_BSRR_BS10
+#define GPIO_BSRR_BS_11                  GPIO_BSRR_BS11
+#define GPIO_BSRR_BS_12                  GPIO_BSRR_BS12
+#define GPIO_BSRR_BS_13                  GPIO_BSRR_BS13
+#define GPIO_BSRR_BS_14                  GPIO_BSRR_BS14
+#define GPIO_BSRR_BS_15                  GPIO_BSRR_BS15
+#define GPIO_BSRR_BR_0                   GPIO_BSRR_BR0
+#define GPIO_BSRR_BR_1                   GPIO_BSRR_BR1
+#define GPIO_BSRR_BR_2                   GPIO_BSRR_BR2
+#define GPIO_BSRR_BR_3                   GPIO_BSRR_BR3
+#define GPIO_BSRR_BR_4                   GPIO_BSRR_BR4
+#define GPIO_BSRR_BR_5                   GPIO_BSRR_BR5
+#define GPIO_BSRR_BR_6                   GPIO_BSRR_BR6
+#define GPIO_BSRR_BR_7                   GPIO_BSRR_BR7
+#define GPIO_BSRR_BR_8                   GPIO_BSRR_BR8
+#define GPIO_BSRR_BR_9                   GPIO_BSRR_BR9
+#define GPIO_BSRR_BR_10                  GPIO_BSRR_BR10
+#define GPIO_BSRR_BR_11                  GPIO_BSRR_BR11
+#define GPIO_BSRR_BR_12                  GPIO_BSRR_BR12
+#define GPIO_BSRR_BR_13                  GPIO_BSRR_BR13
+#define GPIO_BSRR_BR_14                  GPIO_BSRR_BR14
+#define GPIO_BSRR_BR_15                  GPIO_BSRR_BR15
+#define GPIO_BRR_BR0                     GPIO_BSRR_BR0
+#define GPIO_BRR_BR0_Pos                 GPIO_BSRR_BR0_Pos
+#define GPIO_BRR_BR0_Msk                 GPIO_BSRR_BR0_Msk
+#define GPIO_BRR_BR1                     GPIO_BSRR_BR1
+#define GPIO_BRR_BR1_Pos                 GPIO_BSRR_BR1_Pos
+#define GPIO_BRR_BR1_Msk                 GPIO_BSRR_BR1_Msk
+#define GPIO_BRR_BR2                     GPIO_BSRR_BR2
+#define GPIO_BRR_BR2_Pos                 GPIO_BSRR_BR2_Pos
+#define GPIO_BRR_BR2_Msk                 GPIO_BSRR_BR2_Msk
+#define GPIO_BRR_BR3                     GPIO_BSRR_BR3
+#define GPIO_BRR_BR3_Pos                 GPIO_BSRR_BR3_Pos
+#define GPIO_BRR_BR3_Msk                 GPIO_BSRR_BR3_Msk
+#define GPIO_BRR_BR4                     GPIO_BSRR_BR4
+#define GPIO_BRR_BR4_Pos                 GPIO_BSRR_BR4_Pos
+#define GPIO_BRR_BR4_Msk                 GPIO_BSRR_BR4_Msk
+#define GPIO_BRR_BR5                     GPIO_BSRR_BR5
+#define GPIO_BRR_BR5_Pos                 GPIO_BSRR_BR5_Pos
+#define GPIO_BRR_BR5_Msk                 GPIO_BSRR_BR5_Msk
+#define GPIO_BRR_BR6                     GPIO_BSRR_BR6
+#define GPIO_BRR_BR6_Pos                 GPIO_BSRR_BR6_Pos
+#define GPIO_BRR_BR6_Msk                 GPIO_BSRR_BR6_Msk
+#define GPIO_BRR_BR7                     GPIO_BSRR_BR7
+#define GPIO_BRR_BR7_Pos                 GPIO_BSRR_BR7_Pos
+#define GPIO_BRR_BR7_Msk                 GPIO_BSRR_BR7_Msk
+#define GPIO_BRR_BR8                     GPIO_BSRR_BR8
+#define GPIO_BRR_BR8_Pos                 GPIO_BSRR_BR8_Pos
+#define GPIO_BRR_BR8_Msk                 GPIO_BSRR_BR8_Msk
+#define GPIO_BRR_BR9                     GPIO_BSRR_BR9
+#define GPIO_BRR_BR9_Pos                 GPIO_BSRR_BR9_Pos
+#define GPIO_BRR_BR9_Msk                 GPIO_BSRR_BR9_Msk
+#define GPIO_BRR_BR10                    GPIO_BSRR_BR10
+#define GPIO_BRR_BR10_Pos                GPIO_BSRR_BR10_Pos
+#define GPIO_BRR_BR10_Msk                GPIO_BSRR_BR10_Msk
+#define GPIO_BRR_BR11                    GPIO_BSRR_BR11
+#define GPIO_BRR_BR11_Pos                GPIO_BSRR_BR11_Pos
+#define GPIO_BRR_BR11_Msk                GPIO_BSRR_BR11_Msk
+#define GPIO_BRR_BR12                    GPIO_BSRR_BR12
+#define GPIO_BRR_BR12_Pos                GPIO_BSRR_BR12_Pos
+#define GPIO_BRR_BR12_Msk                GPIO_BSRR_BR12_Msk
+#define GPIO_BRR_BR13                    GPIO_BSRR_BR13
+#define GPIO_BRR_BR13_Pos                GPIO_BSRR_BR13_Pos
+#define GPIO_BRR_BR13_Msk                GPIO_BSRR_BR13_Msk
+#define GPIO_BRR_BR14                    GPIO_BSRR_BR14
+#define GPIO_BRR_BR14_Pos                GPIO_BSRR_BR14_Pos
+#define GPIO_BRR_BR14_Msk                GPIO_BSRR_BR14_Msk
+#define GPIO_BRR_BR15                    GPIO_BSRR_BR15
+#define GPIO_BRR_BR15_Pos                GPIO_BSRR_BR15_Pos
+#define GPIO_BRR_BR15_Msk                GPIO_BSRR_BR15_Msk 
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos               (0U)                                  
+#define GPIO_LCKR_LCK0_Msk               (0x1UL << GPIO_LCKR_LCK0_Pos)          /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                   GPIO_LCKR_LCK0_Msk                    
+#define GPIO_LCKR_LCK1_Pos               (1U)                                  
+#define GPIO_LCKR_LCK1_Msk               (0x1UL << GPIO_LCKR_LCK1_Pos)          /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                   GPIO_LCKR_LCK1_Msk                    
+#define GPIO_LCKR_LCK2_Pos               (2U)                                  
+#define GPIO_LCKR_LCK2_Msk               (0x1UL << GPIO_LCKR_LCK2_Pos)          /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                   GPIO_LCKR_LCK2_Msk                    
+#define GPIO_LCKR_LCK3_Pos               (3U)                                  
+#define GPIO_LCKR_LCK3_Msk               (0x1UL << GPIO_LCKR_LCK3_Pos)          /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                   GPIO_LCKR_LCK3_Msk                    
+#define GPIO_LCKR_LCK4_Pos               (4U)                                  
+#define GPIO_LCKR_LCK4_Msk               (0x1UL << GPIO_LCKR_LCK4_Pos)          /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                   GPIO_LCKR_LCK4_Msk                    
+#define GPIO_LCKR_LCK5_Pos               (5U)                                  
+#define GPIO_LCKR_LCK5_Msk               (0x1UL << GPIO_LCKR_LCK5_Pos)          /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                   GPIO_LCKR_LCK5_Msk                    
+#define GPIO_LCKR_LCK6_Pos               (6U)                                  
+#define GPIO_LCKR_LCK6_Msk               (0x1UL << GPIO_LCKR_LCK6_Pos)          /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                   GPIO_LCKR_LCK6_Msk                    
+#define GPIO_LCKR_LCK7_Pos               (7U)                                  
+#define GPIO_LCKR_LCK7_Msk               (0x1UL << GPIO_LCKR_LCK7_Pos)          /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                   GPIO_LCKR_LCK7_Msk                    
+#define GPIO_LCKR_LCK8_Pos               (8U)                                  
+#define GPIO_LCKR_LCK8_Msk               (0x1UL << GPIO_LCKR_LCK8_Pos)          /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                   GPIO_LCKR_LCK8_Msk                    
+#define GPIO_LCKR_LCK9_Pos               (9U)                                  
+#define GPIO_LCKR_LCK9_Msk               (0x1UL << GPIO_LCKR_LCK9_Pos)          /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                   GPIO_LCKR_LCK9_Msk                    
+#define GPIO_LCKR_LCK10_Pos              (10U)                                 
+#define GPIO_LCKR_LCK10_Msk              (0x1UL << GPIO_LCKR_LCK10_Pos)         /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                  GPIO_LCKR_LCK10_Msk                   
+#define GPIO_LCKR_LCK11_Pos              (11U)                                 
+#define GPIO_LCKR_LCK11_Msk              (0x1UL << GPIO_LCKR_LCK11_Pos)         /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                  GPIO_LCKR_LCK11_Msk                   
+#define GPIO_LCKR_LCK12_Pos              (12U)                                 
+#define GPIO_LCKR_LCK12_Msk              (0x1UL << GPIO_LCKR_LCK12_Pos)         /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                  GPIO_LCKR_LCK12_Msk                   
+#define GPIO_LCKR_LCK13_Pos              (13U)                                 
+#define GPIO_LCKR_LCK13_Msk              (0x1UL << GPIO_LCKR_LCK13_Pos)         /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                  GPIO_LCKR_LCK13_Msk                   
+#define GPIO_LCKR_LCK14_Pos              (14U)                                 
+#define GPIO_LCKR_LCK14_Msk              (0x1UL << GPIO_LCKR_LCK14_Pos)         /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                  GPIO_LCKR_LCK14_Msk                   
+#define GPIO_LCKR_LCK15_Pos              (15U)                                 
+#define GPIO_LCKR_LCK15_Msk              (0x1UL << GPIO_LCKR_LCK15_Pos)         /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                  GPIO_LCKR_LCK15_Msk                   
+#define GPIO_LCKR_LCKK_Pos               (16U)                                 
+#define GPIO_LCKR_LCKK_Msk               (0x1UL << GPIO_LCKR_LCKK_Pos)          /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                   GPIO_LCKR_LCKK_Msk                    
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos             (0U)                                  
+#define GPIO_AFRL_AFSEL0_Msk             (0xFUL << GPIO_AFRL_AFSEL0_Pos)        /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                 GPIO_AFRL_AFSEL0_Msk                  
+#define GPIO_AFRL_AFSEL0_0               (0x1UL << GPIO_AFRL_AFSEL0_Pos)        /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1               (0x2UL << GPIO_AFRL_AFSEL0_Pos)        /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2               (0x4UL << GPIO_AFRL_AFSEL0_Pos)        /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3               (0x8UL << GPIO_AFRL_AFSEL0_Pos)        /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos             (4U)                                  
+#define GPIO_AFRL_AFSEL1_Msk             (0xFUL << GPIO_AFRL_AFSEL1_Pos)        /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                 GPIO_AFRL_AFSEL1_Msk                  
+#define GPIO_AFRL_AFSEL1_0               (0x1UL << GPIO_AFRL_AFSEL1_Pos)        /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1               (0x2UL << GPIO_AFRL_AFSEL1_Pos)        /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2               (0x4UL << GPIO_AFRL_AFSEL1_Pos)        /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3               (0x8UL << GPIO_AFRL_AFSEL1_Pos)        /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos             (8U)                                  
+#define GPIO_AFRL_AFSEL2_Msk             (0xFUL << GPIO_AFRL_AFSEL2_Pos)        /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                 GPIO_AFRL_AFSEL2_Msk                  
+#define GPIO_AFRL_AFSEL2_0               (0x1UL << GPIO_AFRL_AFSEL2_Pos)        /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1               (0x2UL << GPIO_AFRL_AFSEL2_Pos)        /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2               (0x4UL << GPIO_AFRL_AFSEL2_Pos)        /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3               (0x8UL << GPIO_AFRL_AFSEL2_Pos)        /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos             (12U)                                 
+#define GPIO_AFRL_AFSEL3_Msk             (0xFUL << GPIO_AFRL_AFSEL3_Pos)        /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                 GPIO_AFRL_AFSEL3_Msk                  
+#define GPIO_AFRL_AFSEL3_0               (0x1UL << GPIO_AFRL_AFSEL3_Pos)        /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1               (0x2UL << GPIO_AFRL_AFSEL3_Pos)        /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2               (0x4UL << GPIO_AFRL_AFSEL3_Pos)        /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3               (0x8UL << GPIO_AFRL_AFSEL3_Pos)        /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos             (16U)                                 
+#define GPIO_AFRL_AFSEL4_Msk             (0xFUL << GPIO_AFRL_AFSEL4_Pos)        /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                 GPIO_AFRL_AFSEL4_Msk                  
+#define GPIO_AFRL_AFSEL4_0               (0x1UL << GPIO_AFRL_AFSEL4_Pos)        /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1               (0x2UL << GPIO_AFRL_AFSEL4_Pos)        /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2               (0x4UL << GPIO_AFRL_AFSEL4_Pos)        /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3               (0x8UL << GPIO_AFRL_AFSEL4_Pos)        /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos             (20U)                                 
+#define GPIO_AFRL_AFSEL5_Msk             (0xFUL << GPIO_AFRL_AFSEL5_Pos)        /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                 GPIO_AFRL_AFSEL5_Msk                  
+#define GPIO_AFRL_AFSEL5_0               (0x1UL << GPIO_AFRL_AFSEL5_Pos)        /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1               (0x2UL << GPIO_AFRL_AFSEL5_Pos)        /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2               (0x4UL << GPIO_AFRL_AFSEL5_Pos)        /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3               (0x8UL << GPIO_AFRL_AFSEL5_Pos)        /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos             (24U)                                 
+#define GPIO_AFRL_AFSEL6_Msk             (0xFUL << GPIO_AFRL_AFSEL6_Pos)        /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                 GPIO_AFRL_AFSEL6_Msk                  
+#define GPIO_AFRL_AFSEL6_0               (0x1UL << GPIO_AFRL_AFSEL6_Pos)        /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1               (0x2UL << GPIO_AFRL_AFSEL6_Pos)        /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2               (0x4UL << GPIO_AFRL_AFSEL6_Pos)        /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3               (0x8UL << GPIO_AFRL_AFSEL6_Pos)        /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos             (28U)                                 
+#define GPIO_AFRL_AFSEL7_Msk             (0xFUL << GPIO_AFRL_AFSEL7_Pos)        /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                 GPIO_AFRL_AFSEL7_Msk                  
+#define GPIO_AFRL_AFSEL7_0               (0x1UL << GPIO_AFRL_AFSEL7_Pos)        /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1               (0x2UL << GPIO_AFRL_AFSEL7_Pos)        /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2               (0x4UL << GPIO_AFRL_AFSEL7_Pos)        /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3               (0x8UL << GPIO_AFRL_AFSEL7_Pos)        /*!< 0x80000000 */
+
+/* Legacy defines */
+#define GPIO_AFRL_AFRL0                  GPIO_AFRL_AFSEL0
+#define GPIO_AFRL_AFRL0_0                GPIO_AFRL_AFSEL0_0
+#define GPIO_AFRL_AFRL0_1                GPIO_AFRL_AFSEL0_1
+#define GPIO_AFRL_AFRL0_2                GPIO_AFRL_AFSEL0_2
+#define GPIO_AFRL_AFRL0_3                GPIO_AFRL_AFSEL0_3
+#define GPIO_AFRL_AFRL1                  GPIO_AFRL_AFSEL1
+#define GPIO_AFRL_AFRL1_0                GPIO_AFRL_AFSEL1_0
+#define GPIO_AFRL_AFRL1_1                GPIO_AFRL_AFSEL1_1
+#define GPIO_AFRL_AFRL1_2                GPIO_AFRL_AFSEL1_2
+#define GPIO_AFRL_AFRL1_3                GPIO_AFRL_AFSEL1_3
+#define GPIO_AFRL_AFRL2                  GPIO_AFRL_AFSEL2
+#define GPIO_AFRL_AFRL2_0                GPIO_AFRL_AFSEL2_0
+#define GPIO_AFRL_AFRL2_1                GPIO_AFRL_AFSEL2_1
+#define GPIO_AFRL_AFRL2_2                GPIO_AFRL_AFSEL2_2
+#define GPIO_AFRL_AFRL2_3                GPIO_AFRL_AFSEL2_3
+#define GPIO_AFRL_AFRL3                  GPIO_AFRL_AFSEL3
+#define GPIO_AFRL_AFRL3_0                GPIO_AFRL_AFSEL3_0
+#define GPIO_AFRL_AFRL3_1                GPIO_AFRL_AFSEL3_1
+#define GPIO_AFRL_AFRL3_2                GPIO_AFRL_AFSEL3_2
+#define GPIO_AFRL_AFRL3_3                GPIO_AFRL_AFSEL3_3
+#define GPIO_AFRL_AFRL4                  GPIO_AFRL_AFSEL4
+#define GPIO_AFRL_AFRL4_0                GPIO_AFRL_AFSEL4_0
+#define GPIO_AFRL_AFRL4_1                GPIO_AFRL_AFSEL4_1
+#define GPIO_AFRL_AFRL4_2                GPIO_AFRL_AFSEL4_2
+#define GPIO_AFRL_AFRL4_3                GPIO_AFRL_AFSEL4_3
+#define GPIO_AFRL_AFRL5                  GPIO_AFRL_AFSEL5
+#define GPIO_AFRL_AFRL5_0                GPIO_AFRL_AFSEL5_0
+#define GPIO_AFRL_AFRL5_1                GPIO_AFRL_AFSEL5_1
+#define GPIO_AFRL_AFRL5_2                GPIO_AFRL_AFSEL5_2
+#define GPIO_AFRL_AFRL5_3                GPIO_AFRL_AFSEL5_3
+#define GPIO_AFRL_AFRL6                  GPIO_AFRL_AFSEL6
+#define GPIO_AFRL_AFRL6_0                GPIO_AFRL_AFSEL6_0
+#define GPIO_AFRL_AFRL6_1                GPIO_AFRL_AFSEL6_1
+#define GPIO_AFRL_AFRL6_2                GPIO_AFRL_AFSEL6_2
+#define GPIO_AFRL_AFRL6_3                GPIO_AFRL_AFSEL6_3
+#define GPIO_AFRL_AFRL7                  GPIO_AFRL_AFSEL7
+#define GPIO_AFRL_AFRL7_0                GPIO_AFRL_AFSEL7_0
+#define GPIO_AFRL_AFRL7_1                GPIO_AFRL_AFSEL7_1
+#define GPIO_AFRL_AFRL7_2                GPIO_AFRL_AFSEL7_2
+#define GPIO_AFRL_AFRL7_3                GPIO_AFRL_AFSEL7_3
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos             (0U)                                  
+#define GPIO_AFRH_AFSEL8_Msk             (0xFUL << GPIO_AFRH_AFSEL8_Pos)        /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                 GPIO_AFRH_AFSEL8_Msk                  
+#define GPIO_AFRH_AFSEL8_0               (0x1UL << GPIO_AFRH_AFSEL8_Pos)        /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1               (0x2UL << GPIO_AFRH_AFSEL8_Pos)        /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2               (0x4UL << GPIO_AFRH_AFSEL8_Pos)        /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3               (0x8UL << GPIO_AFRH_AFSEL8_Pos)        /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos             (4U)                                  
+#define GPIO_AFRH_AFSEL9_Msk             (0xFUL << GPIO_AFRH_AFSEL9_Pos)        /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                 GPIO_AFRH_AFSEL9_Msk                  
+#define GPIO_AFRH_AFSEL9_0               (0x1UL << GPIO_AFRH_AFSEL9_Pos)        /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1               (0x2UL << GPIO_AFRH_AFSEL9_Pos)        /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2               (0x4UL << GPIO_AFRH_AFSEL9_Pos)        /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3               (0x8UL << GPIO_AFRH_AFSEL9_Pos)        /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos            (8U)                                  
+#define GPIO_AFRH_AFSEL10_Msk            (0xFUL << GPIO_AFRH_AFSEL10_Pos)       /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                GPIO_AFRH_AFSEL10_Msk                 
+#define GPIO_AFRH_AFSEL10_0              (0x1UL << GPIO_AFRH_AFSEL10_Pos)       /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1              (0x2UL << GPIO_AFRH_AFSEL10_Pos)       /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2              (0x4UL << GPIO_AFRH_AFSEL10_Pos)       /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3              (0x8UL << GPIO_AFRH_AFSEL10_Pos)       /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos            (12U)                                 
+#define GPIO_AFRH_AFSEL11_Msk            (0xFUL << GPIO_AFRH_AFSEL11_Pos)       /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                GPIO_AFRH_AFSEL11_Msk                 
+#define GPIO_AFRH_AFSEL11_0              (0x1UL << GPIO_AFRH_AFSEL11_Pos)       /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1              (0x2UL << GPIO_AFRH_AFSEL11_Pos)       /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2              (0x4UL << GPIO_AFRH_AFSEL11_Pos)       /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3              (0x8UL << GPIO_AFRH_AFSEL11_Pos)       /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos            (16U)                                 
+#define GPIO_AFRH_AFSEL12_Msk            (0xFUL << GPIO_AFRH_AFSEL12_Pos)       /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                GPIO_AFRH_AFSEL12_Msk                 
+#define GPIO_AFRH_AFSEL12_0              (0x1UL << GPIO_AFRH_AFSEL12_Pos)       /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1              (0x2UL << GPIO_AFRH_AFSEL12_Pos)       /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2              (0x4UL << GPIO_AFRH_AFSEL12_Pos)       /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3              (0x8UL << GPIO_AFRH_AFSEL12_Pos)       /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos            (20U)                                 
+#define GPIO_AFRH_AFSEL13_Msk            (0xFUL << GPIO_AFRH_AFSEL13_Pos)       /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                GPIO_AFRH_AFSEL13_Msk                 
+#define GPIO_AFRH_AFSEL13_0              (0x1UL << GPIO_AFRH_AFSEL13_Pos)       /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1              (0x2UL << GPIO_AFRH_AFSEL13_Pos)       /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2              (0x4UL << GPIO_AFRH_AFSEL13_Pos)       /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3              (0x8UL << GPIO_AFRH_AFSEL13_Pos)       /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos            (24U)                                 
+#define GPIO_AFRH_AFSEL14_Msk            (0xFUL << GPIO_AFRH_AFSEL14_Pos)       /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                GPIO_AFRH_AFSEL14_Msk                 
+#define GPIO_AFRH_AFSEL14_0              (0x1UL << GPIO_AFRH_AFSEL14_Pos)       /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1              (0x2UL << GPIO_AFRH_AFSEL14_Pos)       /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2              (0x4UL << GPIO_AFRH_AFSEL14_Pos)       /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3              (0x8UL << GPIO_AFRH_AFSEL14_Pos)       /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos            (28U)                                 
+#define GPIO_AFRH_AFSEL15_Msk            (0xFUL << GPIO_AFRH_AFSEL15_Pos)       /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                GPIO_AFRH_AFSEL15_Msk                 
+#define GPIO_AFRH_AFSEL15_0              (0x1UL << GPIO_AFRH_AFSEL15_Pos)       /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1              (0x2UL << GPIO_AFRH_AFSEL15_Pos)       /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2              (0x4UL << GPIO_AFRH_AFSEL15_Pos)       /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3              (0x8UL << GPIO_AFRH_AFSEL15_Pos)       /*!< 0x80000000 */
+
+/* Legacy defines */
+#define GPIO_AFRH_AFRH0                  GPIO_AFRH_AFSEL8
+#define GPIO_AFRH_AFRH0_0                GPIO_AFRH_AFSEL8_0
+#define GPIO_AFRH_AFRH0_1                GPIO_AFRH_AFSEL8_1
+#define GPIO_AFRH_AFRH0_2                GPIO_AFRH_AFSEL8_2
+#define GPIO_AFRH_AFRH0_3                GPIO_AFRH_AFSEL8_3
+#define GPIO_AFRH_AFRH1                  GPIO_AFRH_AFSEL9
+#define GPIO_AFRH_AFRH1_0                GPIO_AFRH_AFSEL9_0
+#define GPIO_AFRH_AFRH1_1                GPIO_AFRH_AFSEL9_1
+#define GPIO_AFRH_AFRH1_2                GPIO_AFRH_AFSEL9_2
+#define GPIO_AFRH_AFRH1_3                GPIO_AFRH_AFSEL9_3
+#define GPIO_AFRH_AFRH2                  GPIO_AFRH_AFSEL10
+#define GPIO_AFRH_AFRH2_0                GPIO_AFRH_AFSEL10_0
+#define GPIO_AFRH_AFRH2_1                GPIO_AFRH_AFSEL10_1
+#define GPIO_AFRH_AFRH2_2                GPIO_AFRH_AFSEL10_2
+#define GPIO_AFRH_AFRH2_3                GPIO_AFRH_AFSEL10_3
+#define GPIO_AFRH_AFRH3                  GPIO_AFRH_AFSEL11
+#define GPIO_AFRH_AFRH3_0                GPIO_AFRH_AFSEL11_0
+#define GPIO_AFRH_AFRH3_1                GPIO_AFRH_AFSEL11_1
+#define GPIO_AFRH_AFRH3_2                GPIO_AFRH_AFSEL11_2
+#define GPIO_AFRH_AFRH3_3                GPIO_AFRH_AFSEL11_3
+#define GPIO_AFRH_AFRH4                  GPIO_AFRH_AFSEL12
+#define GPIO_AFRH_AFRH4_0                GPIO_AFRH_AFSEL12_0
+#define GPIO_AFRH_AFRH4_1                GPIO_AFRH_AFSEL12_1
+#define GPIO_AFRH_AFRH4_2                GPIO_AFRH_AFSEL12_2
+#define GPIO_AFRH_AFRH4_3                GPIO_AFRH_AFSEL12_3
+#define GPIO_AFRH_AFRH5                  GPIO_AFRH_AFSEL13
+#define GPIO_AFRH_AFRH5_0                GPIO_AFRH_AFSEL13_0
+#define GPIO_AFRH_AFRH5_1                GPIO_AFRH_AFSEL13_1
+#define GPIO_AFRH_AFRH5_2                GPIO_AFRH_AFSEL13_2
+#define GPIO_AFRH_AFRH5_3                GPIO_AFRH_AFSEL13_3
+#define GPIO_AFRH_AFRH6                  GPIO_AFRH_AFSEL14
+#define GPIO_AFRH_AFRH6_0                GPIO_AFRH_AFSEL14_0
+#define GPIO_AFRH_AFRH6_1                GPIO_AFRH_AFSEL14_1
+#define GPIO_AFRH_AFRH6_2                GPIO_AFRH_AFSEL14_2
+#define GPIO_AFRH_AFRH6_3                GPIO_AFRH_AFSEL14_3
+#define GPIO_AFRH_AFRH7                  GPIO_AFRH_AFSEL15
+#define GPIO_AFRH_AFRH7_0                GPIO_AFRH_AFSEL15_0
+#define GPIO_AFRH_AFRH7_1                GPIO_AFRH_AFSEL15_1
+#define GPIO_AFRH_AFRH7_2                GPIO_AFRH_AFSEL15_2
+#define GPIO_AFRH_AFRH7_3                GPIO_AFRH_AFSEL15_3
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  ********************/
+#define I2C_CR1_PE_Pos            (0U)                                         
+#define I2C_CR1_PE_Msk            (0x1UL << I2C_CR1_PE_Pos)                     /*!< 0x00000001 */
+#define I2C_CR1_PE                I2C_CR1_PE_Msk                               /*!<Peripheral Enable                             */
+#define I2C_CR1_SMBUS_Pos         (1U)                                         
+#define I2C_CR1_SMBUS_Msk         (0x1UL << I2C_CR1_SMBUS_Pos)                  /*!< 0x00000002 */
+#define I2C_CR1_SMBUS             I2C_CR1_SMBUS_Msk                            /*!<SMBus Mode                                    */
+#define I2C_CR1_SMBTYPE_Pos       (3U)                                         
+#define I2C_CR1_SMBTYPE_Msk       (0x1UL << I2C_CR1_SMBTYPE_Pos)                /*!< 0x00000008 */
+#define I2C_CR1_SMBTYPE           I2C_CR1_SMBTYPE_Msk                          /*!<SMBus Type                                    */
+#define I2C_CR1_ENARP_Pos         (4U)                                         
+#define I2C_CR1_ENARP_Msk         (0x1UL << I2C_CR1_ENARP_Pos)                  /*!< 0x00000010 */
+#define I2C_CR1_ENARP             I2C_CR1_ENARP_Msk                            /*!<ARP Enable                                    */
+#define I2C_CR1_ENPEC_Pos         (5U)                                         
+#define I2C_CR1_ENPEC_Msk         (0x1UL << I2C_CR1_ENPEC_Pos)                  /*!< 0x00000020 */
+#define I2C_CR1_ENPEC             I2C_CR1_ENPEC_Msk                            /*!<PEC Enable                                    */
+#define I2C_CR1_ENGC_Pos          (6U)                                         
+#define I2C_CR1_ENGC_Msk          (0x1UL << I2C_CR1_ENGC_Pos)                   /*!< 0x00000040 */
+#define I2C_CR1_ENGC              I2C_CR1_ENGC_Msk                             /*!<General Call Enable                           */
+#define I2C_CR1_NOSTRETCH_Pos     (7U)                                         
+#define I2C_CR1_NOSTRETCH_Msk     (0x1UL << I2C_CR1_NOSTRETCH_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_NOSTRETCH         I2C_CR1_NOSTRETCH_Msk                        /*!<Clock Stretching Disable (Slave mode)         */
+#define I2C_CR1_START_Pos         (8U)                                         
+#define I2C_CR1_START_Msk         (0x1UL << I2C_CR1_START_Pos)                  /*!< 0x00000100 */
+#define I2C_CR1_START             I2C_CR1_START_Msk                            /*!<Start Generation                              */
+#define I2C_CR1_STOP_Pos          (9U)                                         
+#define I2C_CR1_STOP_Msk          (0x1UL << I2C_CR1_STOP_Pos)                   /*!< 0x00000200 */
+#define I2C_CR1_STOP              I2C_CR1_STOP_Msk                             /*!<Stop Generation                               */
+#define I2C_CR1_ACK_Pos           (10U)                                        
+#define I2C_CR1_ACK_Msk           (0x1UL << I2C_CR1_ACK_Pos)                    /*!< 0x00000400 */
+#define I2C_CR1_ACK               I2C_CR1_ACK_Msk                              /*!<Acknowledge Enable                            */
+#define I2C_CR1_POS_Pos           (11U)                                        
+#define I2C_CR1_POS_Msk           (0x1UL << I2C_CR1_POS_Pos)                    /*!< 0x00000800 */
+#define I2C_CR1_POS               I2C_CR1_POS_Msk                              /*!<Acknowledge/PEC Position (for data reception) */
+#define I2C_CR1_PEC_Pos           (12U)                                        
+#define I2C_CR1_PEC_Msk           (0x1UL << I2C_CR1_PEC_Pos)                    /*!< 0x00001000 */
+#define I2C_CR1_PEC               I2C_CR1_PEC_Msk                              /*!<Packet Error Checking                         */
+#define I2C_CR1_ALERT_Pos         (13U)                                        
+#define I2C_CR1_ALERT_Msk         (0x1UL << I2C_CR1_ALERT_Pos)                  /*!< 0x00002000 */
+#define I2C_CR1_ALERT             I2C_CR1_ALERT_Msk                            /*!<SMBus Alert                                   */
+#define I2C_CR1_SWRST_Pos         (15U)                                        
+#define I2C_CR1_SWRST_Msk         (0x1UL << I2C_CR1_SWRST_Pos)                  /*!< 0x00008000 */
+#define I2C_CR1_SWRST             I2C_CR1_SWRST_Msk                            /*!<Software Reset                                */
+
+/*******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_FREQ_Pos          (0U)                                         
+#define I2C_CR2_FREQ_Msk          (0x3FUL << I2C_CR2_FREQ_Pos)                  /*!< 0x0000003F */
+#define I2C_CR2_FREQ              I2C_CR2_FREQ_Msk                             /*!<FREQ[5:0] bits (Peripheral Clock Frequency)   */
+#define I2C_CR2_FREQ_0            (0x01UL << I2C_CR2_FREQ_Pos)                  /*!< 0x00000001 */
+#define I2C_CR2_FREQ_1            (0x02UL << I2C_CR2_FREQ_Pos)                  /*!< 0x00000002 */
+#define I2C_CR2_FREQ_2            (0x04UL << I2C_CR2_FREQ_Pos)                  /*!< 0x00000004 */
+#define I2C_CR2_FREQ_3            (0x08UL << I2C_CR2_FREQ_Pos)                  /*!< 0x00000008 */
+#define I2C_CR2_FREQ_4            (0x10UL << I2C_CR2_FREQ_Pos)                  /*!< 0x00000010 */
+#define I2C_CR2_FREQ_5            (0x20UL << I2C_CR2_FREQ_Pos)                  /*!< 0x00000020 */
+
+#define I2C_CR2_ITERREN_Pos       (8U)                                         
+#define I2C_CR2_ITERREN_Msk       (0x1UL << I2C_CR2_ITERREN_Pos)                /*!< 0x00000100 */
+#define I2C_CR2_ITERREN           I2C_CR2_ITERREN_Msk                          /*!<Error Interrupt Enable  */
+#define I2C_CR2_ITEVTEN_Pos       (9U)                                         
+#define I2C_CR2_ITEVTEN_Msk       (0x1UL << I2C_CR2_ITEVTEN_Pos)                /*!< 0x00000200 */
+#define I2C_CR2_ITEVTEN           I2C_CR2_ITEVTEN_Msk                          /*!<Event Interrupt Enable  */
+#define I2C_CR2_ITBUFEN_Pos       (10U)                                        
+#define I2C_CR2_ITBUFEN_Msk       (0x1UL << I2C_CR2_ITBUFEN_Pos)                /*!< 0x00000400 */
+#define I2C_CR2_ITBUFEN           I2C_CR2_ITBUFEN_Msk                          /*!<Buffer Interrupt Enable */
+#define I2C_CR2_DMAEN_Pos         (11U)                                        
+#define I2C_CR2_DMAEN_Msk         (0x1UL << I2C_CR2_DMAEN_Pos)                  /*!< 0x00000800 */
+#define I2C_CR2_DMAEN             I2C_CR2_DMAEN_Msk                            /*!<DMA Requests Enable     */
+#define I2C_CR2_LAST_Pos          (12U)                                        
+#define I2C_CR2_LAST_Msk          (0x1UL << I2C_CR2_LAST_Pos)                   /*!< 0x00001000 */
+#define I2C_CR2_LAST              I2C_CR2_LAST_Msk                             /*!<DMA Last Transfer       */
+
+/*******************  Bit definition for I2C_OAR1 register  *******************/
+#define I2C_OAR1_ADD1_7           0x000000FEU                                  /*!<Interface Address */
+#define I2C_OAR1_ADD8_9           0x00000300U                                  /*!<Interface Address */
+
+#define I2C_OAR1_ADD0_Pos         (0U)                                         
+#define I2C_OAR1_ADD0_Msk         (0x1UL << I2C_OAR1_ADD0_Pos)                  /*!< 0x00000001 */
+#define I2C_OAR1_ADD0             I2C_OAR1_ADD0_Msk                            /*!<Bit 0 */
+#define I2C_OAR1_ADD1_Pos         (1U)                                         
+#define I2C_OAR1_ADD1_Msk         (0x1UL << I2C_OAR1_ADD1_Pos)                  /*!< 0x00000002 */
+#define I2C_OAR1_ADD1             I2C_OAR1_ADD1_Msk                            /*!<Bit 1 */
+#define I2C_OAR1_ADD2_Pos         (2U)                                         
+#define I2C_OAR1_ADD2_Msk         (0x1UL << I2C_OAR1_ADD2_Pos)                  /*!< 0x00000004 */
+#define I2C_OAR1_ADD2             I2C_OAR1_ADD2_Msk                            /*!<Bit 2 */
+#define I2C_OAR1_ADD3_Pos         (3U)                                         
+#define I2C_OAR1_ADD3_Msk         (0x1UL << I2C_OAR1_ADD3_Pos)                  /*!< 0x00000008 */
+#define I2C_OAR1_ADD3             I2C_OAR1_ADD3_Msk                            /*!<Bit 3 */
+#define I2C_OAR1_ADD4_Pos         (4U)                                         
+#define I2C_OAR1_ADD4_Msk         (0x1UL << I2C_OAR1_ADD4_Pos)                  /*!< 0x00000010 */
+#define I2C_OAR1_ADD4             I2C_OAR1_ADD4_Msk                            /*!<Bit 4 */
+#define I2C_OAR1_ADD5_Pos         (5U)                                         
+#define I2C_OAR1_ADD5_Msk         (0x1UL << I2C_OAR1_ADD5_Pos)                  /*!< 0x00000020 */
+#define I2C_OAR1_ADD5             I2C_OAR1_ADD5_Msk                            /*!<Bit 5 */
+#define I2C_OAR1_ADD6_Pos         (6U)                                         
+#define I2C_OAR1_ADD6_Msk         (0x1UL << I2C_OAR1_ADD6_Pos)                  /*!< 0x00000040 */
+#define I2C_OAR1_ADD6             I2C_OAR1_ADD6_Msk                            /*!<Bit 6 */
+#define I2C_OAR1_ADD7_Pos         (7U)                                         
+#define I2C_OAR1_ADD7_Msk         (0x1UL << I2C_OAR1_ADD7_Pos)                  /*!< 0x00000080 */
+#define I2C_OAR1_ADD7             I2C_OAR1_ADD7_Msk                            /*!<Bit 7 */
+#define I2C_OAR1_ADD8_Pos         (8U)                                         
+#define I2C_OAR1_ADD8_Msk         (0x1UL << I2C_OAR1_ADD8_Pos)                  /*!< 0x00000100 */
+#define I2C_OAR1_ADD8             I2C_OAR1_ADD8_Msk                            /*!<Bit 8 */
+#define I2C_OAR1_ADD9_Pos         (9U)                                         
+#define I2C_OAR1_ADD9_Msk         (0x1UL << I2C_OAR1_ADD9_Pos)                  /*!< 0x00000200 */
+#define I2C_OAR1_ADD9             I2C_OAR1_ADD9_Msk                            /*!<Bit 9 */
+
+#define I2C_OAR1_ADDMODE_Pos      (15U)                                        
+#define I2C_OAR1_ADDMODE_Msk      (0x1UL << I2C_OAR1_ADDMODE_Pos)               /*!< 0x00008000 */
+#define I2C_OAR1_ADDMODE          I2C_OAR1_ADDMODE_Msk                         /*!<Addressing Mode (Slave mode) */
+
+/*******************  Bit definition for I2C_OAR2 register  *******************/
+#define I2C_OAR2_ENDUAL_Pos       (0U)                                         
+#define I2C_OAR2_ENDUAL_Msk       (0x1UL << I2C_OAR2_ENDUAL_Pos)                /*!< 0x00000001 */
+#define I2C_OAR2_ENDUAL           I2C_OAR2_ENDUAL_Msk                          /*!<Dual addressing mode enable */
+#define I2C_OAR2_ADD2_Pos         (1U)                                         
+#define I2C_OAR2_ADD2_Msk         (0x7FUL << I2C_OAR2_ADD2_Pos)                 /*!< 0x000000FE */
+#define I2C_OAR2_ADD2             I2C_OAR2_ADD2_Msk                            /*!<Interface address           */
+
+/********************  Bit definition for I2C_DR register  ********************/
+#define I2C_DR_DR_Pos             (0U)                                         
+#define I2C_DR_DR_Msk             (0xFFUL << I2C_DR_DR_Pos)                     /*!< 0x000000FF */
+#define I2C_DR_DR                 I2C_DR_DR_Msk                                /*!<8-bit Data Register         */
+
+/*******************  Bit definition for I2C_SR1 register  ********************/
+#define I2C_SR1_SB_Pos            (0U)                                         
+#define I2C_SR1_SB_Msk            (0x1UL << I2C_SR1_SB_Pos)                     /*!< 0x00000001 */
+#define I2C_SR1_SB                I2C_SR1_SB_Msk                               /*!<Start Bit (Master mode)                         */
+#define I2C_SR1_ADDR_Pos          (1U)                                         
+#define I2C_SR1_ADDR_Msk          (0x1UL << I2C_SR1_ADDR_Pos)                   /*!< 0x00000002 */
+#define I2C_SR1_ADDR              I2C_SR1_ADDR_Msk                             /*!<Address sent (master mode)/matched (slave mode) */
+#define I2C_SR1_BTF_Pos           (2U)                                         
+#define I2C_SR1_BTF_Msk           (0x1UL << I2C_SR1_BTF_Pos)                    /*!< 0x00000004 */
+#define I2C_SR1_BTF               I2C_SR1_BTF_Msk                              /*!<Byte Transfer Finished                          */
+#define I2C_SR1_ADD10_Pos         (3U)                                         
+#define I2C_SR1_ADD10_Msk         (0x1UL << I2C_SR1_ADD10_Pos)                  /*!< 0x00000008 */
+#define I2C_SR1_ADD10             I2C_SR1_ADD10_Msk                            /*!<10-bit header sent (Master mode)                */
+#define I2C_SR1_STOPF_Pos         (4U)                                         
+#define I2C_SR1_STOPF_Msk         (0x1UL << I2C_SR1_STOPF_Pos)                  /*!< 0x00000010 */
+#define I2C_SR1_STOPF             I2C_SR1_STOPF_Msk                            /*!<Stop detection (Slave mode)                     */
+#define I2C_SR1_RXNE_Pos          (6U)                                         
+#define I2C_SR1_RXNE_Msk          (0x1UL << I2C_SR1_RXNE_Pos)                   /*!< 0x00000040 */
+#define I2C_SR1_RXNE              I2C_SR1_RXNE_Msk                             /*!<Data Register not Empty (receivers)             */
+#define I2C_SR1_TXE_Pos           (7U)                                         
+#define I2C_SR1_TXE_Msk           (0x1UL << I2C_SR1_TXE_Pos)                    /*!< 0x00000080 */
+#define I2C_SR1_TXE               I2C_SR1_TXE_Msk                              /*!<Data Register Empty (transmitters)              */
+#define I2C_SR1_BERR_Pos          (8U)                                         
+#define I2C_SR1_BERR_Msk          (0x1UL << I2C_SR1_BERR_Pos)                   /*!< 0x00000100 */
+#define I2C_SR1_BERR              I2C_SR1_BERR_Msk                             /*!<Bus Error                                       */
+#define I2C_SR1_ARLO_Pos          (9U)                                         
+#define I2C_SR1_ARLO_Msk          (0x1UL << I2C_SR1_ARLO_Pos)                   /*!< 0x00000200 */
+#define I2C_SR1_ARLO              I2C_SR1_ARLO_Msk                             /*!<Arbitration Lost (master mode)                  */
+#define I2C_SR1_AF_Pos            (10U)                                        
+#define I2C_SR1_AF_Msk            (0x1UL << I2C_SR1_AF_Pos)                     /*!< 0x00000400 */
+#define I2C_SR1_AF                I2C_SR1_AF_Msk                               /*!<Acknowledge Failure                             */
+#define I2C_SR1_OVR_Pos           (11U)                                        
+#define I2C_SR1_OVR_Msk           (0x1UL << I2C_SR1_OVR_Pos)                    /*!< 0x00000800 */
+#define I2C_SR1_OVR               I2C_SR1_OVR_Msk                              /*!<Overrun/Underrun                                */
+#define I2C_SR1_PECERR_Pos        (12U)                                        
+#define I2C_SR1_PECERR_Msk        (0x1UL << I2C_SR1_PECERR_Pos)                 /*!< 0x00001000 */
+#define I2C_SR1_PECERR            I2C_SR1_PECERR_Msk                           /*!<PEC Error in reception                          */
+#define I2C_SR1_TIMEOUT_Pos       (14U)                                        
+#define I2C_SR1_TIMEOUT_Msk       (0x1UL << I2C_SR1_TIMEOUT_Pos)                /*!< 0x00004000 */
+#define I2C_SR1_TIMEOUT           I2C_SR1_TIMEOUT_Msk                          /*!<Timeout or Tlow Error                           */
+#define I2C_SR1_SMBALERT_Pos      (15U)                                        
+#define I2C_SR1_SMBALERT_Msk      (0x1UL << I2C_SR1_SMBALERT_Pos)               /*!< 0x00008000 */
+#define I2C_SR1_SMBALERT          I2C_SR1_SMBALERT_Msk                         /*!<SMBus Alert                                     */
+
+/*******************  Bit definition for I2C_SR2 register  ********************/
+#define I2C_SR2_MSL_Pos           (0U)                                         
+#define I2C_SR2_MSL_Msk           (0x1UL << I2C_SR2_MSL_Pos)                    /*!< 0x00000001 */
+#define I2C_SR2_MSL               I2C_SR2_MSL_Msk                              /*!<Master/Slave                                    */
+#define I2C_SR2_BUSY_Pos          (1U)                                         
+#define I2C_SR2_BUSY_Msk          (0x1UL << I2C_SR2_BUSY_Pos)                   /*!< 0x00000002 */
+#define I2C_SR2_BUSY              I2C_SR2_BUSY_Msk                             /*!<Bus Busy                                        */
+#define I2C_SR2_TRA_Pos           (2U)                                         
+#define I2C_SR2_TRA_Msk           (0x1UL << I2C_SR2_TRA_Pos)                    /*!< 0x00000004 */
+#define I2C_SR2_TRA               I2C_SR2_TRA_Msk                              /*!<Transmitter/Receiver                            */
+#define I2C_SR2_GENCALL_Pos       (4U)                                         
+#define I2C_SR2_GENCALL_Msk       (0x1UL << I2C_SR2_GENCALL_Pos)                /*!< 0x00000010 */
+#define I2C_SR2_GENCALL           I2C_SR2_GENCALL_Msk                          /*!<General Call Address (Slave mode)               */
+#define I2C_SR2_SMBDEFAULT_Pos    (5U)                                         
+#define I2C_SR2_SMBDEFAULT_Msk    (0x1UL << I2C_SR2_SMBDEFAULT_Pos)             /*!< 0x00000020 */
+#define I2C_SR2_SMBDEFAULT        I2C_SR2_SMBDEFAULT_Msk                       /*!<SMBus Device Default Address (Slave mode)       */
+#define I2C_SR2_SMBHOST_Pos       (6U)                                         
+#define I2C_SR2_SMBHOST_Msk       (0x1UL << I2C_SR2_SMBHOST_Pos)                /*!< 0x00000040 */
+#define I2C_SR2_SMBHOST           I2C_SR2_SMBHOST_Msk                          /*!<SMBus Host Header (Slave mode)                  */
+#define I2C_SR2_DUALF_Pos         (7U)                                         
+#define I2C_SR2_DUALF_Msk         (0x1UL << I2C_SR2_DUALF_Pos)                  /*!< 0x00000080 */
+#define I2C_SR2_DUALF             I2C_SR2_DUALF_Msk                            /*!<Dual Flag (Slave mode)                          */
+#define I2C_SR2_PEC_Pos           (8U)                                         
+#define I2C_SR2_PEC_Msk           (0xFFUL << I2C_SR2_PEC_Pos)                   /*!< 0x0000FF00 */
+#define I2C_SR2_PEC               I2C_SR2_PEC_Msk                              /*!<Packet Error Checking Register                  */
+
+/*******************  Bit definition for I2C_CCR register  ********************/
+#define I2C_CCR_CCR_Pos           (0U)                                         
+#define I2C_CCR_CCR_Msk           (0xFFFUL << I2C_CCR_CCR_Pos)                  /*!< 0x00000FFF */
+#define I2C_CCR_CCR               I2C_CCR_CCR_Msk                              /*!<Clock Control Register in Fast/Standard mode (Master mode) */
+#define I2C_CCR_DUTY_Pos          (14U)                                        
+#define I2C_CCR_DUTY_Msk          (0x1UL << I2C_CCR_DUTY_Pos)                   /*!< 0x00004000 */
+#define I2C_CCR_DUTY              I2C_CCR_DUTY_Msk                             /*!<Fast Mode Duty Cycle                                       */
+#define I2C_CCR_FS_Pos            (15U)                                        
+#define I2C_CCR_FS_Msk            (0x1UL << I2C_CCR_FS_Pos)                     /*!< 0x00008000 */
+#define I2C_CCR_FS                I2C_CCR_FS_Msk                               /*!<I2C Master Mode Selection                                  */
+
+/******************  Bit definition for I2C_TRISE register  *******************/
+#define I2C_TRISE_TRISE_Pos       (0U)                                         
+#define I2C_TRISE_TRISE_Msk       (0x3FUL << I2C_TRISE_TRISE_Pos)               /*!< 0x0000003F */
+#define I2C_TRISE_TRISE           I2C_TRISE_TRISE_Msk                          /*!<Maximum Rise Time in Fast/Standard mode (Master mode) */
+
+/******************  Bit definition for I2C_FLTR register  *******************/
+#define I2C_FLTR_DNF_Pos          (0U)                                         
+#define I2C_FLTR_DNF_Msk          (0xFUL << I2C_FLTR_DNF_Pos)                   /*!< 0x0000000F */
+#define I2C_FLTR_DNF              I2C_FLTR_DNF_Msk                             /*!<Digital Noise Filter */
+#define I2C_FLTR_ANOFF_Pos        (4U)                                         
+#define I2C_FLTR_ANOFF_Msk        (0x1UL << I2C_FLTR_ANOFF_Pos)                 /*!< 0x00000010 */
+#define I2C_FLTR_ANOFF            I2C_FLTR_ANOFF_Msk                           /*!<Analog Noise Filter OFF */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Independent WATCHDOG                             */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos     (0U)                                               
+#define IWDG_KR_KEY_Msk     (0xFFFFUL << IWDG_KR_KEY_Pos)                       /*!< 0x0000FFFF */
+#define IWDG_KR_KEY         IWDG_KR_KEY_Msk                                    /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos      (0U)                                               
+#define IWDG_PR_PR_Msk      (0x7UL << IWDG_PR_PR_Pos)                           /*!< 0x00000007 */
+#define IWDG_PR_PR          IWDG_PR_PR_Msk                                     /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0        (0x1UL << IWDG_PR_PR_Pos)                           /*!< 0x01 */
+#define IWDG_PR_PR_1        (0x2UL << IWDG_PR_PR_Pos)                           /*!< 0x02 */
+#define IWDG_PR_PR_2        (0x4UL << IWDG_PR_PR_Pos)                           /*!< 0x04 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos     (0U)                                               
+#define IWDG_RLR_RL_Msk     (0xFFFUL << IWDG_RLR_RL_Pos)                        /*!< 0x00000FFF */
+#define IWDG_RLR_RL         IWDG_RLR_RL_Msk                                    /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos     (0U)                                               
+#define IWDG_SR_PVU_Msk     (0x1UL << IWDG_SR_PVU_Pos)                          /*!< 0x00000001 */
+#define IWDG_SR_PVU         IWDG_SR_PVU_Msk                                    /*!<Watchdog prescaler value update      */
+#define IWDG_SR_RVU_Pos     (1U)                                               
+#define IWDG_SR_RVU_Msk     (0x1UL << IWDG_SR_RVU_Pos)                          /*!< 0x00000002 */
+#define IWDG_SR_RVU         IWDG_SR_RVU_Msk                                    /*!<Watchdog counter reload value update */
+
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                             Power Control                                  */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for PWR_CR register  ********************/
+#define PWR_CR_LPDS_Pos        (0U)                                            
+#define PWR_CR_LPDS_Msk        (0x1UL << PWR_CR_LPDS_Pos)                       /*!< 0x00000001 */
+#define PWR_CR_LPDS            PWR_CR_LPDS_Msk                                 /*!< Low-Power Deepsleep                 */
+#define PWR_CR_PDDS_Pos        (1U)                                            
+#define PWR_CR_PDDS_Msk        (0x1UL << PWR_CR_PDDS_Pos)                       /*!< 0x00000002 */
+#define PWR_CR_PDDS            PWR_CR_PDDS_Msk                                 /*!< Power Down Deepsleep                */
+#define PWR_CR_CWUF_Pos        (2U)                                            
+#define PWR_CR_CWUF_Msk        (0x1UL << PWR_CR_CWUF_Pos)                       /*!< 0x00000004 */
+#define PWR_CR_CWUF            PWR_CR_CWUF_Msk                                 /*!< Clear Wakeup Flag                   */
+#define PWR_CR_CSBF_Pos        (3U)                                            
+#define PWR_CR_CSBF_Msk        (0x1UL << PWR_CR_CSBF_Pos)                       /*!< 0x00000008 */
+#define PWR_CR_CSBF            PWR_CR_CSBF_Msk                                 /*!< Clear Standby Flag                  */
+#define PWR_CR_PVDE_Pos        (4U)                                            
+#define PWR_CR_PVDE_Msk        (0x1UL << PWR_CR_PVDE_Pos)                       /*!< 0x00000010 */
+#define PWR_CR_PVDE            PWR_CR_PVDE_Msk                                 /*!< Power Voltage Detector Enable       */
+
+#define PWR_CR_PLS_Pos         (5U)                                            
+#define PWR_CR_PLS_Msk         (0x7UL << PWR_CR_PLS_Pos)                        /*!< 0x000000E0 */
+#define PWR_CR_PLS             PWR_CR_PLS_Msk                                  /*!< PLS[2:0] bits (PVD Level Selection) */
+#define PWR_CR_PLS_0           (0x1UL << PWR_CR_PLS_Pos)                        /*!< 0x00000020 */
+#define PWR_CR_PLS_1           (0x2UL << PWR_CR_PLS_Pos)                        /*!< 0x00000040 */
+#define PWR_CR_PLS_2           (0x4UL << PWR_CR_PLS_Pos)                        /*!< 0x00000080 */
+
+/*!< PVD level configuration */
+#define PWR_CR_PLS_LEV0        0x00000000U                                     /*!< PVD level 0 */
+#define PWR_CR_PLS_LEV1        0x00000020U                                     /*!< PVD level 1 */
+#define PWR_CR_PLS_LEV2        0x00000040U                                     /*!< PVD level 2 */
+#define PWR_CR_PLS_LEV3        0x00000060U                                     /*!< PVD level 3 */
+#define PWR_CR_PLS_LEV4        0x00000080U                                     /*!< PVD level 4 */
+#define PWR_CR_PLS_LEV5        0x000000A0U                                     /*!< PVD level 5 */
+#define PWR_CR_PLS_LEV6        0x000000C0U                                     /*!< PVD level 6 */
+#define PWR_CR_PLS_LEV7        0x000000E0U                                     /*!< PVD level 7 */
+#define PWR_CR_DBP_Pos         (8U)                                            
+#define PWR_CR_DBP_Msk         (0x1UL << PWR_CR_DBP_Pos)                        /*!< 0x00000100 */
+#define PWR_CR_DBP             PWR_CR_DBP_Msk                                  /*!< Disable Backup Domain write protection                     */
+#define PWR_CR_FPDS_Pos        (9U)                                            
+#define PWR_CR_FPDS_Msk        (0x1UL << PWR_CR_FPDS_Pos)                       /*!< 0x00000200 */
+#define PWR_CR_FPDS            PWR_CR_FPDS_Msk                                 /*!< Flash power down in Stop mode                              */
+#define PWR_CR_LPLVDS_Pos      (10U)                                           
+#define PWR_CR_LPLVDS_Msk      (0x1UL << PWR_CR_LPLVDS_Pos)                     /*!< 0x00000400 */
+#define PWR_CR_LPLVDS          PWR_CR_LPLVDS_Msk                               /*!< Low Power Regulator Low Voltage in Deep Sleep mode         */
+#define PWR_CR_MRLVDS_Pos      (11U)                                           
+#define PWR_CR_MRLVDS_Msk      (0x1UL << PWR_CR_MRLVDS_Pos)                     /*!< 0x00000800 */
+#define PWR_CR_MRLVDS          PWR_CR_MRLVDS_Msk                               /*!< Main Regulator Low Voltage in Deep Sleep mode              */
+#define PWR_CR_ADCDC1_Pos      (13U)                                           
+#define PWR_CR_ADCDC1_Msk      (0x1UL << PWR_CR_ADCDC1_Pos)                     /*!< 0x00002000 */
+#define PWR_CR_ADCDC1          PWR_CR_ADCDC1_Msk                               /*!< Refer to AN4073 on how to use this bit                     */ 
+#define PWR_CR_VOS_Pos         (14U)                                           
+#define PWR_CR_VOS_Msk         (0x3UL << PWR_CR_VOS_Pos)                        /*!< 0x0000C000 */
+#define PWR_CR_VOS             PWR_CR_VOS_Msk                                  /*!< VOS[1:0] bits (Regulator voltage scaling output selection) */
+#define PWR_CR_VOS_0           0x00004000U                                     /*!< Bit 0 */
+#define PWR_CR_VOS_1           0x00008000U                                     /*!< Bit 1 */
+
+/* Legacy define */
+#define  PWR_CR_PMODE                        PWR_CR_VOS
+
+/*******************  Bit definition for PWR_CSR register  ********************/
+#define PWR_CSR_WUF_Pos        (0U)                                            
+#define PWR_CSR_WUF_Msk        (0x1UL << PWR_CSR_WUF_Pos)                       /*!< 0x00000001 */
+#define PWR_CSR_WUF            PWR_CSR_WUF_Msk                                 /*!< Wakeup Flag                                      */
+#define PWR_CSR_SBF_Pos        (1U)                                            
+#define PWR_CSR_SBF_Msk        (0x1UL << PWR_CSR_SBF_Pos)                       /*!< 0x00000002 */
+#define PWR_CSR_SBF            PWR_CSR_SBF_Msk                                 /*!< Standby Flag                                     */
+#define PWR_CSR_PVDO_Pos       (2U)                                            
+#define PWR_CSR_PVDO_Msk       (0x1UL << PWR_CSR_PVDO_Pos)                      /*!< 0x00000004 */
+#define PWR_CSR_PVDO           PWR_CSR_PVDO_Msk                                /*!< PVD Output                                       */
+#define PWR_CSR_BRR_Pos        (3U)                                            
+#define PWR_CSR_BRR_Msk        (0x1UL << PWR_CSR_BRR_Pos)                       /*!< 0x00000008 */
+#define PWR_CSR_BRR            PWR_CSR_BRR_Msk                                 /*!< Backup regulator ready                           */
+#define PWR_CSR_EWUP_Pos       (8U)                                            
+#define PWR_CSR_EWUP_Msk       (0x1UL << PWR_CSR_EWUP_Pos)                      /*!< 0x00000100 */
+#define PWR_CSR_EWUP           PWR_CSR_EWUP_Msk                                /*!< Enable WKUP pin                                  */
+#define PWR_CSR_BRE_Pos        (9U)                                            
+#define PWR_CSR_BRE_Msk        (0x1UL << PWR_CSR_BRE_Pos)                       /*!< 0x00000200 */
+#define PWR_CSR_BRE            PWR_CSR_BRE_Msk                                 /*!< Backup regulator enable                          */
+#define PWR_CSR_VOSRDY_Pos     (14U)                                           
+#define PWR_CSR_VOSRDY_Msk     (0x1UL << PWR_CSR_VOSRDY_Pos)                    /*!< 0x00004000 */
+#define PWR_CSR_VOSRDY         PWR_CSR_VOSRDY_Msk                              /*!< Regulator voltage scaling output selection ready */
+
+/* Legacy define */
+#define  PWR_CSR_REGRDY                      PWR_CSR_VOSRDY
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for RCC_CR register  ********************/
+#define RCC_CR_HSION_Pos                   (0U)                                
+#define RCC_CR_HSION_Msk                   (0x1UL << RCC_CR_HSION_Pos)          /*!< 0x00000001 */
+#define RCC_CR_HSION                       RCC_CR_HSION_Msk                    
+#define RCC_CR_HSIRDY_Pos                  (1U)                                
+#define RCC_CR_HSIRDY_Msk                  (0x1UL << RCC_CR_HSIRDY_Pos)         /*!< 0x00000002 */
+#define RCC_CR_HSIRDY                      RCC_CR_HSIRDY_Msk                   
+
+#define RCC_CR_HSITRIM_Pos                 (3U)                                
+#define RCC_CR_HSITRIM_Msk                 (0x1FUL << RCC_CR_HSITRIM_Pos)       /*!< 0x000000F8 */
+#define RCC_CR_HSITRIM                     RCC_CR_HSITRIM_Msk                  
+#define RCC_CR_HSITRIM_0                   (0x01UL << RCC_CR_HSITRIM_Pos)       /*!< 0x00000008 */
+#define RCC_CR_HSITRIM_1                   (0x02UL << RCC_CR_HSITRIM_Pos)       /*!< 0x00000010 */
+#define RCC_CR_HSITRIM_2                   (0x04UL << RCC_CR_HSITRIM_Pos)       /*!< 0x00000020 */
+#define RCC_CR_HSITRIM_3                   (0x08UL << RCC_CR_HSITRIM_Pos)       /*!< 0x00000040 */
+#define RCC_CR_HSITRIM_4                   (0x10UL << RCC_CR_HSITRIM_Pos)       /*!< 0x00000080 */
+
+#define RCC_CR_HSICAL_Pos                  (8U)                                
+#define RCC_CR_HSICAL_Msk                  (0xFFUL << RCC_CR_HSICAL_Pos)        /*!< 0x0000FF00 */
+#define RCC_CR_HSICAL                      RCC_CR_HSICAL_Msk                   
+#define RCC_CR_HSICAL_0                    (0x01UL << RCC_CR_HSICAL_Pos)        /*!< 0x00000100 */
+#define RCC_CR_HSICAL_1                    (0x02UL << RCC_CR_HSICAL_Pos)        /*!< 0x00000200 */
+#define RCC_CR_HSICAL_2                    (0x04UL << RCC_CR_HSICAL_Pos)        /*!< 0x00000400 */
+#define RCC_CR_HSICAL_3                    (0x08UL << RCC_CR_HSICAL_Pos)        /*!< 0x00000800 */
+#define RCC_CR_HSICAL_4                    (0x10UL << RCC_CR_HSICAL_Pos)        /*!< 0x00001000 */
+#define RCC_CR_HSICAL_5                    (0x20UL << RCC_CR_HSICAL_Pos)        /*!< 0x00002000 */
+#define RCC_CR_HSICAL_6                    (0x40UL << RCC_CR_HSICAL_Pos)        /*!< 0x00004000 */
+#define RCC_CR_HSICAL_7                    (0x80UL << RCC_CR_HSICAL_Pos)        /*!< 0x00008000 */
+
+#define RCC_CR_HSEON_Pos                   (16U)                               
+#define RCC_CR_HSEON_Msk                   (0x1UL << RCC_CR_HSEON_Pos)          /*!< 0x00010000 */
+#define RCC_CR_HSEON                       RCC_CR_HSEON_Msk                    
+#define RCC_CR_HSERDY_Pos                  (17U)                               
+#define RCC_CR_HSERDY_Msk                  (0x1UL << RCC_CR_HSERDY_Pos)         /*!< 0x00020000 */
+#define RCC_CR_HSERDY                      RCC_CR_HSERDY_Msk                   
+#define RCC_CR_HSEBYP_Pos                  (18U)                               
+#define RCC_CR_HSEBYP_Msk                  (0x1UL << RCC_CR_HSEBYP_Pos)         /*!< 0x00040000 */
+#define RCC_CR_HSEBYP                      RCC_CR_HSEBYP_Msk                   
+#define RCC_CR_CSSON_Pos                   (19U)                               
+#define RCC_CR_CSSON_Msk                   (0x1UL << RCC_CR_CSSON_Pos)          /*!< 0x00080000 */
+#define RCC_CR_CSSON                       RCC_CR_CSSON_Msk                    
+#define RCC_CR_PLLON_Pos                   (24U)                               
+#define RCC_CR_PLLON_Msk                   (0x1UL << RCC_CR_PLLON_Pos)          /*!< 0x01000000 */
+#define RCC_CR_PLLON                       RCC_CR_PLLON_Msk                    
+#define RCC_CR_PLLRDY_Pos                  (25U)                               
+#define RCC_CR_PLLRDY_Msk                  (0x1UL << RCC_CR_PLLRDY_Pos)         /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                      RCC_CR_PLLRDY_Msk                   
+/*
+ * @brief Specific device feature definitions (not present on all devices in the STM32F4 serie)
+ */
+#define RCC_PLLI2S_SUPPORT                                                     /*!< Support PLLI2S oscillator */
+
+#define RCC_CR_PLLI2SON_Pos                (26U)                               
+#define RCC_CR_PLLI2SON_Msk                (0x1UL << RCC_CR_PLLI2SON_Pos)       /*!< 0x04000000 */
+#define RCC_CR_PLLI2SON                    RCC_CR_PLLI2SON_Msk                 
+#define RCC_CR_PLLI2SRDY_Pos               (27U)                               
+#define RCC_CR_PLLI2SRDY_Msk               (0x1UL << RCC_CR_PLLI2SRDY_Pos)      /*!< 0x08000000 */
+#define RCC_CR_PLLI2SRDY                   RCC_CR_PLLI2SRDY_Msk                
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLM_Pos               (0U)                                
+#define RCC_PLLCFGR_PLLM_Msk               (0x3FUL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x0000003F */
+#define RCC_PLLCFGR_PLLM                   RCC_PLLCFGR_PLLM_Msk                
+#define RCC_PLLCFGR_PLLM_0                 (0x01UL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLM_1                 (0x02UL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x00000002 */
+#define RCC_PLLCFGR_PLLM_2                 (0x04UL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x00000004 */
+#define RCC_PLLCFGR_PLLM_3                 (0x08UL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x00000008 */
+#define RCC_PLLCFGR_PLLM_4                 (0x10UL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_5                 (0x20UL << RCC_PLLCFGR_PLLM_Pos)     /*!< 0x00000020 */
+
+#define RCC_PLLCFGR_PLLN_Pos               (6U)                                
+#define RCC_PLLCFGR_PLLN_Msk               (0x1FFUL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00007FC0 */
+#define RCC_PLLCFGR_PLLN                   RCC_PLLCFGR_PLLN_Msk                
+#define RCC_PLLCFGR_PLLN_0                 (0x001UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00000040 */
+#define RCC_PLLCFGR_PLLN_1                 (0x002UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00000080 */
+#define RCC_PLLCFGR_PLLN_2                 (0x004UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_3                 (0x008UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_4                 (0x010UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_5                 (0x020UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_6                 (0x040UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_7                 (0x080UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_8                 (0x100UL << RCC_PLLCFGR_PLLN_Pos)    /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLP_Pos               (16U)                               
+#define RCC_PLLCFGR_PLLP_Msk               (0x3UL << RCC_PLLCFGR_PLLP_Pos)      /*!< 0x00030000 */
+#define RCC_PLLCFGR_PLLP                   RCC_PLLCFGR_PLLP_Msk                
+#define RCC_PLLCFGR_PLLP_0                 (0x1UL << RCC_PLLCFGR_PLLP_Pos)      /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLP_1                 (0x2UL << RCC_PLLCFGR_PLLP_Pos)      /*!< 0x00020000 */
+
+#define RCC_PLLCFGR_PLLSRC_Pos             (22U)                               
+#define RCC_PLLCFGR_PLLSRC_Msk             (0x1UL << RCC_PLLCFGR_PLLSRC_Pos)    /*!< 0x00400000 */
+#define RCC_PLLCFGR_PLLSRC                 RCC_PLLCFGR_PLLSRC_Msk              
+#define RCC_PLLCFGR_PLLSRC_HSE_Pos         (22U)                               
+#define RCC_PLLCFGR_PLLSRC_HSE_Msk         (0x1UL << RCC_PLLCFGR_PLLSRC_HSE_Pos) /*!< 0x00400000 */
+#define RCC_PLLCFGR_PLLSRC_HSE             RCC_PLLCFGR_PLLSRC_HSE_Msk          
+#define RCC_PLLCFGR_PLLSRC_HSI             0x00000000U                         
+
+#define RCC_PLLCFGR_PLLQ_Pos               (24U)                               
+#define RCC_PLLCFGR_PLLQ_Msk               (0xFUL << RCC_PLLCFGR_PLLQ_Pos)      /*!< 0x0F000000 */
+#define RCC_PLLCFGR_PLLQ                   RCC_PLLCFGR_PLLQ_Msk                
+#define RCC_PLLCFGR_PLLQ_0                 (0x1UL << RCC_PLLCFGR_PLLQ_Pos)      /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQ_1                 (0x2UL << RCC_PLLCFGR_PLLQ_Pos)      /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_2                 (0x4UL << RCC_PLLCFGR_PLLQ_Pos)      /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_3                 (0x8UL << RCC_PLLCFGR_PLLQ_Pos)      /*!< 0x08000000 */
+
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                    (0U)                                
+#define RCC_CFGR_SW_Msk                    (0x3UL << RCC_CFGR_SW_Pos)           /*!< 0x00000003 */
+#define RCC_CFGR_SW                        RCC_CFGR_SW_Msk                     /*!< SW[1:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                      (0x1UL << RCC_CFGR_SW_Pos)           /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                      (0x2UL << RCC_CFGR_SW_Pos)           /*!< 0x00000002 */
+
+#define RCC_CFGR_SW_HSI                    0x00000000U                         /*!< HSI selected as system clock */
+#define RCC_CFGR_SW_HSE                    0x00000001U                         /*!< HSE selected as system clock */
+#define RCC_CFGR_SW_PLL                    0x00000002U                         /*!< PLL selected as system clock */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos                   (2U)                                
+#define RCC_CFGR_SWS_Msk                   (0x3UL << RCC_CFGR_SWS_Pos)          /*!< 0x0000000C */
+#define RCC_CFGR_SWS                       RCC_CFGR_SWS_Msk                    /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                     (0x1UL << RCC_CFGR_SWS_Pos)          /*!< 0x00000004 */
+#define RCC_CFGR_SWS_1                     (0x2UL << RCC_CFGR_SWS_Pos)          /*!< 0x00000008 */
+
+#define RCC_CFGR_SWS_HSI                   0x00000000U                         /*!< HSI oscillator used as system clock        */
+#define RCC_CFGR_SWS_HSE                   0x00000004U                         /*!< HSE oscillator used as system clock        */
+#define RCC_CFGR_SWS_PLL                   0x00000008U                         /*!< PLL used as system clock                   */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos                  (4U)                                
+#define RCC_CFGR_HPRE_Msk                  (0xFUL << RCC_CFGR_HPRE_Pos)         /*!< 0x000000F0 */
+#define RCC_CFGR_HPRE                      RCC_CFGR_HPRE_Msk                   /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                    (0x1UL << RCC_CFGR_HPRE_Pos)         /*!< 0x00000010 */
+#define RCC_CFGR_HPRE_1                    (0x2UL << RCC_CFGR_HPRE_Pos)         /*!< 0x00000020 */
+#define RCC_CFGR_HPRE_2                    (0x4UL << RCC_CFGR_HPRE_Pos)         /*!< 0x00000040 */
+#define RCC_CFGR_HPRE_3                    (0x8UL << RCC_CFGR_HPRE_Pos)         /*!< 0x00000080 */
+
+#define RCC_CFGR_HPRE_DIV1                 0x00000000U                         /*!< SYSCLK not divided    */
+#define RCC_CFGR_HPRE_DIV2                 0x00000080U                         /*!< SYSCLK divided by 2   */
+#define RCC_CFGR_HPRE_DIV4                 0x00000090U                         /*!< SYSCLK divided by 4   */
+#define RCC_CFGR_HPRE_DIV8                 0x000000A0U                         /*!< SYSCLK divided by 8   */
+#define RCC_CFGR_HPRE_DIV16                0x000000B0U                         /*!< SYSCLK divided by 16  */
+#define RCC_CFGR_HPRE_DIV64                0x000000C0U                         /*!< SYSCLK divided by 64  */
+#define RCC_CFGR_HPRE_DIV128               0x000000D0U                         /*!< SYSCLK divided by 128 */
+#define RCC_CFGR_HPRE_DIV256               0x000000E0U                         /*!< SYSCLK divided by 256 */
+#define RCC_CFGR_HPRE_DIV512               0x000000F0U                         /*!< SYSCLK divided by 512 */
+
+/*!< PPRE1 configuration */
+#define RCC_CFGR_PPRE1_Pos                 (10U)                               
+#define RCC_CFGR_PPRE1_Msk                 (0x7UL << RCC_CFGR_PPRE1_Pos)        /*!< 0x00001C00 */
+#define RCC_CFGR_PPRE1                     RCC_CFGR_PPRE1_Msk                  /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define RCC_CFGR_PPRE1_0                   (0x1UL << RCC_CFGR_PPRE1_Pos)        /*!< 0x00000400 */
+#define RCC_CFGR_PPRE1_1                   (0x2UL << RCC_CFGR_PPRE1_Pos)        /*!< 0x00000800 */
+#define RCC_CFGR_PPRE1_2                   (0x4UL << RCC_CFGR_PPRE1_Pos)        /*!< 0x00001000 */
+
+#define RCC_CFGR_PPRE1_DIV1                0x00000000U                         /*!< HCLK not divided   */
+#define RCC_CFGR_PPRE1_DIV2                0x00001000U                         /*!< HCLK divided by 2  */
+#define RCC_CFGR_PPRE1_DIV4                0x00001400U                         /*!< HCLK divided by 4  */
+#define RCC_CFGR_PPRE1_DIV8                0x00001800U                         /*!< HCLK divided by 8  */
+#define RCC_CFGR_PPRE1_DIV16               0x00001C00U                         /*!< HCLK divided by 16 */
+
+/*!< PPRE2 configuration */
+#define RCC_CFGR_PPRE2_Pos                 (13U)                               
+#define RCC_CFGR_PPRE2_Msk                 (0x7UL << RCC_CFGR_PPRE2_Pos)        /*!< 0x0000E000 */
+#define RCC_CFGR_PPRE2                     RCC_CFGR_PPRE2_Msk                  /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define RCC_CFGR_PPRE2_0                   (0x1UL << RCC_CFGR_PPRE2_Pos)        /*!< 0x00002000 */
+#define RCC_CFGR_PPRE2_1                   (0x2UL << RCC_CFGR_PPRE2_Pos)        /*!< 0x00004000 */
+#define RCC_CFGR_PPRE2_2                   (0x4UL << RCC_CFGR_PPRE2_Pos)        /*!< 0x00008000 */
+
+#define RCC_CFGR_PPRE2_DIV1                0x00000000U                         /*!< HCLK not divided   */
+#define RCC_CFGR_PPRE2_DIV2                0x00008000U                         /*!< HCLK divided by 2  */
+#define RCC_CFGR_PPRE2_DIV4                0x0000A000U                         /*!< HCLK divided by 4  */
+#define RCC_CFGR_PPRE2_DIV8                0x0000C000U                         /*!< HCLK divided by 8  */
+#define RCC_CFGR_PPRE2_DIV16               0x0000E000U                         /*!< HCLK divided by 16 */
+
+/*!< RTCPRE configuration */
+#define RCC_CFGR_RTCPRE_Pos                (16U)                               
+#define RCC_CFGR_RTCPRE_Msk                (0x1FUL << RCC_CFGR_RTCPRE_Pos)      /*!< 0x001F0000 */
+#define RCC_CFGR_RTCPRE                    RCC_CFGR_RTCPRE_Msk                 
+#define RCC_CFGR_RTCPRE_0                  (0x01UL << RCC_CFGR_RTCPRE_Pos)      /*!< 0x00010000 */
+#define RCC_CFGR_RTCPRE_1                  (0x02UL << RCC_CFGR_RTCPRE_Pos)      /*!< 0x00020000 */
+#define RCC_CFGR_RTCPRE_2                  (0x04UL << RCC_CFGR_RTCPRE_Pos)      /*!< 0x00040000 */
+#define RCC_CFGR_RTCPRE_3                  (0x08UL << RCC_CFGR_RTCPRE_Pos)      /*!< 0x00080000 */
+#define RCC_CFGR_RTCPRE_4                  (0x10UL << RCC_CFGR_RTCPRE_Pos)      /*!< 0x00100000 */
+
+/*!< MCO1 configuration */
+#define RCC_CFGR_MCO1_Pos                  (21U)                               
+#define RCC_CFGR_MCO1_Msk                  (0x3UL << RCC_CFGR_MCO1_Pos)         /*!< 0x00600000 */
+#define RCC_CFGR_MCO1                      RCC_CFGR_MCO1_Msk                   
+#define RCC_CFGR_MCO1_0                    (0x1UL << RCC_CFGR_MCO1_Pos)         /*!< 0x00200000 */
+#define RCC_CFGR_MCO1_1                    (0x2UL << RCC_CFGR_MCO1_Pos)         /*!< 0x00400000 */
+
+#define RCC_CFGR_I2SSRC_Pos                (23U)                               
+#define RCC_CFGR_I2SSRC_Msk                (0x1UL << RCC_CFGR_I2SSRC_Pos)       /*!< 0x00800000 */
+#define RCC_CFGR_I2SSRC                    RCC_CFGR_I2SSRC_Msk                 
+
+#define RCC_CFGR_MCO1PRE_Pos               (24U)                               
+#define RCC_CFGR_MCO1PRE_Msk               (0x7UL << RCC_CFGR_MCO1PRE_Pos)      /*!< 0x07000000 */
+#define RCC_CFGR_MCO1PRE                   RCC_CFGR_MCO1PRE_Msk                
+#define RCC_CFGR_MCO1PRE_0                 (0x1UL << RCC_CFGR_MCO1PRE_Pos)      /*!< 0x01000000 */
+#define RCC_CFGR_MCO1PRE_1                 (0x2UL << RCC_CFGR_MCO1PRE_Pos)      /*!< 0x02000000 */
+#define RCC_CFGR_MCO1PRE_2                 (0x4UL << RCC_CFGR_MCO1PRE_Pos)      /*!< 0x04000000 */
+
+#define RCC_CFGR_MCO2PRE_Pos               (27U)                               
+#define RCC_CFGR_MCO2PRE_Msk               (0x7UL << RCC_CFGR_MCO2PRE_Pos)      /*!< 0x38000000 */
+#define RCC_CFGR_MCO2PRE                   RCC_CFGR_MCO2PRE_Msk                
+#define RCC_CFGR_MCO2PRE_0                 (0x1UL << RCC_CFGR_MCO2PRE_Pos)      /*!< 0x08000000 */
+#define RCC_CFGR_MCO2PRE_1                 (0x2UL << RCC_CFGR_MCO2PRE_Pos)      /*!< 0x10000000 */
+#define RCC_CFGR_MCO2PRE_2                 (0x4UL << RCC_CFGR_MCO2PRE_Pos)      /*!< 0x20000000 */
+
+#define RCC_CFGR_MCO2_Pos                  (30U)                               
+#define RCC_CFGR_MCO2_Msk                  (0x3UL << RCC_CFGR_MCO2_Pos)         /*!< 0xC0000000 */
+#define RCC_CFGR_MCO2                      RCC_CFGR_MCO2_Msk                   
+#define RCC_CFGR_MCO2_0                    (0x1UL << RCC_CFGR_MCO2_Pos)         /*!< 0x40000000 */
+#define RCC_CFGR_MCO2_1                    (0x2UL << RCC_CFGR_MCO2_Pos)         /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIR register  *******************/
+#define RCC_CIR_LSIRDYF_Pos                (0U)                                
+#define RCC_CIR_LSIRDYF_Msk                (0x1UL << RCC_CIR_LSIRDYF_Pos)       /*!< 0x00000001 */
+#define RCC_CIR_LSIRDYF                    RCC_CIR_LSIRDYF_Msk                 
+#define RCC_CIR_LSERDYF_Pos                (1U)                                
+#define RCC_CIR_LSERDYF_Msk                (0x1UL << RCC_CIR_LSERDYF_Pos)       /*!< 0x00000002 */
+#define RCC_CIR_LSERDYF                    RCC_CIR_LSERDYF_Msk                 
+#define RCC_CIR_HSIRDYF_Pos                (2U)                                
+#define RCC_CIR_HSIRDYF_Msk                (0x1UL << RCC_CIR_HSIRDYF_Pos)       /*!< 0x00000004 */
+#define RCC_CIR_HSIRDYF                    RCC_CIR_HSIRDYF_Msk                 
+#define RCC_CIR_HSERDYF_Pos                (3U)                                
+#define RCC_CIR_HSERDYF_Msk                (0x1UL << RCC_CIR_HSERDYF_Pos)       /*!< 0x00000008 */
+#define RCC_CIR_HSERDYF                    RCC_CIR_HSERDYF_Msk                 
+#define RCC_CIR_PLLRDYF_Pos                (4U)                                
+#define RCC_CIR_PLLRDYF_Msk                (0x1UL << RCC_CIR_PLLRDYF_Pos)       /*!< 0x00000010 */
+#define RCC_CIR_PLLRDYF                    RCC_CIR_PLLRDYF_Msk                 
+#define RCC_CIR_PLLI2SRDYF_Pos             (5U)                                
+#define RCC_CIR_PLLI2SRDYF_Msk             (0x1UL << RCC_CIR_PLLI2SRDYF_Pos)    /*!< 0x00000020 */
+#define RCC_CIR_PLLI2SRDYF                 RCC_CIR_PLLI2SRDYF_Msk              
+
+#define RCC_CIR_CSSF_Pos                   (7U)                                
+#define RCC_CIR_CSSF_Msk                   (0x1UL << RCC_CIR_CSSF_Pos)          /*!< 0x00000080 */
+#define RCC_CIR_CSSF                       RCC_CIR_CSSF_Msk                    
+#define RCC_CIR_LSIRDYIE_Pos               (8U)                                
+#define RCC_CIR_LSIRDYIE_Msk               (0x1UL << RCC_CIR_LSIRDYIE_Pos)      /*!< 0x00000100 */
+#define RCC_CIR_LSIRDYIE                   RCC_CIR_LSIRDYIE_Msk                
+#define RCC_CIR_LSERDYIE_Pos               (9U)                                
+#define RCC_CIR_LSERDYIE_Msk               (0x1UL << RCC_CIR_LSERDYIE_Pos)      /*!< 0x00000200 */
+#define RCC_CIR_LSERDYIE                   RCC_CIR_LSERDYIE_Msk                
+#define RCC_CIR_HSIRDYIE_Pos               (10U)                               
+#define RCC_CIR_HSIRDYIE_Msk               (0x1UL << RCC_CIR_HSIRDYIE_Pos)      /*!< 0x00000400 */
+#define RCC_CIR_HSIRDYIE                   RCC_CIR_HSIRDYIE_Msk                
+#define RCC_CIR_HSERDYIE_Pos               (11U)                               
+#define RCC_CIR_HSERDYIE_Msk               (0x1UL << RCC_CIR_HSERDYIE_Pos)      /*!< 0x00000800 */
+#define RCC_CIR_HSERDYIE                   RCC_CIR_HSERDYIE_Msk                
+#define RCC_CIR_PLLRDYIE_Pos               (12U)                               
+#define RCC_CIR_PLLRDYIE_Msk               (0x1UL << RCC_CIR_PLLRDYIE_Pos)      /*!< 0x00001000 */
+#define RCC_CIR_PLLRDYIE                   RCC_CIR_PLLRDYIE_Msk                
+#define RCC_CIR_PLLI2SRDYIE_Pos            (13U)                               
+#define RCC_CIR_PLLI2SRDYIE_Msk            (0x1UL << RCC_CIR_PLLI2SRDYIE_Pos)   /*!< 0x00002000 */
+#define RCC_CIR_PLLI2SRDYIE                RCC_CIR_PLLI2SRDYIE_Msk             
+
+#define RCC_CIR_LSIRDYC_Pos                (16U)                               
+#define RCC_CIR_LSIRDYC_Msk                (0x1UL << RCC_CIR_LSIRDYC_Pos)       /*!< 0x00010000 */
+#define RCC_CIR_LSIRDYC                    RCC_CIR_LSIRDYC_Msk                 
+#define RCC_CIR_LSERDYC_Pos                (17U)                               
+#define RCC_CIR_LSERDYC_Msk                (0x1UL << RCC_CIR_LSERDYC_Pos)       /*!< 0x00020000 */
+#define RCC_CIR_LSERDYC                    RCC_CIR_LSERDYC_Msk                 
+#define RCC_CIR_HSIRDYC_Pos                (18U)                               
+#define RCC_CIR_HSIRDYC_Msk                (0x1UL << RCC_CIR_HSIRDYC_Pos)       /*!< 0x00040000 */
+#define RCC_CIR_HSIRDYC                    RCC_CIR_HSIRDYC_Msk                 
+#define RCC_CIR_HSERDYC_Pos                (19U)                               
+#define RCC_CIR_HSERDYC_Msk                (0x1UL << RCC_CIR_HSERDYC_Pos)       /*!< 0x00080000 */
+#define RCC_CIR_HSERDYC                    RCC_CIR_HSERDYC_Msk                 
+#define RCC_CIR_PLLRDYC_Pos                (20U)                               
+#define RCC_CIR_PLLRDYC_Msk                (0x1UL << RCC_CIR_PLLRDYC_Pos)       /*!< 0x00100000 */
+#define RCC_CIR_PLLRDYC                    RCC_CIR_PLLRDYC_Msk                 
+#define RCC_CIR_PLLI2SRDYC_Pos             (21U)                               
+#define RCC_CIR_PLLI2SRDYC_Msk             (0x1UL << RCC_CIR_PLLI2SRDYC_Pos)    /*!< 0x00200000 */
+#define RCC_CIR_PLLI2SRDYC                 RCC_CIR_PLLI2SRDYC_Msk              
+
+#define RCC_CIR_CSSC_Pos                   (23U)                               
+#define RCC_CIR_CSSC_Msk                   (0x1UL << RCC_CIR_CSSC_Pos)          /*!< 0x00800000 */
+#define RCC_CIR_CSSC                       RCC_CIR_CSSC_Msk                    
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define RCC_AHB1RSTR_GPIOARST_Pos          (0U)                                
+#define RCC_AHB1RSTR_GPIOARST_Msk          (0x1UL << RCC_AHB1RSTR_GPIOARST_Pos) /*!< 0x00000001 */
+#define RCC_AHB1RSTR_GPIOARST              RCC_AHB1RSTR_GPIOARST_Msk           
+#define RCC_AHB1RSTR_GPIOBRST_Pos          (1U)                                
+#define RCC_AHB1RSTR_GPIOBRST_Msk          (0x1UL << RCC_AHB1RSTR_GPIOBRST_Pos) /*!< 0x00000002 */
+#define RCC_AHB1RSTR_GPIOBRST              RCC_AHB1RSTR_GPIOBRST_Msk           
+#define RCC_AHB1RSTR_GPIOCRST_Pos          (2U)                                
+#define RCC_AHB1RSTR_GPIOCRST_Msk          (0x1UL << RCC_AHB1RSTR_GPIOCRST_Pos) /*!< 0x00000004 */
+#define RCC_AHB1RSTR_GPIOCRST              RCC_AHB1RSTR_GPIOCRST_Msk           
+#define RCC_AHB1RSTR_GPIODRST_Pos          (3U)                                
+#define RCC_AHB1RSTR_GPIODRST_Msk          (0x1UL << RCC_AHB1RSTR_GPIODRST_Pos) /*!< 0x00000008 */
+#define RCC_AHB1RSTR_GPIODRST              RCC_AHB1RSTR_GPIODRST_Msk           
+#define RCC_AHB1RSTR_GPIOERST_Pos          (4U)                                
+#define RCC_AHB1RSTR_GPIOERST_Msk          (0x1UL << RCC_AHB1RSTR_GPIOERST_Pos) /*!< 0x00000010 */
+#define RCC_AHB1RSTR_GPIOERST              RCC_AHB1RSTR_GPIOERST_Msk           
+#define RCC_AHB1RSTR_GPIOHRST_Pos          (7U)                                
+#define RCC_AHB1RSTR_GPIOHRST_Msk          (0x1UL << RCC_AHB1RSTR_GPIOHRST_Pos) /*!< 0x00000080 */
+#define RCC_AHB1RSTR_GPIOHRST              RCC_AHB1RSTR_GPIOHRST_Msk           
+#define RCC_AHB1RSTR_CRCRST_Pos            (12U)                               
+#define RCC_AHB1RSTR_CRCRST_Msk            (0x1UL << RCC_AHB1RSTR_CRCRST_Pos)   /*!< 0x00001000 */
+#define RCC_AHB1RSTR_CRCRST                RCC_AHB1RSTR_CRCRST_Msk             
+#define RCC_AHB1RSTR_DMA1RST_Pos           (21U)                               
+#define RCC_AHB1RSTR_DMA1RST_Msk           (0x1UL << RCC_AHB1RSTR_DMA1RST_Pos)  /*!< 0x00200000 */
+#define RCC_AHB1RSTR_DMA1RST               RCC_AHB1RSTR_DMA1RST_Msk            
+#define RCC_AHB1RSTR_DMA2RST_Pos           (22U)                               
+#define RCC_AHB1RSTR_DMA2RST_Msk           (0x1UL << RCC_AHB1RSTR_DMA2RST_Pos)  /*!< 0x00400000 */
+#define RCC_AHB1RSTR_DMA2RST               RCC_AHB1RSTR_DMA2RST_Msk            
+
+/********************  Bit definition for RCC_AHB2RSTR register  **************/
+#define RCC_AHB2RSTR_OTGFSRST_Pos          (7U)                                
+#define RCC_AHB2RSTR_OTGFSRST_Msk          (0x1UL << RCC_AHB2RSTR_OTGFSRST_Pos) /*!< 0x00000080 */
+#define RCC_AHB2RSTR_OTGFSRST              RCC_AHB2RSTR_OTGFSRST_Msk           
+/********************  Bit definition for RCC_AHB3RSTR register  **************/
+
+
+/********************  Bit definition for RCC_APB1RSTR register  **************/
+#define RCC_APB1RSTR_TIM2RST_Pos           (0U)                                
+#define RCC_APB1RSTR_TIM2RST_Msk           (0x1UL << RCC_APB1RSTR_TIM2RST_Pos)  /*!< 0x00000001 */
+#define RCC_APB1RSTR_TIM2RST               RCC_APB1RSTR_TIM2RST_Msk            
+#define RCC_APB1RSTR_TIM3RST_Pos           (1U)                                
+#define RCC_APB1RSTR_TIM3RST_Msk           (0x1UL << RCC_APB1RSTR_TIM3RST_Pos)  /*!< 0x00000002 */
+#define RCC_APB1RSTR_TIM3RST               RCC_APB1RSTR_TIM3RST_Msk            
+#define RCC_APB1RSTR_TIM4RST_Pos           (2U)                                
+#define RCC_APB1RSTR_TIM4RST_Msk           (0x1UL << RCC_APB1RSTR_TIM4RST_Pos)  /*!< 0x00000004 */
+#define RCC_APB1RSTR_TIM4RST               RCC_APB1RSTR_TIM4RST_Msk            
+#define RCC_APB1RSTR_TIM5RST_Pos           (3U)                                
+#define RCC_APB1RSTR_TIM5RST_Msk           (0x1UL << RCC_APB1RSTR_TIM5RST_Pos)  /*!< 0x00000008 */
+#define RCC_APB1RSTR_TIM5RST               RCC_APB1RSTR_TIM5RST_Msk            
+#define RCC_APB1RSTR_WWDGRST_Pos           (11U)                               
+#define RCC_APB1RSTR_WWDGRST_Msk           (0x1UL << RCC_APB1RSTR_WWDGRST_Pos)  /*!< 0x00000800 */
+#define RCC_APB1RSTR_WWDGRST               RCC_APB1RSTR_WWDGRST_Msk            
+#define RCC_APB1RSTR_SPI2RST_Pos           (14U)                               
+#define RCC_APB1RSTR_SPI2RST_Msk           (0x1UL << RCC_APB1RSTR_SPI2RST_Pos)  /*!< 0x00004000 */
+#define RCC_APB1RSTR_SPI2RST               RCC_APB1RSTR_SPI2RST_Msk            
+#define RCC_APB1RSTR_SPI3RST_Pos           (15U)                               
+#define RCC_APB1RSTR_SPI3RST_Msk           (0x1UL << RCC_APB1RSTR_SPI3RST_Pos)  /*!< 0x00008000 */
+#define RCC_APB1RSTR_SPI3RST               RCC_APB1RSTR_SPI3RST_Msk            
+#define RCC_APB1RSTR_USART2RST_Pos         (17U)                               
+#define RCC_APB1RSTR_USART2RST_Msk         (0x1UL << RCC_APB1RSTR_USART2RST_Pos) /*!< 0x00020000 */
+#define RCC_APB1RSTR_USART2RST             RCC_APB1RSTR_USART2RST_Msk          
+#define RCC_APB1RSTR_I2C1RST_Pos           (21U)                               
+#define RCC_APB1RSTR_I2C1RST_Msk           (0x1UL << RCC_APB1RSTR_I2C1RST_Pos)  /*!< 0x00200000 */
+#define RCC_APB1RSTR_I2C1RST               RCC_APB1RSTR_I2C1RST_Msk            
+#define RCC_APB1RSTR_I2C2RST_Pos           (22U)                               
+#define RCC_APB1RSTR_I2C2RST_Msk           (0x1UL << RCC_APB1RSTR_I2C2RST_Pos)  /*!< 0x00400000 */
+#define RCC_APB1RSTR_I2C2RST               RCC_APB1RSTR_I2C2RST_Msk            
+#define RCC_APB1RSTR_I2C3RST_Pos           (23U)                               
+#define RCC_APB1RSTR_I2C3RST_Msk           (0x1UL << RCC_APB1RSTR_I2C3RST_Pos)  /*!< 0x00800000 */
+#define RCC_APB1RSTR_I2C3RST               RCC_APB1RSTR_I2C3RST_Msk            
+#define RCC_APB1RSTR_PWRRST_Pos            (28U)                               
+#define RCC_APB1RSTR_PWRRST_Msk            (0x1UL << RCC_APB1RSTR_PWRRST_Pos)   /*!< 0x10000000 */
+#define RCC_APB1RSTR_PWRRST                RCC_APB1RSTR_PWRRST_Msk             
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define RCC_APB2RSTR_TIM1RST_Pos           (0U)                                
+#define RCC_APB2RSTR_TIM1RST_Msk           (0x1UL << RCC_APB2RSTR_TIM1RST_Pos)  /*!< 0x00000001 */
+#define RCC_APB2RSTR_TIM1RST               RCC_APB2RSTR_TIM1RST_Msk            
+#define RCC_APB2RSTR_USART1RST_Pos         (4U)                                
+#define RCC_APB2RSTR_USART1RST_Msk         (0x1UL << RCC_APB2RSTR_USART1RST_Pos) /*!< 0x00000010 */
+#define RCC_APB2RSTR_USART1RST             RCC_APB2RSTR_USART1RST_Msk          
+#define RCC_APB2RSTR_USART6RST_Pos         (5U)                                
+#define RCC_APB2RSTR_USART6RST_Msk         (0x1UL << RCC_APB2RSTR_USART6RST_Pos) /*!< 0x00000020 */
+#define RCC_APB2RSTR_USART6RST             RCC_APB2RSTR_USART6RST_Msk          
+#define RCC_APB2RSTR_ADCRST_Pos            (8U)                                
+#define RCC_APB2RSTR_ADCRST_Msk            (0x1UL << RCC_APB2RSTR_ADCRST_Pos)   /*!< 0x00000100 */
+#define RCC_APB2RSTR_ADCRST                RCC_APB2RSTR_ADCRST_Msk             
+#define RCC_APB2RSTR_SDIORST_Pos           (11U)                               
+#define RCC_APB2RSTR_SDIORST_Msk           (0x1UL << RCC_APB2RSTR_SDIORST_Pos)  /*!< 0x00000800 */
+#define RCC_APB2RSTR_SDIORST               RCC_APB2RSTR_SDIORST_Msk            
+#define RCC_APB2RSTR_SPI1RST_Pos           (12U)                               
+#define RCC_APB2RSTR_SPI1RST_Msk           (0x1UL << RCC_APB2RSTR_SPI1RST_Pos)  /*!< 0x00001000 */
+#define RCC_APB2RSTR_SPI1RST               RCC_APB2RSTR_SPI1RST_Msk            
+#define RCC_APB2RSTR_SPI4RST_Pos           (13U)                               
+#define RCC_APB2RSTR_SPI4RST_Msk           (0x1UL << RCC_APB2RSTR_SPI4RST_Pos)  /*!< 0x00002000 */
+#define RCC_APB2RSTR_SPI4RST               RCC_APB2RSTR_SPI4RST_Msk            
+#define RCC_APB2RSTR_SYSCFGRST_Pos         (14U)                               
+#define RCC_APB2RSTR_SYSCFGRST_Msk         (0x1UL << RCC_APB2RSTR_SYSCFGRST_Pos) /*!< 0x00004000 */
+#define RCC_APB2RSTR_SYSCFGRST             RCC_APB2RSTR_SYSCFGRST_Msk          
+#define RCC_APB2RSTR_TIM9RST_Pos           (16U)                               
+#define RCC_APB2RSTR_TIM9RST_Msk           (0x1UL << RCC_APB2RSTR_TIM9RST_Pos)  /*!< 0x00010000 */
+#define RCC_APB2RSTR_TIM9RST               RCC_APB2RSTR_TIM9RST_Msk            
+#define RCC_APB2RSTR_TIM10RST_Pos          (17U)                               
+#define RCC_APB2RSTR_TIM10RST_Msk          (0x1UL << RCC_APB2RSTR_TIM10RST_Pos) /*!< 0x00020000 */
+#define RCC_APB2RSTR_TIM10RST              RCC_APB2RSTR_TIM10RST_Msk           
+#define RCC_APB2RSTR_TIM11RST_Pos          (18U)                               
+#define RCC_APB2RSTR_TIM11RST_Msk          (0x1UL << RCC_APB2RSTR_TIM11RST_Pos) /*!< 0x00040000 */
+#define RCC_APB2RSTR_TIM11RST              RCC_APB2RSTR_TIM11RST_Msk           
+
+/* Old SPI1RST bit definition, maintained for legacy purpose */
+#define  RCC_APB2RSTR_SPI1                   RCC_APB2RSTR_SPI1RST
+
+/********************  Bit definition for RCC_AHB1ENR register  ***************/
+#define RCC_AHB1ENR_GPIOAEN_Pos            (0U)                                
+#define RCC_AHB1ENR_GPIOAEN_Msk            (0x1UL << RCC_AHB1ENR_GPIOAEN_Pos)   /*!< 0x00000001 */
+#define RCC_AHB1ENR_GPIOAEN                RCC_AHB1ENR_GPIOAEN_Msk             
+#define RCC_AHB1ENR_GPIOBEN_Pos            (1U)                                
+#define RCC_AHB1ENR_GPIOBEN_Msk            (0x1UL << RCC_AHB1ENR_GPIOBEN_Pos)   /*!< 0x00000002 */
+#define RCC_AHB1ENR_GPIOBEN                RCC_AHB1ENR_GPIOBEN_Msk             
+#define RCC_AHB1ENR_GPIOCEN_Pos            (2U)                                
+#define RCC_AHB1ENR_GPIOCEN_Msk            (0x1UL << RCC_AHB1ENR_GPIOCEN_Pos)   /*!< 0x00000004 */
+#define RCC_AHB1ENR_GPIOCEN                RCC_AHB1ENR_GPIOCEN_Msk             
+#define RCC_AHB1ENR_GPIODEN_Pos            (3U)                                
+#define RCC_AHB1ENR_GPIODEN_Msk            (0x1UL << RCC_AHB1ENR_GPIODEN_Pos)   /*!< 0x00000008 */
+#define RCC_AHB1ENR_GPIODEN                RCC_AHB1ENR_GPIODEN_Msk             
+#define RCC_AHB1ENR_GPIOEEN_Pos            (4U)                                
+#define RCC_AHB1ENR_GPIOEEN_Msk            (0x1UL << RCC_AHB1ENR_GPIOEEN_Pos)   /*!< 0x00000010 */
+#define RCC_AHB1ENR_GPIOEEN                RCC_AHB1ENR_GPIOEEN_Msk             
+#define RCC_AHB1ENR_GPIOHEN_Pos            (7U)                                
+#define RCC_AHB1ENR_GPIOHEN_Msk            (0x1UL << RCC_AHB1ENR_GPIOHEN_Pos)   /*!< 0x00000080 */
+#define RCC_AHB1ENR_GPIOHEN                RCC_AHB1ENR_GPIOHEN_Msk             
+#define RCC_AHB1ENR_CRCEN_Pos              (12U)                               
+#define RCC_AHB1ENR_CRCEN_Msk              (0x1UL << RCC_AHB1ENR_CRCEN_Pos)     /*!< 0x00001000 */
+#define RCC_AHB1ENR_CRCEN                  RCC_AHB1ENR_CRCEN_Msk               
+#define RCC_AHB1ENR_DMA1EN_Pos             (21U)                               
+#define RCC_AHB1ENR_DMA1EN_Msk             (0x1UL << RCC_AHB1ENR_DMA1EN_Pos)    /*!< 0x00200000 */
+#define RCC_AHB1ENR_DMA1EN                 RCC_AHB1ENR_DMA1EN_Msk              
+#define RCC_AHB1ENR_DMA2EN_Pos             (22U)                               
+#define RCC_AHB1ENR_DMA2EN_Msk             (0x1UL << RCC_AHB1ENR_DMA2EN_Pos)    /*!< 0x00400000 */
+#define RCC_AHB1ENR_DMA2EN                 RCC_AHB1ENR_DMA2EN_Msk              
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+/*
+ * @brief Specific device feature definitions (not present on all devices in the STM32F4 serie)
+ */
+#define RCC_AHB2_SUPPORT                   /*!< AHB2 Bus is supported */
+
+#define RCC_AHB2ENR_OTGFSEN_Pos            (7U)                                
+#define RCC_AHB2ENR_OTGFSEN_Msk            (0x1UL << RCC_AHB2ENR_OTGFSEN_Pos)   /*!< 0x00000080 */
+#define RCC_AHB2ENR_OTGFSEN                RCC_AHB2ENR_OTGFSEN_Msk             
+
+/********************  Bit definition for RCC_APB1ENR register  ***************/
+#define RCC_APB1ENR_TIM2EN_Pos             (0U)                                
+#define RCC_APB1ENR_TIM2EN_Msk             (0x1UL << RCC_APB1ENR_TIM2EN_Pos)    /*!< 0x00000001 */
+#define RCC_APB1ENR_TIM2EN                 RCC_APB1ENR_TIM2EN_Msk              
+#define RCC_APB1ENR_TIM3EN_Pos             (1U)                                
+#define RCC_APB1ENR_TIM3EN_Msk             (0x1UL << RCC_APB1ENR_TIM3EN_Pos)    /*!< 0x00000002 */
+#define RCC_APB1ENR_TIM3EN                 RCC_APB1ENR_TIM3EN_Msk              
+#define RCC_APB1ENR_TIM4EN_Pos             (2U)                                
+#define RCC_APB1ENR_TIM4EN_Msk             (0x1UL << RCC_APB1ENR_TIM4EN_Pos)    /*!< 0x00000004 */
+#define RCC_APB1ENR_TIM4EN                 RCC_APB1ENR_TIM4EN_Msk              
+#define RCC_APB1ENR_TIM5EN_Pos             (3U)                                
+#define RCC_APB1ENR_TIM5EN_Msk             (0x1UL << RCC_APB1ENR_TIM5EN_Pos)    /*!< 0x00000008 */
+#define RCC_APB1ENR_TIM5EN                 RCC_APB1ENR_TIM5EN_Msk              
+#define RCC_APB1ENR_WWDGEN_Pos             (11U)                               
+#define RCC_APB1ENR_WWDGEN_Msk             (0x1UL << RCC_APB1ENR_WWDGEN_Pos)    /*!< 0x00000800 */
+#define RCC_APB1ENR_WWDGEN                 RCC_APB1ENR_WWDGEN_Msk              
+#define RCC_APB1ENR_SPI2EN_Pos             (14U)                               
+#define RCC_APB1ENR_SPI2EN_Msk             (0x1UL << RCC_APB1ENR_SPI2EN_Pos)    /*!< 0x00004000 */
+#define RCC_APB1ENR_SPI2EN                 RCC_APB1ENR_SPI2EN_Msk              
+#define RCC_APB1ENR_SPI3EN_Pos             (15U)                               
+#define RCC_APB1ENR_SPI3EN_Msk             (0x1UL << RCC_APB1ENR_SPI3EN_Pos)    /*!< 0x00008000 */
+#define RCC_APB1ENR_SPI3EN                 RCC_APB1ENR_SPI3EN_Msk              
+#define RCC_APB1ENR_USART2EN_Pos           (17U)                               
+#define RCC_APB1ENR_USART2EN_Msk           (0x1UL << RCC_APB1ENR_USART2EN_Pos)  /*!< 0x00020000 */
+#define RCC_APB1ENR_USART2EN               RCC_APB1ENR_USART2EN_Msk            
+#define RCC_APB1ENR_I2C1EN_Pos             (21U)                               
+#define RCC_APB1ENR_I2C1EN_Msk             (0x1UL << RCC_APB1ENR_I2C1EN_Pos)    /*!< 0x00200000 */
+#define RCC_APB1ENR_I2C1EN                 RCC_APB1ENR_I2C1EN_Msk              
+#define RCC_APB1ENR_I2C2EN_Pos             (22U)                               
+#define RCC_APB1ENR_I2C2EN_Msk             (0x1UL << RCC_APB1ENR_I2C2EN_Pos)    /*!< 0x00400000 */
+#define RCC_APB1ENR_I2C2EN                 RCC_APB1ENR_I2C2EN_Msk              
+#define RCC_APB1ENR_I2C3EN_Pos             (23U)                               
+#define RCC_APB1ENR_I2C3EN_Msk             (0x1UL << RCC_APB1ENR_I2C3EN_Pos)    /*!< 0x00800000 */
+#define RCC_APB1ENR_I2C3EN                 RCC_APB1ENR_I2C3EN_Msk              
+#define RCC_APB1ENR_PWREN_Pos              (28U)                               
+#define RCC_APB1ENR_PWREN_Msk              (0x1UL << RCC_APB1ENR_PWREN_Pos)     /*!< 0x10000000 */
+#define RCC_APB1ENR_PWREN                  RCC_APB1ENR_PWREN_Msk               
+
+/********************  Bit definition for RCC_APB2ENR register  ***************/
+#define RCC_APB2ENR_TIM1EN_Pos             (0U)                                
+#define RCC_APB2ENR_TIM1EN_Msk             (0x1UL << RCC_APB2ENR_TIM1EN_Pos)    /*!< 0x00000001 */
+#define RCC_APB2ENR_TIM1EN                 RCC_APB2ENR_TIM1EN_Msk              
+#define RCC_APB2ENR_USART1EN_Pos           (4U)                                
+#define RCC_APB2ENR_USART1EN_Msk           (0x1UL << RCC_APB2ENR_USART1EN_Pos)  /*!< 0x00000010 */
+#define RCC_APB2ENR_USART1EN               RCC_APB2ENR_USART1EN_Msk            
+#define RCC_APB2ENR_USART6EN_Pos           (5U)                                
+#define RCC_APB2ENR_USART6EN_Msk           (0x1UL << RCC_APB2ENR_USART6EN_Pos)  /*!< 0x00000020 */
+#define RCC_APB2ENR_USART6EN               RCC_APB2ENR_USART6EN_Msk            
+#define RCC_APB2ENR_ADC1EN_Pos             (8U)                                
+#define RCC_APB2ENR_ADC1EN_Msk             (0x1UL << RCC_APB2ENR_ADC1EN_Pos)    /*!< 0x00000100 */
+#define RCC_APB2ENR_ADC1EN                 RCC_APB2ENR_ADC1EN_Msk              
+#define RCC_APB2ENR_SDIOEN_Pos             (11U)                               
+#define RCC_APB2ENR_SDIOEN_Msk             (0x1UL << RCC_APB2ENR_SDIOEN_Pos)    /*!< 0x00000800 */
+#define RCC_APB2ENR_SDIOEN                 RCC_APB2ENR_SDIOEN_Msk              
+#define RCC_APB2ENR_SPI1EN_Pos             (12U)                               
+#define RCC_APB2ENR_SPI1EN_Msk             (0x1UL << RCC_APB2ENR_SPI1EN_Pos)    /*!< 0x00001000 */
+#define RCC_APB2ENR_SPI1EN                 RCC_APB2ENR_SPI1EN_Msk              
+#define RCC_APB2ENR_SPI4EN_Pos             (13U)                               
+#define RCC_APB2ENR_SPI4EN_Msk             (0x1UL << RCC_APB2ENR_SPI4EN_Pos)    /*!< 0x00002000 */
+#define RCC_APB2ENR_SPI4EN                 RCC_APB2ENR_SPI4EN_Msk              
+#define RCC_APB2ENR_SYSCFGEN_Pos           (14U)                               
+#define RCC_APB2ENR_SYSCFGEN_Msk           (0x1UL << RCC_APB2ENR_SYSCFGEN_Pos)  /*!< 0x00004000 */
+#define RCC_APB2ENR_SYSCFGEN               RCC_APB2ENR_SYSCFGEN_Msk            
+#define RCC_APB2ENR_TIM9EN_Pos             (16U)                               
+#define RCC_APB2ENR_TIM9EN_Msk             (0x1UL << RCC_APB2ENR_TIM9EN_Pos)    /*!< 0x00010000 */
+#define RCC_APB2ENR_TIM9EN                 RCC_APB2ENR_TIM9EN_Msk              
+#define RCC_APB2ENR_TIM10EN_Pos            (17U)                               
+#define RCC_APB2ENR_TIM10EN_Msk            (0x1UL << RCC_APB2ENR_TIM10EN_Pos)   /*!< 0x00020000 */
+#define RCC_APB2ENR_TIM10EN                RCC_APB2ENR_TIM10EN_Msk             
+#define RCC_APB2ENR_TIM11EN_Pos            (18U)                               
+#define RCC_APB2ENR_TIM11EN_Msk            (0x1UL << RCC_APB2ENR_TIM11EN_Pos)   /*!< 0x00040000 */
+#define RCC_APB2ENR_TIM11EN                RCC_APB2ENR_TIM11EN_Msk             
+
+/********************  Bit definition for RCC_AHB1LPENR register  *************/
+#define RCC_AHB1LPENR_GPIOALPEN_Pos        (0U)                                
+#define RCC_AHB1LPENR_GPIOALPEN_Msk        (0x1UL << RCC_AHB1LPENR_GPIOALPEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB1LPENR_GPIOALPEN            RCC_AHB1LPENR_GPIOALPEN_Msk         
+#define RCC_AHB1LPENR_GPIOBLPEN_Pos        (1U)                                
+#define RCC_AHB1LPENR_GPIOBLPEN_Msk        (0x1UL << RCC_AHB1LPENR_GPIOBLPEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB1LPENR_GPIOBLPEN            RCC_AHB1LPENR_GPIOBLPEN_Msk         
+#define RCC_AHB1LPENR_GPIOCLPEN_Pos        (2U)                                
+#define RCC_AHB1LPENR_GPIOCLPEN_Msk        (0x1UL << RCC_AHB1LPENR_GPIOCLPEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1LPENR_GPIOCLPEN            RCC_AHB1LPENR_GPIOCLPEN_Msk         
+#define RCC_AHB1LPENR_GPIODLPEN_Pos        (3U)                                
+#define RCC_AHB1LPENR_GPIODLPEN_Msk        (0x1UL << RCC_AHB1LPENR_GPIODLPEN_Pos) /*!< 0x00000008 */
+#define RCC_AHB1LPENR_GPIODLPEN            RCC_AHB1LPENR_GPIODLPEN_Msk         
+#define RCC_AHB1LPENR_GPIOELPEN_Pos        (4U)                                
+#define RCC_AHB1LPENR_GPIOELPEN_Msk        (0x1UL << RCC_AHB1LPENR_GPIOELPEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB1LPENR_GPIOELPEN            RCC_AHB1LPENR_GPIOELPEN_Msk         
+#define RCC_AHB1LPENR_GPIOHLPEN_Pos        (7U)                                
+#define RCC_AHB1LPENR_GPIOHLPEN_Msk        (0x1UL << RCC_AHB1LPENR_GPIOHLPEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB1LPENR_GPIOHLPEN            RCC_AHB1LPENR_GPIOHLPEN_Msk         
+#define RCC_AHB1LPENR_CRCLPEN_Pos          (12U)                               
+#define RCC_AHB1LPENR_CRCLPEN_Msk          (0x1UL << RCC_AHB1LPENR_CRCLPEN_Pos) /*!< 0x00001000 */
+#define RCC_AHB1LPENR_CRCLPEN              RCC_AHB1LPENR_CRCLPEN_Msk           
+#define RCC_AHB1LPENR_FLITFLPEN_Pos        (15U)                               
+#define RCC_AHB1LPENR_FLITFLPEN_Msk        (0x1UL << RCC_AHB1LPENR_FLITFLPEN_Pos) /*!< 0x00008000 */
+#define RCC_AHB1LPENR_FLITFLPEN            RCC_AHB1LPENR_FLITFLPEN_Msk         
+#define RCC_AHB1LPENR_SRAM1LPEN_Pos        (16U)                               
+#define RCC_AHB1LPENR_SRAM1LPEN_Msk        (0x1UL << RCC_AHB1LPENR_SRAM1LPEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB1LPENR_SRAM1LPEN            RCC_AHB1LPENR_SRAM1LPEN_Msk         
+#define RCC_AHB1LPENR_DMA1LPEN_Pos         (21U)                               
+#define RCC_AHB1LPENR_DMA1LPEN_Msk         (0x1UL << RCC_AHB1LPENR_DMA1LPEN_Pos) /*!< 0x00200000 */
+#define RCC_AHB1LPENR_DMA1LPEN             RCC_AHB1LPENR_DMA1LPEN_Msk          
+#define RCC_AHB1LPENR_DMA2LPEN_Pos         (22U)                               
+#define RCC_AHB1LPENR_DMA2LPEN_Msk         (0x1UL << RCC_AHB1LPENR_DMA2LPEN_Pos) /*!< 0x00400000 */
+#define RCC_AHB1LPENR_DMA2LPEN             RCC_AHB1LPENR_DMA2LPEN_Msk          
+
+
+/********************  Bit definition for RCC_AHB2LPENR register  *************/
+#define RCC_AHB2LPENR_OTGFSLPEN_Pos        (7U)                                
+#define RCC_AHB2LPENR_OTGFSLPEN_Msk        (0x1UL << RCC_AHB2LPENR_OTGFSLPEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2LPENR_OTGFSLPEN            RCC_AHB2LPENR_OTGFSLPEN_Msk         
+
+/********************  Bit definition for RCC_AHB3LPENR register  *************/
+
+/********************  Bit definition for RCC_APB1LPENR register  *************/
+#define RCC_APB1LPENR_TIM2LPEN_Pos         (0U)                                
+#define RCC_APB1LPENR_TIM2LPEN_Msk         (0x1UL << RCC_APB1LPENR_TIM2LPEN_Pos) /*!< 0x00000001 */
+#define RCC_APB1LPENR_TIM2LPEN             RCC_APB1LPENR_TIM2LPEN_Msk          
+#define RCC_APB1LPENR_TIM3LPEN_Pos         (1U)                                
+#define RCC_APB1LPENR_TIM3LPEN_Msk         (0x1UL << RCC_APB1LPENR_TIM3LPEN_Pos) /*!< 0x00000002 */
+#define RCC_APB1LPENR_TIM3LPEN             RCC_APB1LPENR_TIM3LPEN_Msk          
+#define RCC_APB1LPENR_TIM4LPEN_Pos         (2U)                                
+#define RCC_APB1LPENR_TIM4LPEN_Msk         (0x1UL << RCC_APB1LPENR_TIM4LPEN_Pos) /*!< 0x00000004 */
+#define RCC_APB1LPENR_TIM4LPEN             RCC_APB1LPENR_TIM4LPEN_Msk          
+#define RCC_APB1LPENR_TIM5LPEN_Pos         (3U)                                
+#define RCC_APB1LPENR_TIM5LPEN_Msk         (0x1UL << RCC_APB1LPENR_TIM5LPEN_Pos) /*!< 0x00000008 */
+#define RCC_APB1LPENR_TIM5LPEN             RCC_APB1LPENR_TIM5LPEN_Msk          
+#define RCC_APB1LPENR_WWDGLPEN_Pos         (11U)                               
+#define RCC_APB1LPENR_WWDGLPEN_Msk         (0x1UL << RCC_APB1LPENR_WWDGLPEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1LPENR_WWDGLPEN             RCC_APB1LPENR_WWDGLPEN_Msk          
+#define RCC_APB1LPENR_SPI2LPEN_Pos         (14U)                               
+#define RCC_APB1LPENR_SPI2LPEN_Msk         (0x1UL << RCC_APB1LPENR_SPI2LPEN_Pos) /*!< 0x00004000 */
+#define RCC_APB1LPENR_SPI2LPEN             RCC_APB1LPENR_SPI2LPEN_Msk          
+#define RCC_APB1LPENR_SPI3LPEN_Pos         (15U)                               
+#define RCC_APB1LPENR_SPI3LPEN_Msk         (0x1UL << RCC_APB1LPENR_SPI3LPEN_Pos) /*!< 0x00008000 */
+#define RCC_APB1LPENR_SPI3LPEN             RCC_APB1LPENR_SPI3LPEN_Msk          
+#define RCC_APB1LPENR_USART2LPEN_Pos       (17U)                               
+#define RCC_APB1LPENR_USART2LPEN_Msk       (0x1UL << RCC_APB1LPENR_USART2LPEN_Pos) /*!< 0x00020000 */
+#define RCC_APB1LPENR_USART2LPEN           RCC_APB1LPENR_USART2LPEN_Msk        
+#define RCC_APB1LPENR_I2C1LPEN_Pos         (21U)                               
+#define RCC_APB1LPENR_I2C1LPEN_Msk         (0x1UL << RCC_APB1LPENR_I2C1LPEN_Pos) /*!< 0x00200000 */
+#define RCC_APB1LPENR_I2C1LPEN             RCC_APB1LPENR_I2C1LPEN_Msk          
+#define RCC_APB1LPENR_I2C2LPEN_Pos         (22U)                               
+#define RCC_APB1LPENR_I2C2LPEN_Msk         (0x1UL << RCC_APB1LPENR_I2C2LPEN_Pos) /*!< 0x00400000 */
+#define RCC_APB1LPENR_I2C2LPEN             RCC_APB1LPENR_I2C2LPEN_Msk          
+#define RCC_APB1LPENR_I2C3LPEN_Pos         (23U)                               
+#define RCC_APB1LPENR_I2C3LPEN_Msk         (0x1UL << RCC_APB1LPENR_I2C3LPEN_Pos) /*!< 0x00800000 */
+#define RCC_APB1LPENR_I2C3LPEN             RCC_APB1LPENR_I2C3LPEN_Msk          
+#define RCC_APB1LPENR_PWRLPEN_Pos          (28U)                               
+#define RCC_APB1LPENR_PWRLPEN_Msk          (0x1UL << RCC_APB1LPENR_PWRLPEN_Pos) /*!< 0x10000000 */
+#define RCC_APB1LPENR_PWRLPEN              RCC_APB1LPENR_PWRLPEN_Msk           
+
+/********************  Bit definition for RCC_APB2LPENR register  *************/
+#define RCC_APB2LPENR_TIM1LPEN_Pos         (0U)                                
+#define RCC_APB2LPENR_TIM1LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM1LPEN_Pos) /*!< 0x00000001 */
+#define RCC_APB2LPENR_TIM1LPEN             RCC_APB2LPENR_TIM1LPEN_Msk          
+#define RCC_APB2LPENR_USART1LPEN_Pos       (4U)                                
+#define RCC_APB2LPENR_USART1LPEN_Msk       (0x1UL << RCC_APB2LPENR_USART1LPEN_Pos) /*!< 0x00000010 */
+#define RCC_APB2LPENR_USART1LPEN           RCC_APB2LPENR_USART1LPEN_Msk        
+#define RCC_APB2LPENR_USART6LPEN_Pos       (5U)                                
+#define RCC_APB2LPENR_USART6LPEN_Msk       (0x1UL << RCC_APB2LPENR_USART6LPEN_Pos) /*!< 0x00000020 */
+#define RCC_APB2LPENR_USART6LPEN           RCC_APB2LPENR_USART6LPEN_Msk        
+#define RCC_APB2LPENR_ADC1LPEN_Pos         (8U)                                
+#define RCC_APB2LPENR_ADC1LPEN_Msk         (0x1UL << RCC_APB2LPENR_ADC1LPEN_Pos) /*!< 0x00000100 */
+#define RCC_APB2LPENR_ADC1LPEN             RCC_APB2LPENR_ADC1LPEN_Msk          
+#define RCC_APB2LPENR_SDIOLPEN_Pos         (11U)                               
+#define RCC_APB2LPENR_SDIOLPEN_Msk         (0x1UL << RCC_APB2LPENR_SDIOLPEN_Pos) /*!< 0x00000800 */
+#define RCC_APB2LPENR_SDIOLPEN             RCC_APB2LPENR_SDIOLPEN_Msk          
+#define RCC_APB2LPENR_SPI1LPEN_Pos         (12U)                               
+#define RCC_APB2LPENR_SPI1LPEN_Msk         (0x1UL << RCC_APB2LPENR_SPI1LPEN_Pos) /*!< 0x00001000 */
+#define RCC_APB2LPENR_SPI1LPEN             RCC_APB2LPENR_SPI1LPEN_Msk          
+#define RCC_APB2LPENR_SPI4LPEN_Pos         (13U)                               
+#define RCC_APB2LPENR_SPI4LPEN_Msk         (0x1UL << RCC_APB2LPENR_SPI4LPEN_Pos) /*!< 0x00002000 */
+#define RCC_APB2LPENR_SPI4LPEN             RCC_APB2LPENR_SPI4LPEN_Msk          
+#define RCC_APB2LPENR_SYSCFGLPEN_Pos       (14U)                               
+#define RCC_APB2LPENR_SYSCFGLPEN_Msk       (0x1UL << RCC_APB2LPENR_SYSCFGLPEN_Pos) /*!< 0x00004000 */
+#define RCC_APB2LPENR_SYSCFGLPEN           RCC_APB2LPENR_SYSCFGLPEN_Msk        
+#define RCC_APB2LPENR_TIM9LPEN_Pos         (16U)                               
+#define RCC_APB2LPENR_TIM9LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM9LPEN_Pos) /*!< 0x00010000 */
+#define RCC_APB2LPENR_TIM9LPEN             RCC_APB2LPENR_TIM9LPEN_Msk          
+#define RCC_APB2LPENR_TIM10LPEN_Pos        (17U)                               
+#define RCC_APB2LPENR_TIM10LPEN_Msk        (0x1UL << RCC_APB2LPENR_TIM10LPEN_Pos) /*!< 0x00020000 */
+#define RCC_APB2LPENR_TIM10LPEN            RCC_APB2LPENR_TIM10LPEN_Msk         
+#define RCC_APB2LPENR_TIM11LPEN_Pos        (18U)                               
+#define RCC_APB2LPENR_TIM11LPEN_Msk        (0x1UL << RCC_APB2LPENR_TIM11LPEN_Pos) /*!< 0x00040000 */
+#define RCC_APB2LPENR_TIM11LPEN            RCC_APB2LPENR_TIM11LPEN_Msk         
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos                 (0U)                                
+#define RCC_BDCR_LSEON_Msk                 (0x1UL << RCC_BDCR_LSEON_Pos)        /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                     RCC_BDCR_LSEON_Msk                  
+#define RCC_BDCR_LSERDY_Pos                (1U)                                
+#define RCC_BDCR_LSERDY_Msk                (0x1UL << RCC_BDCR_LSERDY_Pos)       /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                    RCC_BDCR_LSERDY_Msk                 
+#define RCC_BDCR_LSEBYP_Pos                (2U)                                
+#define RCC_BDCR_LSEBYP_Msk                (0x1UL << RCC_BDCR_LSEBYP_Pos)       /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                    RCC_BDCR_LSEBYP_Msk                 
+
+#define RCC_BDCR_RTCSEL_Pos                (8U)                                
+#define RCC_BDCR_RTCSEL_Msk                (0x3UL << RCC_BDCR_RTCSEL_Pos)       /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                    RCC_BDCR_RTCSEL_Msk                 
+#define RCC_BDCR_RTCSEL_0                  (0x1UL << RCC_BDCR_RTCSEL_Pos)       /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                  (0x2UL << RCC_BDCR_RTCSEL_Pos)       /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos                 (15U)                               
+#define RCC_BDCR_RTCEN_Msk                 (0x1UL << RCC_BDCR_RTCEN_Pos)        /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                     RCC_BDCR_RTCEN_Msk                  
+#define RCC_BDCR_BDRST_Pos                 (16U)                               
+#define RCC_BDCR_BDRST_Msk                 (0x1UL << RCC_BDCR_BDRST_Pos)        /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                     RCC_BDCR_BDRST_Msk                  
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSION_Pos                  (0U)                                
+#define RCC_CSR_LSION_Msk                  (0x1UL << RCC_CSR_LSION_Pos)         /*!< 0x00000001 */
+#define RCC_CSR_LSION                      RCC_CSR_LSION_Msk                   
+#define RCC_CSR_LSIRDY_Pos                 (1U)                                
+#define RCC_CSR_LSIRDY_Msk                 (0x1UL << RCC_CSR_LSIRDY_Pos)        /*!< 0x00000002 */
+#define RCC_CSR_LSIRDY                     RCC_CSR_LSIRDY_Msk                  
+#define RCC_CSR_RMVF_Pos                   (24U)                               
+#define RCC_CSR_RMVF_Msk                   (0x1UL << RCC_CSR_RMVF_Pos)          /*!< 0x01000000 */
+#define RCC_CSR_RMVF                       RCC_CSR_RMVF_Msk                    
+#define RCC_CSR_BORRSTF_Pos                (25U)                               
+#define RCC_CSR_BORRSTF_Msk                (0x1UL << RCC_CSR_BORRSTF_Pos)       /*!< 0x02000000 */
+#define RCC_CSR_BORRSTF                    RCC_CSR_BORRSTF_Msk                 
+#define RCC_CSR_PINRSTF_Pos                (26U)
+#define RCC_CSR_PINRSTF_Msk                (0x1UL << RCC_CSR_PINRSTF_Pos)       /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                    RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_PORRSTF_Pos                (27U)                               
+#define RCC_CSR_PORRSTF_Msk                (0x1UL << RCC_CSR_PORRSTF_Pos)       /*!< 0x08000000 */
+#define RCC_CSR_PORRSTF                    RCC_CSR_PORRSTF_Msk                 
+#define RCC_CSR_SFTRSTF_Pos                (28U)                               
+#define RCC_CSR_SFTRSTF_Msk                (0x1UL << RCC_CSR_SFTRSTF_Pos)       /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                    RCC_CSR_SFTRSTF_Msk                 
+#define RCC_CSR_IWDGRSTF_Pos               (29U)
+#define RCC_CSR_IWDGRSTF_Msk               (0x1UL << RCC_CSR_IWDGRSTF_Pos)      /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                   RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos               (30U)                               
+#define RCC_CSR_WWDGRSTF_Msk               (0x1UL << RCC_CSR_WWDGRSTF_Pos)      /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                   RCC_CSR_WWDGRSTF_Msk                
+#define RCC_CSR_LPWRRSTF_Pos               (31U)                               
+#define RCC_CSR_LPWRRSTF_Msk               (0x1UL << RCC_CSR_LPWRRSTF_Pos)      /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                   RCC_CSR_LPWRRSTF_Msk
+/* Legacy defines */
+#define RCC_CSR_PADRSTF                    RCC_CSR_PINRSTF
+#define RCC_CSR_WDGRSTF                    RCC_CSR_IWDGRSTF
+
+/********************  Bit definition for RCC_SSCGR register  *****************/
+#define RCC_SSCGR_MODPER_Pos               (0U)                                
+#define RCC_SSCGR_MODPER_Msk               (0x1FFFUL << RCC_SSCGR_MODPER_Pos)   /*!< 0x00001FFF */
+#define RCC_SSCGR_MODPER                   RCC_SSCGR_MODPER_Msk                
+#define RCC_SSCGR_INCSTEP_Pos              (13U)                               
+#define RCC_SSCGR_INCSTEP_Msk              (0x7FFFUL << RCC_SSCGR_INCSTEP_Pos)  /*!< 0x0FFFE000 */
+#define RCC_SSCGR_INCSTEP                  RCC_SSCGR_INCSTEP_Msk               
+#define RCC_SSCGR_SPREADSEL_Pos            (30U)                               
+#define RCC_SSCGR_SPREADSEL_Msk            (0x1UL << RCC_SSCGR_SPREADSEL_Pos)   /*!< 0x40000000 */
+#define RCC_SSCGR_SPREADSEL                RCC_SSCGR_SPREADSEL_Msk             
+#define RCC_SSCGR_SSCGEN_Pos               (31U)                               
+#define RCC_SSCGR_SSCGEN_Msk               (0x1UL << RCC_SSCGR_SSCGEN_Pos)      /*!< 0x80000000 */
+#define RCC_SSCGR_SSCGEN                   RCC_SSCGR_SSCGEN_Msk                
+
+/********************  Bit definition for RCC_PLLI2SCFGR register  ************/
+#define RCC_PLLI2SCFGR_PLLI2SN_Pos         (6U)                                
+#define RCC_PLLI2SCFGR_PLLI2SN_Msk         (0x1FFUL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00007FC0 */
+#define RCC_PLLI2SCFGR_PLLI2SN             RCC_PLLI2SCFGR_PLLI2SN_Msk          
+#define RCC_PLLI2SCFGR_PLLI2SN_0           (0x001UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00000040 */
+#define RCC_PLLI2SCFGR_PLLI2SN_1           (0x002UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00000080 */
+#define RCC_PLLI2SCFGR_PLLI2SN_2           (0x004UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00000100 */
+#define RCC_PLLI2SCFGR_PLLI2SN_3           (0x008UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00000200 */
+#define RCC_PLLI2SCFGR_PLLI2SN_4           (0x010UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00000400 */
+#define RCC_PLLI2SCFGR_PLLI2SN_5           (0x020UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00000800 */
+#define RCC_PLLI2SCFGR_PLLI2SN_6           (0x040UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00001000 */
+#define RCC_PLLI2SCFGR_PLLI2SN_7           (0x080UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00002000 */
+#define RCC_PLLI2SCFGR_PLLI2SN_8           (0x100UL << RCC_PLLI2SCFGR_PLLI2SN_Pos) /*!< 0x00004000 */
+
+#define RCC_PLLI2SCFGR_PLLI2SR_Pos         (28U)                               
+#define RCC_PLLI2SCFGR_PLLI2SR_Msk         (0x7UL << RCC_PLLI2SCFGR_PLLI2SR_Pos) /*!< 0x70000000 */
+#define RCC_PLLI2SCFGR_PLLI2SR             RCC_PLLI2SCFGR_PLLI2SR_Msk          
+#define RCC_PLLI2SCFGR_PLLI2SR_0           (0x1UL << RCC_PLLI2SCFGR_PLLI2SR_Pos) /*!< 0x10000000 */
+#define RCC_PLLI2SCFGR_PLLI2SR_1           (0x2UL << RCC_PLLI2SCFGR_PLLI2SR_Pos) /*!< 0x20000000 */
+#define RCC_PLLI2SCFGR_PLLI2SR_2           (0x4UL << RCC_PLLI2SCFGR_PLLI2SR_Pos) /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_DCKCFGR register  ***************/
+
+#define RCC_DCKCFGR_TIMPRE_Pos             (24U)                               
+#define RCC_DCKCFGR_TIMPRE_Msk             (0x1UL << RCC_DCKCFGR_TIMPRE_Pos)    /*!< 0x01000000 */
+#define RCC_DCKCFGR_TIMPRE                 RCC_DCKCFGR_TIMPRE_Msk              
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                 (22U)                                    
+#define RTC_TR_PM_Msk                 (0x1UL << RTC_TR_PM_Pos)                  /*!< 0x00400000 */
+#define RTC_TR_PM                     RTC_TR_PM_Msk                            
+#define RTC_TR_HT_Pos                 (20U)                                    
+#define RTC_TR_HT_Msk                 (0x3UL << RTC_TR_HT_Pos)                  /*!< 0x00300000 */
+#define RTC_TR_HT                     RTC_TR_HT_Msk                            
+#define RTC_TR_HT_0                   (0x1UL << RTC_TR_HT_Pos)                  /*!< 0x00100000 */
+#define RTC_TR_HT_1                   (0x2UL << RTC_TR_HT_Pos)                  /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                 (16U)                                    
+#define RTC_TR_HU_Msk                 (0xFUL << RTC_TR_HU_Pos)                  /*!< 0x000F0000 */
+#define RTC_TR_HU                     RTC_TR_HU_Msk                            
+#define RTC_TR_HU_0                   (0x1UL << RTC_TR_HU_Pos)                  /*!< 0x00010000 */
+#define RTC_TR_HU_1                   (0x2UL << RTC_TR_HU_Pos)                  /*!< 0x00020000 */
+#define RTC_TR_HU_2                   (0x4UL << RTC_TR_HU_Pos)                  /*!< 0x00040000 */
+#define RTC_TR_HU_3                   (0x8UL << RTC_TR_HU_Pos)                  /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos                (12U)                                    
+#define RTC_TR_MNT_Msk                (0x7UL << RTC_TR_MNT_Pos)                 /*!< 0x00007000 */
+#define RTC_TR_MNT                    RTC_TR_MNT_Msk                           
+#define RTC_TR_MNT_0                  (0x1UL << RTC_TR_MNT_Pos)                 /*!< 0x00001000 */
+#define RTC_TR_MNT_1                  (0x2UL << RTC_TR_MNT_Pos)                 /*!< 0x00002000 */
+#define RTC_TR_MNT_2                  (0x4UL << RTC_TR_MNT_Pos)                 /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos                (8U)                                     
+#define RTC_TR_MNU_Msk                (0xFUL << RTC_TR_MNU_Pos)                 /*!< 0x00000F00 */
+#define RTC_TR_MNU                    RTC_TR_MNU_Msk                           
+#define RTC_TR_MNU_0                  (0x1UL << RTC_TR_MNU_Pos)                 /*!< 0x00000100 */
+#define RTC_TR_MNU_1                  (0x2UL << RTC_TR_MNU_Pos)                 /*!< 0x00000200 */
+#define RTC_TR_MNU_2                  (0x4UL << RTC_TR_MNU_Pos)                 /*!< 0x00000400 */
+#define RTC_TR_MNU_3                  (0x8UL << RTC_TR_MNU_Pos)                 /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                 (4U)                                     
+#define RTC_TR_ST_Msk                 (0x7UL << RTC_TR_ST_Pos)                  /*!< 0x00000070 */
+#define RTC_TR_ST                     RTC_TR_ST_Msk                            
+#define RTC_TR_ST_0                   (0x1UL << RTC_TR_ST_Pos)                  /*!< 0x00000010 */
+#define RTC_TR_ST_1                   (0x2UL << RTC_TR_ST_Pos)                  /*!< 0x00000020 */
+#define RTC_TR_ST_2                   (0x4UL << RTC_TR_ST_Pos)                  /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                 (0U)                                     
+#define RTC_TR_SU_Msk                 (0xFUL << RTC_TR_SU_Pos)                  /*!< 0x0000000F */
+#define RTC_TR_SU                     RTC_TR_SU_Msk                            
+#define RTC_TR_SU_0                   (0x1UL << RTC_TR_SU_Pos)                  /*!< 0x00000001 */
+#define RTC_TR_SU_1                   (0x2UL << RTC_TR_SU_Pos)                  /*!< 0x00000002 */
+#define RTC_TR_SU_2                   (0x4UL << RTC_TR_SU_Pos)                  /*!< 0x00000004 */
+#define RTC_TR_SU_3                   (0x8UL << RTC_TR_SU_Pos)                  /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                 (20U)                                    
+#define RTC_DR_YT_Msk                 (0xFUL << RTC_DR_YT_Pos)                  /*!< 0x00F00000 */
+#define RTC_DR_YT                     RTC_DR_YT_Msk                            
+#define RTC_DR_YT_0                   (0x1UL << RTC_DR_YT_Pos)                  /*!< 0x00100000 */
+#define RTC_DR_YT_1                   (0x2UL << RTC_DR_YT_Pos)                  /*!< 0x00200000 */
+#define RTC_DR_YT_2                   (0x4UL << RTC_DR_YT_Pos)                  /*!< 0x00400000 */
+#define RTC_DR_YT_3                   (0x8UL << RTC_DR_YT_Pos)                  /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                 (16U)                                    
+#define RTC_DR_YU_Msk                 (0xFUL << RTC_DR_YU_Pos)                  /*!< 0x000F0000 */
+#define RTC_DR_YU                     RTC_DR_YU_Msk                            
+#define RTC_DR_YU_0                   (0x1UL << RTC_DR_YU_Pos)                  /*!< 0x00010000 */
+#define RTC_DR_YU_1                   (0x2UL << RTC_DR_YU_Pos)                  /*!< 0x00020000 */
+#define RTC_DR_YU_2                   (0x4UL << RTC_DR_YU_Pos)                  /*!< 0x00040000 */
+#define RTC_DR_YU_3                   (0x8UL << RTC_DR_YU_Pos)                  /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos                (13U)                                    
+#define RTC_DR_WDU_Msk                (0x7UL << RTC_DR_WDU_Pos)                 /*!< 0x0000E000 */
+#define RTC_DR_WDU                    RTC_DR_WDU_Msk                           
+#define RTC_DR_WDU_0                  (0x1UL << RTC_DR_WDU_Pos)                 /*!< 0x00002000 */
+#define RTC_DR_WDU_1                  (0x2UL << RTC_DR_WDU_Pos)                 /*!< 0x00004000 */
+#define RTC_DR_WDU_2                  (0x4UL << RTC_DR_WDU_Pos)                 /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                 (12U)                                    
+#define RTC_DR_MT_Msk                 (0x1UL << RTC_DR_MT_Pos)                  /*!< 0x00001000 */
+#define RTC_DR_MT                     RTC_DR_MT_Msk                            
+#define RTC_DR_MU_Pos                 (8U)                                     
+#define RTC_DR_MU_Msk                 (0xFUL << RTC_DR_MU_Pos)                  /*!< 0x00000F00 */
+#define RTC_DR_MU                     RTC_DR_MU_Msk                            
+#define RTC_DR_MU_0                   (0x1UL << RTC_DR_MU_Pos)                  /*!< 0x00000100 */
+#define RTC_DR_MU_1                   (0x2UL << RTC_DR_MU_Pos)                  /*!< 0x00000200 */
+#define RTC_DR_MU_2                   (0x4UL << RTC_DR_MU_Pos)                  /*!< 0x00000400 */
+#define RTC_DR_MU_3                   (0x8UL << RTC_DR_MU_Pos)                  /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                 (4U)                                     
+#define RTC_DR_DT_Msk                 (0x3UL << RTC_DR_DT_Pos)                  /*!< 0x00000030 */
+#define RTC_DR_DT                     RTC_DR_DT_Msk                            
+#define RTC_DR_DT_0                   (0x1UL << RTC_DR_DT_Pos)                  /*!< 0x00000010 */
+#define RTC_DR_DT_1                   (0x2UL << RTC_DR_DT_Pos)                  /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                 (0U)                                     
+#define RTC_DR_DU_Msk                 (0xFUL << RTC_DR_DU_Pos)                  /*!< 0x0000000F */
+#define RTC_DR_DU                     RTC_DR_DU_Msk                            
+#define RTC_DR_DU_0                   (0x1UL << RTC_DR_DU_Pos)                  /*!< 0x00000001 */
+#define RTC_DR_DU_1                   (0x2UL << RTC_DR_DU_Pos)                  /*!< 0x00000002 */
+#define RTC_DR_DU_2                   (0x4UL << RTC_DR_DU_Pos)                  /*!< 0x00000004 */
+#define RTC_DR_DU_3                   (0x8UL << RTC_DR_DU_Pos)                  /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_COE_Pos                (23U)                                    
+#define RTC_CR_COE_Msk                (0x1UL << RTC_CR_COE_Pos)                 /*!< 0x00800000 */
+#define RTC_CR_COE                    RTC_CR_COE_Msk                           
+#define RTC_CR_OSEL_Pos               (21U)                                    
+#define RTC_CR_OSEL_Msk               (0x3UL << RTC_CR_OSEL_Pos)                /*!< 0x00600000 */
+#define RTC_CR_OSEL                   RTC_CR_OSEL_Msk                          
+#define RTC_CR_OSEL_0                 (0x1UL << RTC_CR_OSEL_Pos)                /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                 (0x2UL << RTC_CR_OSEL_Pos)                /*!< 0x00400000 */
+#define RTC_CR_POL_Pos                (20U)                                    
+#define RTC_CR_POL_Msk                (0x1UL << RTC_CR_POL_Pos)                 /*!< 0x00100000 */
+#define RTC_CR_POL                    RTC_CR_POL_Msk                           
+#define RTC_CR_COSEL_Pos              (19U)                                    
+#define RTC_CR_COSEL_Msk              (0x1UL << RTC_CR_COSEL_Pos)               /*!< 0x00080000 */
+#define RTC_CR_COSEL                  RTC_CR_COSEL_Msk                         
+#define RTC_CR_BKP_Pos                 (18U)                                   
+#define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)                /*!< 0x00040000 */
+#define RTC_CR_BKP                     RTC_CR_BKP_Msk                          
+#define RTC_CR_SUB1H_Pos              (17U)                                    
+#define RTC_CR_SUB1H_Msk              (0x1UL << RTC_CR_SUB1H_Pos)               /*!< 0x00020000 */
+#define RTC_CR_SUB1H                  RTC_CR_SUB1H_Msk                         
+#define RTC_CR_ADD1H_Pos              (16U)                                    
+#define RTC_CR_ADD1H_Msk              (0x1UL << RTC_CR_ADD1H_Pos)               /*!< 0x00010000 */
+#define RTC_CR_ADD1H                  RTC_CR_ADD1H_Msk                         
+#define RTC_CR_TSIE_Pos               (15U)                                    
+#define RTC_CR_TSIE_Msk               (0x1UL << RTC_CR_TSIE_Pos)                /*!< 0x00008000 */
+#define RTC_CR_TSIE                   RTC_CR_TSIE_Msk                          
+#define RTC_CR_WUTIE_Pos              (14U)                                    
+#define RTC_CR_WUTIE_Msk              (0x1UL << RTC_CR_WUTIE_Pos)               /*!< 0x00004000 */
+#define RTC_CR_WUTIE                  RTC_CR_WUTIE_Msk                         
+#define RTC_CR_ALRBIE_Pos             (13U)                                    
+#define RTC_CR_ALRBIE_Msk             (0x1UL << RTC_CR_ALRBIE_Pos)              /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                 RTC_CR_ALRBIE_Msk                        
+#define RTC_CR_ALRAIE_Pos             (12U)                                    
+#define RTC_CR_ALRAIE_Msk             (0x1UL << RTC_CR_ALRAIE_Pos)              /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                 RTC_CR_ALRAIE_Msk                        
+#define RTC_CR_TSE_Pos                (11U)                                    
+#define RTC_CR_TSE_Msk                (0x1UL << RTC_CR_TSE_Pos)                 /*!< 0x00000800 */
+#define RTC_CR_TSE                    RTC_CR_TSE_Msk                           
+#define RTC_CR_WUTE_Pos               (10U)                                    
+#define RTC_CR_WUTE_Msk               (0x1UL << RTC_CR_WUTE_Pos)                /*!< 0x00000400 */
+#define RTC_CR_WUTE                   RTC_CR_WUTE_Msk                          
+#define RTC_CR_ALRBE_Pos              (9U)                                     
+#define RTC_CR_ALRBE_Msk              (0x1UL << RTC_CR_ALRBE_Pos)               /*!< 0x00000200 */
+#define RTC_CR_ALRBE                  RTC_CR_ALRBE_Msk                         
+#define RTC_CR_ALRAE_Pos              (8U)                                     
+#define RTC_CR_ALRAE_Msk              (0x1UL << RTC_CR_ALRAE_Pos)               /*!< 0x00000100 */
+#define RTC_CR_ALRAE                  RTC_CR_ALRAE_Msk                         
+#define RTC_CR_DCE_Pos                (7U)                                     
+#define RTC_CR_DCE_Msk                (0x1UL << RTC_CR_DCE_Pos)                 /*!< 0x00000080 */
+#define RTC_CR_DCE                    RTC_CR_DCE_Msk                           
+#define RTC_CR_FMT_Pos                (6U)                                     
+#define RTC_CR_FMT_Msk                (0x1UL << RTC_CR_FMT_Pos)                 /*!< 0x00000040 */
+#define RTC_CR_FMT                    RTC_CR_FMT_Msk                           
+#define RTC_CR_BYPSHAD_Pos            (5U)                                     
+#define RTC_CR_BYPSHAD_Msk            (0x1UL << RTC_CR_BYPSHAD_Pos)             /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD                RTC_CR_BYPSHAD_Msk                       
+#define RTC_CR_REFCKON_Pos            (4U)                                     
+#define RTC_CR_REFCKON_Msk            (0x1UL << RTC_CR_REFCKON_Pos)             /*!< 0x00000010 */
+#define RTC_CR_REFCKON                RTC_CR_REFCKON_Msk                       
+#define RTC_CR_TSEDGE_Pos             (3U)                                     
+#define RTC_CR_TSEDGE_Msk             (0x1UL << RTC_CR_TSEDGE_Pos)              /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                 RTC_CR_TSEDGE_Msk                        
+#define RTC_CR_WUCKSEL_Pos            (0U)                                     
+#define RTC_CR_WUCKSEL_Msk            (0x7UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL                RTC_CR_WUCKSEL_Msk                       
+#define RTC_CR_WUCKSEL_0              (0x1UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1              (0x2UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2              (0x4UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000004 */
+
+/* Legacy defines */
+#define RTC_CR_BCK                     RTC_CR_BKP
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_RECALPF_Pos           (16U)                                    
+#define RTC_ISR_RECALPF_Msk           (0x1UL << RTC_ISR_RECALPF_Pos)            /*!< 0x00010000 */
+#define RTC_ISR_RECALPF               RTC_ISR_RECALPF_Msk                      
+#define RTC_ISR_TAMP1F_Pos            (13U)                                    
+#define RTC_ISR_TAMP1F_Msk            (0x1UL << RTC_ISR_TAMP1F_Pos)             /*!< 0x00002000 */
+#define RTC_ISR_TAMP1F                RTC_ISR_TAMP1F_Msk                       
+#define RTC_ISR_TAMP2F_Pos            (14U)                                    
+#define RTC_ISR_TAMP2F_Msk            (0x1UL << RTC_ISR_TAMP2F_Pos)             /*!< 0x00004000 */
+#define RTC_ISR_TAMP2F                RTC_ISR_TAMP2F_Msk                       
+#define RTC_ISR_TSOVF_Pos             (12U)                                    
+#define RTC_ISR_TSOVF_Msk             (0x1UL << RTC_ISR_TSOVF_Pos)              /*!< 0x00001000 */
+#define RTC_ISR_TSOVF                 RTC_ISR_TSOVF_Msk                        
+#define RTC_ISR_TSF_Pos               (11U)                                    
+#define RTC_ISR_TSF_Msk               (0x1UL << RTC_ISR_TSF_Pos)                /*!< 0x00000800 */
+#define RTC_ISR_TSF                   RTC_ISR_TSF_Msk                          
+#define RTC_ISR_WUTF_Pos              (10U)                                    
+#define RTC_ISR_WUTF_Msk              (0x1UL << RTC_ISR_WUTF_Pos)               /*!< 0x00000400 */
+#define RTC_ISR_WUTF                  RTC_ISR_WUTF_Msk                         
+#define RTC_ISR_ALRBF_Pos             (9U)                                     
+#define RTC_ISR_ALRBF_Msk             (0x1UL << RTC_ISR_ALRBF_Pos)              /*!< 0x00000200 */
+#define RTC_ISR_ALRBF                 RTC_ISR_ALRBF_Msk                        
+#define RTC_ISR_ALRAF_Pos             (8U)                                     
+#define RTC_ISR_ALRAF_Msk             (0x1UL << RTC_ISR_ALRAF_Pos)              /*!< 0x00000100 */
+#define RTC_ISR_ALRAF                 RTC_ISR_ALRAF_Msk                        
+#define RTC_ISR_INIT_Pos              (7U)                                     
+#define RTC_ISR_INIT_Msk              (0x1UL << RTC_ISR_INIT_Pos)               /*!< 0x00000080 */
+#define RTC_ISR_INIT                  RTC_ISR_INIT_Msk                         
+#define RTC_ISR_INITF_Pos             (6U)                                     
+#define RTC_ISR_INITF_Msk             (0x1UL << RTC_ISR_INITF_Pos)              /*!< 0x00000040 */
+#define RTC_ISR_INITF                 RTC_ISR_INITF_Msk                        
+#define RTC_ISR_RSF_Pos               (5U)                                     
+#define RTC_ISR_RSF_Msk               (0x1UL << RTC_ISR_RSF_Pos)                /*!< 0x00000020 */
+#define RTC_ISR_RSF                   RTC_ISR_RSF_Msk                          
+#define RTC_ISR_INITS_Pos             (4U)                                     
+#define RTC_ISR_INITS_Msk             (0x1UL << RTC_ISR_INITS_Pos)              /*!< 0x00000010 */
+#define RTC_ISR_INITS                 RTC_ISR_INITS_Msk                        
+#define RTC_ISR_SHPF_Pos              (3U)                                     
+#define RTC_ISR_SHPF_Msk              (0x1UL << RTC_ISR_SHPF_Pos)               /*!< 0x00000008 */
+#define RTC_ISR_SHPF                  RTC_ISR_SHPF_Msk                         
+#define RTC_ISR_WUTWF_Pos             (2U)                                     
+#define RTC_ISR_WUTWF_Msk             (0x1UL << RTC_ISR_WUTWF_Pos)              /*!< 0x00000004 */
+#define RTC_ISR_WUTWF                 RTC_ISR_WUTWF_Msk                        
+#define RTC_ISR_ALRBWF_Pos            (1U)                                     
+#define RTC_ISR_ALRBWF_Msk            (0x1UL << RTC_ISR_ALRBWF_Pos)             /*!< 0x00000002 */
+#define RTC_ISR_ALRBWF                RTC_ISR_ALRBWF_Msk                       
+#define RTC_ISR_ALRAWF_Pos            (0U)                                     
+#define RTC_ISR_ALRAWF_Msk            (0x1UL << RTC_ISR_ALRAWF_Pos)             /*!< 0x00000001 */
+#define RTC_ISR_ALRAWF                RTC_ISR_ALRAWF_Msk                       
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos         (16U)                                    
+#define RTC_PRER_PREDIV_A_Msk         (0x7FUL << RTC_PRER_PREDIV_A_Pos)         /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A             RTC_PRER_PREDIV_A_Msk                    
+#define RTC_PRER_PREDIV_S_Pos         (0U)                                     
+#define RTC_PRER_PREDIV_S_Msk         (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)       /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S             RTC_PRER_PREDIV_S_Msk                    
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos              (0U)                                     
+#define RTC_WUTR_WUT_Msk              (0xFFFFUL << RTC_WUTR_WUT_Pos)            /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                  RTC_WUTR_WUT_Msk                         
+
+/********************  Bits definition for RTC_CALIBR register  ***************/
+#define RTC_CALIBR_DCS_Pos            (7U)                                     
+#define RTC_CALIBR_DCS_Msk            (0x1UL << RTC_CALIBR_DCS_Pos)             /*!< 0x00000080 */
+#define RTC_CALIBR_DCS                RTC_CALIBR_DCS_Msk                       
+#define RTC_CALIBR_DC_Pos             (0U)                                     
+#define RTC_CALIBR_DC_Msk             (0x1FUL << RTC_CALIBR_DC_Pos)             /*!< 0x0000001F */
+#define RTC_CALIBR_DC                 RTC_CALIBR_DC_Msk                        
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos           (31U)                                    
+#define RTC_ALRMAR_MSK4_Msk           (0x1UL << RTC_ALRMAR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4               RTC_ALRMAR_MSK4_Msk                      
+#define RTC_ALRMAR_WDSEL_Pos          (30U)                                    
+#define RTC_ALRMAR_WDSEL_Msk          (0x1UL << RTC_ALRMAR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL              RTC_ALRMAR_WDSEL_Msk                     
+#define RTC_ALRMAR_DT_Pos             (28U)                                    
+#define RTC_ALRMAR_DT_Msk             (0x3UL << RTC_ALRMAR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                 RTC_ALRMAR_DT_Msk                        
+#define RTC_ALRMAR_DT_0               (0x1UL << RTC_ALRMAR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1               (0x2UL << RTC_ALRMAR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos             (24U)                                    
+#define RTC_ALRMAR_DU_Msk             (0xFUL << RTC_ALRMAR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                 RTC_ALRMAR_DU_Msk                        
+#define RTC_ALRMAR_DU_0               (0x1UL << RTC_ALRMAR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1               (0x2UL << RTC_ALRMAR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2               (0x4UL << RTC_ALRMAR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3               (0x8UL << RTC_ALRMAR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos           (23U)                                    
+#define RTC_ALRMAR_MSK3_Msk           (0x1UL << RTC_ALRMAR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3               RTC_ALRMAR_MSK3_Msk                      
+#define RTC_ALRMAR_PM_Pos             (22U)                                    
+#define RTC_ALRMAR_PM_Msk             (0x1UL << RTC_ALRMAR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                 RTC_ALRMAR_PM_Msk                        
+#define RTC_ALRMAR_HT_Pos             (20U)                                    
+#define RTC_ALRMAR_HT_Msk             (0x3UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                 RTC_ALRMAR_HT_Msk                        
+#define RTC_ALRMAR_HT_0               (0x1UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1               (0x2UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos             (16U)                                    
+#define RTC_ALRMAR_HU_Msk             (0xFUL << RTC_ALRMAR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                 RTC_ALRMAR_HU_Msk                        
+#define RTC_ALRMAR_HU_0               (0x1UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1               (0x2UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2               (0x4UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3               (0x8UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos           (15U)                                    
+#define RTC_ALRMAR_MSK2_Msk           (0x1UL << RTC_ALRMAR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2               RTC_ALRMAR_MSK2_Msk                      
+#define RTC_ALRMAR_MNT_Pos            (12U)                                    
+#define RTC_ALRMAR_MNT_Msk            (0x7UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT                RTC_ALRMAR_MNT_Msk                       
+#define RTC_ALRMAR_MNT_0              (0x1UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1              (0x2UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2              (0x4UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos            (8U)                                     
+#define RTC_ALRMAR_MNU_Msk            (0xFUL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU                RTC_ALRMAR_MNU_Msk                       
+#define RTC_ALRMAR_MNU_0              (0x1UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1              (0x2UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2              (0x4UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3              (0x8UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos           (7U)                                     
+#define RTC_ALRMAR_MSK1_Msk           (0x1UL << RTC_ALRMAR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1               RTC_ALRMAR_MSK1_Msk                      
+#define RTC_ALRMAR_ST_Pos             (4U)                                     
+#define RTC_ALRMAR_ST_Msk             (0x7UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                 RTC_ALRMAR_ST_Msk                        
+#define RTC_ALRMAR_ST_0               (0x1UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1               (0x2UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2               (0x4UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos             (0U)                                     
+#define RTC_ALRMAR_SU_Msk             (0xFUL << RTC_ALRMAR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                 RTC_ALRMAR_SU_Msk                        
+#define RTC_ALRMAR_SU_0               (0x1UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1               (0x2UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2               (0x4UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3               (0x8UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos           (31U)                                    
+#define RTC_ALRMBR_MSK4_Msk           (0x1UL << RTC_ALRMBR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4               RTC_ALRMBR_MSK4_Msk                      
+#define RTC_ALRMBR_WDSEL_Pos          (30U)                                    
+#define RTC_ALRMBR_WDSEL_Msk          (0x1UL << RTC_ALRMBR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL              RTC_ALRMBR_WDSEL_Msk                     
+#define RTC_ALRMBR_DT_Pos             (28U)                                    
+#define RTC_ALRMBR_DT_Msk             (0x3UL << RTC_ALRMBR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                 RTC_ALRMBR_DT_Msk                        
+#define RTC_ALRMBR_DT_0               (0x1UL << RTC_ALRMBR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1               (0x2UL << RTC_ALRMBR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos             (24U)                                    
+#define RTC_ALRMBR_DU_Msk             (0xFUL << RTC_ALRMBR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                 RTC_ALRMBR_DU_Msk                        
+#define RTC_ALRMBR_DU_0               (0x1UL << RTC_ALRMBR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1               (0x2UL << RTC_ALRMBR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2               (0x4UL << RTC_ALRMBR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3               (0x8UL << RTC_ALRMBR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos           (23U)                                    
+#define RTC_ALRMBR_MSK3_Msk           (0x1UL << RTC_ALRMBR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3               RTC_ALRMBR_MSK3_Msk                      
+#define RTC_ALRMBR_PM_Pos             (22U)                                    
+#define RTC_ALRMBR_PM_Msk             (0x1UL << RTC_ALRMBR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                 RTC_ALRMBR_PM_Msk                        
+#define RTC_ALRMBR_HT_Pos             (20U)                                    
+#define RTC_ALRMBR_HT_Msk             (0x3UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                 RTC_ALRMBR_HT_Msk                        
+#define RTC_ALRMBR_HT_0               (0x1UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1               (0x2UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos             (16U)                                    
+#define RTC_ALRMBR_HU_Msk             (0xFUL << RTC_ALRMBR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                 RTC_ALRMBR_HU_Msk                        
+#define RTC_ALRMBR_HU_0               (0x1UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1               (0x2UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2               (0x4UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3               (0x8UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos           (15U)                                    
+#define RTC_ALRMBR_MSK2_Msk           (0x1UL << RTC_ALRMBR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2               RTC_ALRMBR_MSK2_Msk                      
+#define RTC_ALRMBR_MNT_Pos            (12U)                                    
+#define RTC_ALRMBR_MNT_Msk            (0x7UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT                RTC_ALRMBR_MNT_Msk                       
+#define RTC_ALRMBR_MNT_0              (0x1UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1              (0x2UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2              (0x4UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos            (8U)                                     
+#define RTC_ALRMBR_MNU_Msk            (0xFUL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU                RTC_ALRMBR_MNU_Msk                       
+#define RTC_ALRMBR_MNU_0              (0x1UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1              (0x2UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2              (0x4UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3              (0x8UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos           (7U)                                     
+#define RTC_ALRMBR_MSK1_Msk           (0x1UL << RTC_ALRMBR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1               RTC_ALRMBR_MSK1_Msk                      
+#define RTC_ALRMBR_ST_Pos             (4U)                                     
+#define RTC_ALRMBR_ST_Msk             (0x7UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                 RTC_ALRMBR_ST_Msk                        
+#define RTC_ALRMBR_ST_0               (0x1UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1               (0x2UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2               (0x4UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos             (0U)                                     
+#define RTC_ALRMBR_SU_Msk             (0xFUL << RTC_ALRMBR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                 RTC_ALRMBR_SU_Msk                        
+#define RTC_ALRMBR_SU_0               (0x1UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1               (0x2UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2               (0x4UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3               (0x8UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos               (0U)                                     
+#define RTC_WPR_KEY_Msk               (0xFFUL << RTC_WPR_KEY_Pos)               /*!< 0x000000FF */
+#define RTC_WPR_KEY                   RTC_WPR_KEY_Msk                          
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos                (0U)                                     
+#define RTC_SSR_SS_Msk                (0xFFFFUL << RTC_SSR_SS_Pos)              /*!< 0x0000FFFF */
+#define RTC_SSR_SS                    RTC_SSR_SS_Msk                           
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos          (0U)                                     
+#define RTC_SHIFTR_SUBFS_Msk          (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)        /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS              RTC_SHIFTR_SUBFS_Msk                     
+#define RTC_SHIFTR_ADD1S_Pos          (31U)                                    
+#define RTC_SHIFTR_ADD1S_Msk          (0x1UL << RTC_SHIFTR_ADD1S_Pos)           /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S              RTC_SHIFTR_ADD1S_Msk                     
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos               (22U)                                    
+#define RTC_TSTR_PM_Msk               (0x1UL << RTC_TSTR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TSTR_PM                   RTC_TSTR_PM_Msk                          
+#define RTC_TSTR_HT_Pos               (20U)                                    
+#define RTC_TSTR_HT_Msk               (0x3UL << RTC_TSTR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TSTR_HT                   RTC_TSTR_HT_Msk                          
+#define RTC_TSTR_HT_0                 (0x1UL << RTC_TSTR_HT_Pos)                /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                 (0x2UL << RTC_TSTR_HT_Pos)                /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos               (16U)                                    
+#define RTC_TSTR_HU_Msk               (0xFUL << RTC_TSTR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TSTR_HU                   RTC_TSTR_HU_Msk                          
+#define RTC_TSTR_HU_0                 (0x1UL << RTC_TSTR_HU_Pos)                /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                 (0x2UL << RTC_TSTR_HU_Pos)                /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                 (0x4UL << RTC_TSTR_HU_Pos)                /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                 (0x8UL << RTC_TSTR_HU_Pos)                /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos              (12U)                                    
+#define RTC_TSTR_MNT_Msk              (0x7UL << RTC_TSTR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TSTR_MNT                  RTC_TSTR_MNT_Msk                         
+#define RTC_TSTR_MNT_0                (0x1UL << RTC_TSTR_MNT_Pos)               /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1                (0x2UL << RTC_TSTR_MNT_Pos)               /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2                (0x4UL << RTC_TSTR_MNT_Pos)               /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos              (8U)                                     
+#define RTC_TSTR_MNU_Msk              (0xFUL << RTC_TSTR_MNU_Pos)               /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                  RTC_TSTR_MNU_Msk                         
+#define RTC_TSTR_MNU_0                (0x1UL << RTC_TSTR_MNU_Pos)               /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1                (0x2UL << RTC_TSTR_MNU_Pos)               /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2                (0x4UL << RTC_TSTR_MNU_Pos)               /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3                (0x8UL << RTC_TSTR_MNU_Pos)               /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos               (4U)                                     
+#define RTC_TSTR_ST_Msk               (0x7UL << RTC_TSTR_ST_Pos)                /*!< 0x00000070 */
+#define RTC_TSTR_ST                   RTC_TSTR_ST_Msk                          
+#define RTC_TSTR_ST_0                 (0x1UL << RTC_TSTR_ST_Pos)                /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                 (0x2UL << RTC_TSTR_ST_Pos)                /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                 (0x4UL << RTC_TSTR_ST_Pos)                /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos               (0U)                                     
+#define RTC_TSTR_SU_Msk               (0xFUL << RTC_TSTR_SU_Pos)                /*!< 0x0000000F */
+#define RTC_TSTR_SU                   RTC_TSTR_SU_Msk                          
+#define RTC_TSTR_SU_0                 (0x1UL << RTC_TSTR_SU_Pos)                /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                 (0x2UL << RTC_TSTR_SU_Pos)                /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                 (0x4UL << RTC_TSTR_SU_Pos)                /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                 (0x8UL << RTC_TSTR_SU_Pos)                /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos              (13U)                                    
+#define RTC_TSDR_WDU_Msk              (0x7UL << RTC_TSDR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                  RTC_TSDR_WDU_Msk                         
+#define RTC_TSDR_WDU_0                (0x1UL << RTC_TSDR_WDU_Pos)               /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1                (0x2UL << RTC_TSDR_WDU_Pos)               /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2                (0x4UL << RTC_TSDR_WDU_Pos)               /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos               (12U)                                    
+#define RTC_TSDR_MT_Msk               (0x1UL << RTC_TSDR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_TSDR_MT                   RTC_TSDR_MT_Msk                          
+#define RTC_TSDR_MU_Pos               (8U)                                     
+#define RTC_TSDR_MU_Msk               (0xFUL << RTC_TSDR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSDR_MU                   RTC_TSDR_MU_Msk                          
+#define RTC_TSDR_MU_0                 (0x1UL << RTC_TSDR_MU_Pos)                /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                 (0x2UL << RTC_TSDR_MU_Pos)                /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                 (0x4UL << RTC_TSDR_MU_Pos)                /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                 (0x8UL << RTC_TSDR_MU_Pos)                /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos               (4U)                                     
+#define RTC_TSDR_DT_Msk               (0x3UL << RTC_TSDR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_TSDR_DT                   RTC_TSDR_DT_Msk                          
+#define RTC_TSDR_DT_0                 (0x1UL << RTC_TSDR_DT_Pos)                /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                 (0x2UL << RTC_TSDR_DT_Pos)                /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos               (0U)                                     
+#define RTC_TSDR_DU_Msk               (0xFUL << RTC_TSDR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_TSDR_DU                   RTC_TSDR_DU_Msk                          
+#define RTC_TSDR_DU_0                 (0x1UL << RTC_TSDR_DU_Pos)                /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                 (0x2UL << RTC_TSDR_DU_Pos)                /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                 (0x4UL << RTC_TSDR_DU_Pos)                /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                 (0x8UL << RTC_TSDR_DU_Pos)                /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos              (0U)                                     
+#define RTC_TSSSR_SS_Msk              (0xFFFFUL << RTC_TSSSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                  RTC_TSSSR_SS_Msk                         
+
+/********************  Bits definition for RTC_CAL register  *****************/
+#define RTC_CALR_CALP_Pos             (15U)                                    
+#define RTC_CALR_CALP_Msk             (0x1UL << RTC_CALR_CALP_Pos)              /*!< 0x00008000 */
+#define RTC_CALR_CALP                 RTC_CALR_CALP_Msk                        
+#define RTC_CALR_CALW8_Pos            (14U)                                    
+#define RTC_CALR_CALW8_Msk            (0x1UL << RTC_CALR_CALW8_Pos)             /*!< 0x00004000 */
+#define RTC_CALR_CALW8                RTC_CALR_CALW8_Msk                       
+#define RTC_CALR_CALW16_Pos           (13U)                                    
+#define RTC_CALR_CALW16_Msk           (0x1UL << RTC_CALR_CALW16_Pos)            /*!< 0x00002000 */
+#define RTC_CALR_CALW16               RTC_CALR_CALW16_Msk                      
+#define RTC_CALR_CALM_Pos             (0U)                                     
+#define RTC_CALR_CALM_Msk             (0x1FFUL << RTC_CALR_CALM_Pos)            /*!< 0x000001FF */
+#define RTC_CALR_CALM                 RTC_CALR_CALM_Msk                        
+#define RTC_CALR_CALM_0               (0x001UL << RTC_CALR_CALM_Pos)            /*!< 0x00000001 */
+#define RTC_CALR_CALM_1               (0x002UL << RTC_CALR_CALM_Pos)            /*!< 0x00000002 */
+#define RTC_CALR_CALM_2               (0x004UL << RTC_CALR_CALM_Pos)            /*!< 0x00000004 */
+#define RTC_CALR_CALM_3               (0x008UL << RTC_CALR_CALM_Pos)            /*!< 0x00000008 */
+#define RTC_CALR_CALM_4               (0x010UL << RTC_CALR_CALM_Pos)            /*!< 0x00000010 */
+#define RTC_CALR_CALM_5               (0x020UL << RTC_CALR_CALM_Pos)            /*!< 0x00000020 */
+#define RTC_CALR_CALM_6               (0x040UL << RTC_CALR_CALM_Pos)            /*!< 0x00000040 */
+#define RTC_CALR_CALM_7               (0x080UL << RTC_CALR_CALM_Pos)            /*!< 0x00000080 */
+#define RTC_CALR_CALM_8               (0x100UL << RTC_CALR_CALM_Pos)            /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_TAFCR register  ****************/
+#define RTC_TAFCR_ALARMOUTTYPE_Pos    (18U)                                    
+#define RTC_TAFCR_ALARMOUTTYPE_Msk    (0x1UL << RTC_TAFCR_ALARMOUTTYPE_Pos)     /*!< 0x00040000 */
+#define RTC_TAFCR_ALARMOUTTYPE        RTC_TAFCR_ALARMOUTTYPE_Msk               
+#define RTC_TAFCR_TSINSEL_Pos         (17U)                                    
+#define RTC_TAFCR_TSINSEL_Msk         (0x1UL << RTC_TAFCR_TSINSEL_Pos)          /*!< 0x00020000 */
+#define RTC_TAFCR_TSINSEL             RTC_TAFCR_TSINSEL_Msk                    
+#define RTC_TAFCR_TAMP1INSEL_Pos      (16U)                                    
+#define RTC_TAFCR_TAMP1INSEL_Msk      (0x1UL << RTC_TAFCR_TAMP1INSEL_Pos)        /*!< 0x00010000 */
+#define RTC_TAFCR_TAMP1INSEL          RTC_TAFCR_TAMP1INSEL_Msk                  
+#define RTC_TAFCR_TAMPPUDIS_Pos       (15U)                                    
+#define RTC_TAFCR_TAMPPUDIS_Msk       (0x1UL << RTC_TAFCR_TAMPPUDIS_Pos)        /*!< 0x00008000 */
+#define RTC_TAFCR_TAMPPUDIS           RTC_TAFCR_TAMPPUDIS_Msk                  
+#define RTC_TAFCR_TAMPPRCH_Pos        (13U)                                    
+#define RTC_TAFCR_TAMPPRCH_Msk        (0x3UL << RTC_TAFCR_TAMPPRCH_Pos)         /*!< 0x00006000 */
+#define RTC_TAFCR_TAMPPRCH            RTC_TAFCR_TAMPPRCH_Msk                   
+#define RTC_TAFCR_TAMPPRCH_0          (0x1UL << RTC_TAFCR_TAMPPRCH_Pos)         /*!< 0x00002000 */
+#define RTC_TAFCR_TAMPPRCH_1          (0x2UL << RTC_TAFCR_TAMPPRCH_Pos)         /*!< 0x00004000 */
+#define RTC_TAFCR_TAMPFLT_Pos         (11U)                                    
+#define RTC_TAFCR_TAMPFLT_Msk         (0x3UL << RTC_TAFCR_TAMPFLT_Pos)          /*!< 0x00001800 */
+#define RTC_TAFCR_TAMPFLT             RTC_TAFCR_TAMPFLT_Msk                    
+#define RTC_TAFCR_TAMPFLT_0           (0x1UL << RTC_TAFCR_TAMPFLT_Pos)          /*!< 0x00000800 */
+#define RTC_TAFCR_TAMPFLT_1           (0x2UL << RTC_TAFCR_TAMPFLT_Pos)          /*!< 0x00001000 */
+#define RTC_TAFCR_TAMPFREQ_Pos        (8U)                                     
+#define RTC_TAFCR_TAMPFREQ_Msk        (0x7UL << RTC_TAFCR_TAMPFREQ_Pos)         /*!< 0x00000700 */
+#define RTC_TAFCR_TAMPFREQ            RTC_TAFCR_TAMPFREQ_Msk                   
+#define RTC_TAFCR_TAMPFREQ_0          (0x1UL << RTC_TAFCR_TAMPFREQ_Pos)         /*!< 0x00000100 */
+#define RTC_TAFCR_TAMPFREQ_1          (0x2UL << RTC_TAFCR_TAMPFREQ_Pos)         /*!< 0x00000200 */
+#define RTC_TAFCR_TAMPFREQ_2          (0x4UL << RTC_TAFCR_TAMPFREQ_Pos)         /*!< 0x00000400 */
+#define RTC_TAFCR_TAMPTS_Pos          (7U)                                     
+#define RTC_TAFCR_TAMPTS_Msk          (0x1UL << RTC_TAFCR_TAMPTS_Pos)           /*!< 0x00000080 */
+#define RTC_TAFCR_TAMPTS              RTC_TAFCR_TAMPTS_Msk                     
+#define RTC_TAFCR_TAMP2TRG_Pos        (4U)                                     
+#define RTC_TAFCR_TAMP2TRG_Msk        (0x1UL << RTC_TAFCR_TAMP2TRG_Pos)         /*!< 0x00000010 */
+#define RTC_TAFCR_TAMP2TRG            RTC_TAFCR_TAMP2TRG_Msk                   
+#define RTC_TAFCR_TAMP2E_Pos          (3U)                                     
+#define RTC_TAFCR_TAMP2E_Msk          (0x1UL << RTC_TAFCR_TAMP2E_Pos)           /*!< 0x00000008 */
+#define RTC_TAFCR_TAMP2E              RTC_TAFCR_TAMP2E_Msk                     
+#define RTC_TAFCR_TAMPIE_Pos          (2U)                                     
+#define RTC_TAFCR_TAMPIE_Msk          (0x1UL << RTC_TAFCR_TAMPIE_Pos)           /*!< 0x00000004 */
+#define RTC_TAFCR_TAMPIE              RTC_TAFCR_TAMPIE_Msk                     
+#define RTC_TAFCR_TAMP1TRG_Pos        (1U)                                     
+#define RTC_TAFCR_TAMP1TRG_Msk        (0x1UL << RTC_TAFCR_TAMP1TRG_Pos)         /*!< 0x00000002 */
+#define RTC_TAFCR_TAMP1TRG            RTC_TAFCR_TAMP1TRG_Msk                   
+#define RTC_TAFCR_TAMP1E_Pos          (0U)                                     
+#define RTC_TAFCR_TAMP1E_Msk          (0x1UL << RTC_TAFCR_TAMP1E_Pos)           /*!< 0x00000001 */
+#define RTC_TAFCR_TAMP1E              RTC_TAFCR_TAMP1E_Msk                     
+
+/* Legacy defines */
+#define RTC_TAFCR_TAMPINSEL           RTC_TAFCR_TAMP1INSEL
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos       (24U)                                    
+#define RTC_ALRMASSR_MASKSS_Msk       (0xFUL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS           RTC_ALRMASSR_MASKSS_Msk                  
+#define RTC_ALRMASSR_MASKSS_0         (0x1UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1         (0x2UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2         (0x4UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3         (0x8UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos           (0U)                                     
+#define RTC_ALRMASSR_SS_Msk           (0x7FFFUL << RTC_ALRMASSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS               RTC_ALRMASSR_SS_Msk                      
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos       (24U)                                    
+#define RTC_ALRMBSSR_MASKSS_Msk       (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS           RTC_ALRMBSSR_MASKSS_Msk                  
+#define RTC_ALRMBSSR_MASKSS_0         (0x1UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1         (0x2UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2         (0x4UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3         (0x8UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos           (0U)                                     
+#define RTC_ALRMBSSR_SS_Msk           (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS               RTC_ALRMBSSR_SS_Msk                      
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R_Pos                 (0U)                                     
+#define RTC_BKP0R_Msk                 (0xFFFFFFFFUL << RTC_BKP0R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP0R                     RTC_BKP0R_Msk                            
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R_Pos                 (0U)                                     
+#define RTC_BKP1R_Msk                 (0xFFFFFFFFUL << RTC_BKP1R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP1R                     RTC_BKP1R_Msk                            
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R_Pos                 (0U)                                     
+#define RTC_BKP2R_Msk                 (0xFFFFFFFFUL << RTC_BKP2R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP2R                     RTC_BKP2R_Msk                            
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R_Pos                 (0U)                                     
+#define RTC_BKP3R_Msk                 (0xFFFFFFFFUL << RTC_BKP3R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP3R                     RTC_BKP3R_Msk                            
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R_Pos                 (0U)                                     
+#define RTC_BKP4R_Msk                 (0xFFFFFFFFUL << RTC_BKP4R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP4R                     RTC_BKP4R_Msk                            
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R_Pos                 (0U)                                     
+#define RTC_BKP5R_Msk                 (0xFFFFFFFFUL << RTC_BKP5R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP5R                     RTC_BKP5R_Msk                            
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R_Pos                 (0U)                                     
+#define RTC_BKP6R_Msk                 (0xFFFFFFFFUL << RTC_BKP6R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP6R                     RTC_BKP6R_Msk                            
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R_Pos                 (0U)                                     
+#define RTC_BKP7R_Msk                 (0xFFFFFFFFUL << RTC_BKP7R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP7R                     RTC_BKP7R_Msk                            
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R_Pos                 (0U)                                     
+#define RTC_BKP8R_Msk                 (0xFFFFFFFFUL << RTC_BKP8R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP8R                     RTC_BKP8R_Msk                            
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R_Pos                 (0U)                                     
+#define RTC_BKP9R_Msk                 (0xFFFFFFFFUL << RTC_BKP9R_Pos)           /*!< 0xFFFFFFFF */
+#define RTC_BKP9R                     RTC_BKP9R_Msk                            
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R_Pos                (0U)                                     
+#define RTC_BKP10R_Msk                (0xFFFFFFFFUL << RTC_BKP10R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP10R                    RTC_BKP10R_Msk                           
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R_Pos                (0U)                                     
+#define RTC_BKP11R_Msk                (0xFFFFFFFFUL << RTC_BKP11R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP11R                    RTC_BKP11R_Msk                           
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R_Pos                (0U)                                     
+#define RTC_BKP12R_Msk                (0xFFFFFFFFUL << RTC_BKP12R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP12R                    RTC_BKP12R_Msk                           
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R_Pos                (0U)                                     
+#define RTC_BKP13R_Msk                (0xFFFFFFFFUL << RTC_BKP13R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP13R                    RTC_BKP13R_Msk                           
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R_Pos                (0U)                                     
+#define RTC_BKP14R_Msk                (0xFFFFFFFFUL << RTC_BKP14R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP14R                    RTC_BKP14R_Msk                           
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R_Pos                (0U)                                     
+#define RTC_BKP15R_Msk                (0xFFFFFFFFUL << RTC_BKP15R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP15R                    RTC_BKP15R_Msk                           
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R_Pos                (0U)                                     
+#define RTC_BKP16R_Msk                (0xFFFFFFFFUL << RTC_BKP16R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP16R                    RTC_BKP16R_Msk                           
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R_Pos                (0U)                                     
+#define RTC_BKP17R_Msk                (0xFFFFFFFFUL << RTC_BKP17R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP17R                    RTC_BKP17R_Msk                           
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R_Pos                (0U)                                     
+#define RTC_BKP18R_Msk                (0xFFFFFFFFUL << RTC_BKP18R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP18R                    RTC_BKP18R_Msk                           
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R_Pos                (0U)                                     
+#define RTC_BKP19R_Msk                (0xFFFFFFFFUL << RTC_BKP19R_Pos)          /*!< 0xFFFFFFFF */
+#define RTC_BKP19R                    RTC_BKP19R_Msk                           
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                       0x000000014U
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          SD host Interface                                 */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SDIO_POWER register  ******************/
+#define SDIO_POWER_PWRCTRL_Pos         (0U)                                    
+#define SDIO_POWER_PWRCTRL_Msk         (0x3UL << SDIO_POWER_PWRCTRL_Pos)        /*!< 0x00000003 */
+#define SDIO_POWER_PWRCTRL             SDIO_POWER_PWRCTRL_Msk                  /*!<PWRCTRL[1:0] bits (Power supply control bits) */
+#define SDIO_POWER_PWRCTRL_0           (0x1UL << SDIO_POWER_PWRCTRL_Pos)        /*!< 0x01 */
+#define SDIO_POWER_PWRCTRL_1           (0x2UL << SDIO_POWER_PWRCTRL_Pos)        /*!< 0x02 */
+
+/******************  Bit definition for SDIO_CLKCR register  ******************/
+#define SDIO_CLKCR_CLKDIV_Pos          (0U)                                    
+#define SDIO_CLKCR_CLKDIV_Msk          (0xFFUL << SDIO_CLKCR_CLKDIV_Pos)        /*!< 0x000000FF */
+#define SDIO_CLKCR_CLKDIV              SDIO_CLKCR_CLKDIV_Msk                   /*!<Clock divide factor             */
+#define SDIO_CLKCR_CLKEN_Pos           (8U)                                    
+#define SDIO_CLKCR_CLKEN_Msk           (0x1UL << SDIO_CLKCR_CLKEN_Pos)          /*!< 0x00000100 */
+#define SDIO_CLKCR_CLKEN               SDIO_CLKCR_CLKEN_Msk                    /*!<Clock enable bit                */
+#define SDIO_CLKCR_PWRSAV_Pos          (9U)                                    
+#define SDIO_CLKCR_PWRSAV_Msk          (0x1UL << SDIO_CLKCR_PWRSAV_Pos)         /*!< 0x00000200 */
+#define SDIO_CLKCR_PWRSAV              SDIO_CLKCR_PWRSAV_Msk                   /*!<Power saving configuration bit  */
+#define SDIO_CLKCR_BYPASS_Pos          (10U)                                   
+#define SDIO_CLKCR_BYPASS_Msk          (0x1UL << SDIO_CLKCR_BYPASS_Pos)         /*!< 0x00000400 */
+#define SDIO_CLKCR_BYPASS              SDIO_CLKCR_BYPASS_Msk                   /*!<Clock divider bypass enable bit */
+
+#define SDIO_CLKCR_WIDBUS_Pos          (11U)                                   
+#define SDIO_CLKCR_WIDBUS_Msk          (0x3UL << SDIO_CLKCR_WIDBUS_Pos)         /*!< 0x00001800 */
+#define SDIO_CLKCR_WIDBUS              SDIO_CLKCR_WIDBUS_Msk                   /*!<WIDBUS[1:0] bits (Wide bus mode enable bit) */
+#define SDIO_CLKCR_WIDBUS_0            (0x1UL << SDIO_CLKCR_WIDBUS_Pos)         /*!< 0x0800 */
+#define SDIO_CLKCR_WIDBUS_1            (0x2UL << SDIO_CLKCR_WIDBUS_Pos)         /*!< 0x1000 */
+
+#define SDIO_CLKCR_NEGEDGE_Pos         (13U)                                   
+#define SDIO_CLKCR_NEGEDGE_Msk         (0x1UL << SDIO_CLKCR_NEGEDGE_Pos)        /*!< 0x00002000 */
+#define SDIO_CLKCR_NEGEDGE             SDIO_CLKCR_NEGEDGE_Msk                  /*!<SDIO_CK dephasing selection bit */
+#define SDIO_CLKCR_HWFC_EN_Pos         (14U)                                   
+#define SDIO_CLKCR_HWFC_EN_Msk         (0x1UL << SDIO_CLKCR_HWFC_EN_Pos)        /*!< 0x00004000 */
+#define SDIO_CLKCR_HWFC_EN             SDIO_CLKCR_HWFC_EN_Msk                  /*!<HW Flow Control enable          */
+
+/*******************  Bit definition for SDIO_ARG register  *******************/
+#define SDIO_ARG_CMDARG_Pos            (0U)                                    
+#define SDIO_ARG_CMDARG_Msk            (0xFFFFFFFFUL << SDIO_ARG_CMDARG_Pos)    /*!< 0xFFFFFFFF */
+#define SDIO_ARG_CMDARG                SDIO_ARG_CMDARG_Msk                     /*!<Command argument */
+
+/*******************  Bit definition for SDIO_CMD register  *******************/
+#define SDIO_CMD_CMDINDEX_Pos          (0U)                                    
+#define SDIO_CMD_CMDINDEX_Msk          (0x3FUL << SDIO_CMD_CMDINDEX_Pos)        /*!< 0x0000003F */
+#define SDIO_CMD_CMDINDEX              SDIO_CMD_CMDINDEX_Msk                   /*!<Command Index                               */
+
+#define SDIO_CMD_WAITRESP_Pos          (6U)                                    
+#define SDIO_CMD_WAITRESP_Msk          (0x3UL << SDIO_CMD_WAITRESP_Pos)         /*!< 0x000000C0 */
+#define SDIO_CMD_WAITRESP              SDIO_CMD_WAITRESP_Msk                   /*!<WAITRESP[1:0] bits (Wait for response bits) */
+#define SDIO_CMD_WAITRESP_0            (0x1UL << SDIO_CMD_WAITRESP_Pos)         /*!< 0x0040 */
+#define SDIO_CMD_WAITRESP_1            (0x2UL << SDIO_CMD_WAITRESP_Pos)         /*!< 0x0080 */
+
+#define SDIO_CMD_WAITINT_Pos           (8U)                                    
+#define SDIO_CMD_WAITINT_Msk           (0x1UL << SDIO_CMD_WAITINT_Pos)          /*!< 0x00000100 */
+#define SDIO_CMD_WAITINT               SDIO_CMD_WAITINT_Msk                    /*!<CPSM Waits for Interrupt Request                               */
+#define SDIO_CMD_WAITPEND_Pos          (9U)                                    
+#define SDIO_CMD_WAITPEND_Msk          (0x1UL << SDIO_CMD_WAITPEND_Pos)         /*!< 0x00000200 */
+#define SDIO_CMD_WAITPEND              SDIO_CMD_WAITPEND_Msk                   /*!<CPSM Waits for ends of data transfer (CmdPend internal signal) */
+#define SDIO_CMD_CPSMEN_Pos            (10U)                                   
+#define SDIO_CMD_CPSMEN_Msk            (0x1UL << SDIO_CMD_CPSMEN_Pos)           /*!< 0x00000400 */
+#define SDIO_CMD_CPSMEN                SDIO_CMD_CPSMEN_Msk                     /*!<Command path state machine (CPSM) Enable bit                   */
+#define SDIO_CMD_SDIOSUSPEND_Pos       (11U)                                   
+#define SDIO_CMD_SDIOSUSPEND_Msk       (0x1UL << SDIO_CMD_SDIOSUSPEND_Pos)      /*!< 0x00000800 */
+#define SDIO_CMD_SDIOSUSPEND           SDIO_CMD_SDIOSUSPEND_Msk                /*!<SD I/O suspend command                                         */
+#define SDIO_CMD_ENCMDCOMPL_Pos        (12U)                                   
+#define SDIO_CMD_ENCMDCOMPL_Msk        (0x1UL << SDIO_CMD_ENCMDCOMPL_Pos)       /*!< 0x00001000 */
+#define SDIO_CMD_ENCMDCOMPL            SDIO_CMD_ENCMDCOMPL_Msk                 /*!<Enable CMD completion                                          */
+#define SDIO_CMD_NIEN_Pos              (13U)                                   
+#define SDIO_CMD_NIEN_Msk              (0x1UL << SDIO_CMD_NIEN_Pos)             /*!< 0x00002000 */
+#define SDIO_CMD_NIEN                  SDIO_CMD_NIEN_Msk                       /*!<Not Interrupt Enable                                           */
+#define SDIO_CMD_CEATACMD_Pos          (14U)                                   
+#define SDIO_CMD_CEATACMD_Msk          (0x1UL << SDIO_CMD_CEATACMD_Pos)         /*!< 0x00004000 */
+#define SDIO_CMD_CEATACMD              SDIO_CMD_CEATACMD_Msk                   /*!<CE-ATA command                                                 */
+
+/*****************  Bit definition for SDIO_RESPCMD register  *****************/
+#define SDIO_RESPCMD_RESPCMD_Pos       (0U)                                    
+#define SDIO_RESPCMD_RESPCMD_Msk       (0x3FUL << SDIO_RESPCMD_RESPCMD_Pos)     /*!< 0x0000003F */
+#define SDIO_RESPCMD_RESPCMD           SDIO_RESPCMD_RESPCMD_Msk                /*!<Response command index */
+
+/******************  Bit definition for SDIO_RESP0 register  ******************/
+#define SDIO_RESP0_CARDSTATUS0_Pos     (0U)                                    
+#define SDIO_RESP0_CARDSTATUS0_Msk     (0xFFFFFFFFUL << SDIO_RESP0_CARDSTATUS0_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_RESP0_CARDSTATUS0         SDIO_RESP0_CARDSTATUS0_Msk              /*!<Card Status */
+
+/******************  Bit definition for SDIO_RESP1 register  ******************/
+#define SDIO_RESP1_CARDSTATUS1_Pos     (0U)                                    
+#define SDIO_RESP1_CARDSTATUS1_Msk     (0xFFFFFFFFUL << SDIO_RESP1_CARDSTATUS1_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_RESP1_CARDSTATUS1         SDIO_RESP1_CARDSTATUS1_Msk              /*!<Card Status */
+
+/******************  Bit definition for SDIO_RESP2 register  ******************/
+#define SDIO_RESP2_CARDSTATUS2_Pos     (0U)                                    
+#define SDIO_RESP2_CARDSTATUS2_Msk     (0xFFFFFFFFUL << SDIO_RESP2_CARDSTATUS2_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_RESP2_CARDSTATUS2         SDIO_RESP2_CARDSTATUS2_Msk              /*!<Card Status */
+
+/******************  Bit definition for SDIO_RESP3 register  ******************/
+#define SDIO_RESP3_CARDSTATUS3_Pos     (0U)                                    
+#define SDIO_RESP3_CARDSTATUS3_Msk     (0xFFFFFFFFUL << SDIO_RESP3_CARDSTATUS3_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_RESP3_CARDSTATUS3         SDIO_RESP3_CARDSTATUS3_Msk              /*!<Card Status */
+
+/******************  Bit definition for SDIO_RESP4 register  ******************/
+#define SDIO_RESP4_CARDSTATUS4_Pos     (0U)                                    
+#define SDIO_RESP4_CARDSTATUS4_Msk     (0xFFFFFFFFUL << SDIO_RESP4_CARDSTATUS4_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_RESP4_CARDSTATUS4         SDIO_RESP4_CARDSTATUS4_Msk              /*!<Card Status */
+
+/******************  Bit definition for SDIO_DTIMER register  *****************/
+#define SDIO_DTIMER_DATATIME_Pos       (0U)                                    
+#define SDIO_DTIMER_DATATIME_Msk       (0xFFFFFFFFUL << SDIO_DTIMER_DATATIME_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_DTIMER_DATATIME           SDIO_DTIMER_DATATIME_Msk                /*!<Data timeout period. */
+
+/******************  Bit definition for SDIO_DLEN register  *******************/
+#define SDIO_DLEN_DATALENGTH_Pos       (0U)                                    
+#define SDIO_DLEN_DATALENGTH_Msk       (0x1FFFFFFUL << SDIO_DLEN_DATALENGTH_Pos) /*!< 0x01FFFFFF */
+#define SDIO_DLEN_DATALENGTH           SDIO_DLEN_DATALENGTH_Msk                /*!<Data length value    */
+
+/******************  Bit definition for SDIO_DCTRL register  ******************/
+#define SDIO_DCTRL_DTEN_Pos            (0U)                                    
+#define SDIO_DCTRL_DTEN_Msk            (0x1UL << SDIO_DCTRL_DTEN_Pos)           /*!< 0x00000001 */
+#define SDIO_DCTRL_DTEN                SDIO_DCTRL_DTEN_Msk                     /*!<Data transfer enabled bit         */
+#define SDIO_DCTRL_DTDIR_Pos           (1U)                                    
+#define SDIO_DCTRL_DTDIR_Msk           (0x1UL << SDIO_DCTRL_DTDIR_Pos)          /*!< 0x00000002 */
+#define SDIO_DCTRL_DTDIR               SDIO_DCTRL_DTDIR_Msk                    /*!<Data transfer direction selection */
+#define SDIO_DCTRL_DTMODE_Pos          (2U)                                    
+#define SDIO_DCTRL_DTMODE_Msk          (0x1UL << SDIO_DCTRL_DTMODE_Pos)         /*!< 0x00000004 */
+#define SDIO_DCTRL_DTMODE              SDIO_DCTRL_DTMODE_Msk                   /*!<Data transfer mode selection      */
+#define SDIO_DCTRL_DMAEN_Pos           (3U)                                    
+#define SDIO_DCTRL_DMAEN_Msk           (0x1UL << SDIO_DCTRL_DMAEN_Pos)          /*!< 0x00000008 */
+#define SDIO_DCTRL_DMAEN               SDIO_DCTRL_DMAEN_Msk                    /*!<DMA enabled bit                   */
+
+#define SDIO_DCTRL_DBLOCKSIZE_Pos      (4U)                                    
+#define SDIO_DCTRL_DBLOCKSIZE_Msk      (0xFUL << SDIO_DCTRL_DBLOCKSIZE_Pos)     /*!< 0x000000F0 */
+#define SDIO_DCTRL_DBLOCKSIZE          SDIO_DCTRL_DBLOCKSIZE_Msk               /*!<DBLOCKSIZE[3:0] bits (Data block size) */
+#define SDIO_DCTRL_DBLOCKSIZE_0        (0x1UL << SDIO_DCTRL_DBLOCKSIZE_Pos)     /*!< 0x0010 */
+#define SDIO_DCTRL_DBLOCKSIZE_1        (0x2UL << SDIO_DCTRL_DBLOCKSIZE_Pos)     /*!< 0x0020 */
+#define SDIO_DCTRL_DBLOCKSIZE_2        (0x4UL << SDIO_DCTRL_DBLOCKSIZE_Pos)     /*!< 0x0040 */
+#define SDIO_DCTRL_DBLOCKSIZE_3        (0x8UL << SDIO_DCTRL_DBLOCKSIZE_Pos)     /*!< 0x0080 */
+
+#define SDIO_DCTRL_RWSTART_Pos         (8U)                                    
+#define SDIO_DCTRL_RWSTART_Msk         (0x1UL << SDIO_DCTRL_RWSTART_Pos)        /*!< 0x00000100 */
+#define SDIO_DCTRL_RWSTART             SDIO_DCTRL_RWSTART_Msk                  /*!<Read wait start         */
+#define SDIO_DCTRL_RWSTOP_Pos          (9U)                                    
+#define SDIO_DCTRL_RWSTOP_Msk          (0x1UL << SDIO_DCTRL_RWSTOP_Pos)         /*!< 0x00000200 */
+#define SDIO_DCTRL_RWSTOP              SDIO_DCTRL_RWSTOP_Msk                   /*!<Read wait stop          */
+#define SDIO_DCTRL_RWMOD_Pos           (10U)                                   
+#define SDIO_DCTRL_RWMOD_Msk           (0x1UL << SDIO_DCTRL_RWMOD_Pos)          /*!< 0x00000400 */
+#define SDIO_DCTRL_RWMOD               SDIO_DCTRL_RWMOD_Msk                    /*!<Read wait mode          */
+#define SDIO_DCTRL_SDIOEN_Pos          (11U)                                   
+#define SDIO_DCTRL_SDIOEN_Msk          (0x1UL << SDIO_DCTRL_SDIOEN_Pos)         /*!< 0x00000800 */
+#define SDIO_DCTRL_SDIOEN              SDIO_DCTRL_SDIOEN_Msk                   /*!<SD I/O enable functions */
+
+/******************  Bit definition for SDIO_DCOUNT register  *****************/
+#define SDIO_DCOUNT_DATACOUNT_Pos      (0U)                                    
+#define SDIO_DCOUNT_DATACOUNT_Msk      (0x1FFFFFFUL << SDIO_DCOUNT_DATACOUNT_Pos) /*!< 0x01FFFFFF */
+#define SDIO_DCOUNT_DATACOUNT          SDIO_DCOUNT_DATACOUNT_Msk               /*!<Data count value */
+
+/******************  Bit definition for SDIO_STA register  ********************/
+#define SDIO_STA_CCRCFAIL_Pos          (0U)                                    
+#define SDIO_STA_CCRCFAIL_Msk          (0x1UL << SDIO_STA_CCRCFAIL_Pos)         /*!< 0x00000001 */
+#define SDIO_STA_CCRCFAIL              SDIO_STA_CCRCFAIL_Msk                   /*!<Command response received (CRC check failed)  */
+#define SDIO_STA_DCRCFAIL_Pos          (1U)                                    
+#define SDIO_STA_DCRCFAIL_Msk          (0x1UL << SDIO_STA_DCRCFAIL_Pos)         /*!< 0x00000002 */
+#define SDIO_STA_DCRCFAIL              SDIO_STA_DCRCFAIL_Msk                   /*!<Data block sent/received (CRC check failed)   */
+#define SDIO_STA_CTIMEOUT_Pos          (2U)                                    
+#define SDIO_STA_CTIMEOUT_Msk          (0x1UL << SDIO_STA_CTIMEOUT_Pos)         /*!< 0x00000004 */
+#define SDIO_STA_CTIMEOUT              SDIO_STA_CTIMEOUT_Msk                   /*!<Command response timeout                      */
+#define SDIO_STA_DTIMEOUT_Pos          (3U)                                    
+#define SDIO_STA_DTIMEOUT_Msk          (0x1UL << SDIO_STA_DTIMEOUT_Pos)         /*!< 0x00000008 */
+#define SDIO_STA_DTIMEOUT              SDIO_STA_DTIMEOUT_Msk                   /*!<Data timeout                                  */
+#define SDIO_STA_TXUNDERR_Pos          (4U)                                    
+#define SDIO_STA_TXUNDERR_Msk          (0x1UL << SDIO_STA_TXUNDERR_Pos)         /*!< 0x00000010 */
+#define SDIO_STA_TXUNDERR              SDIO_STA_TXUNDERR_Msk                   /*!<Transmit FIFO underrun error                  */
+#define SDIO_STA_RXOVERR_Pos           (5U)                                    
+#define SDIO_STA_RXOVERR_Msk           (0x1UL << SDIO_STA_RXOVERR_Pos)          /*!< 0x00000020 */
+#define SDIO_STA_RXOVERR               SDIO_STA_RXOVERR_Msk                    /*!<Received FIFO overrun error                   */
+#define SDIO_STA_CMDREND_Pos           (6U)                                    
+#define SDIO_STA_CMDREND_Msk           (0x1UL << SDIO_STA_CMDREND_Pos)          /*!< 0x00000040 */
+#define SDIO_STA_CMDREND               SDIO_STA_CMDREND_Msk                    /*!<Command response received (CRC check passed)  */
+#define SDIO_STA_CMDSENT_Pos           (7U)                                    
+#define SDIO_STA_CMDSENT_Msk           (0x1UL << SDIO_STA_CMDSENT_Pos)          /*!< 0x00000080 */
+#define SDIO_STA_CMDSENT               SDIO_STA_CMDSENT_Msk                    /*!<Command sent (no response required)           */
+#define SDIO_STA_DATAEND_Pos           (8U)                                    
+#define SDIO_STA_DATAEND_Msk           (0x1UL << SDIO_STA_DATAEND_Pos)          /*!< 0x00000100 */
+#define SDIO_STA_DATAEND               SDIO_STA_DATAEND_Msk                    /*!<Data end (data counter, SDIDCOUNT, is zero)   */
+#define SDIO_STA_STBITERR_Pos          (9U)                                    
+#define SDIO_STA_STBITERR_Msk          (0x1UL << SDIO_STA_STBITERR_Pos)         /*!< 0x00000200 */
+#define SDIO_STA_STBITERR              SDIO_STA_STBITERR_Msk                   /*!<Start bit not detected on all data signals in wide bus mode */
+#define SDIO_STA_DBCKEND_Pos           (10U)                                   
+#define SDIO_STA_DBCKEND_Msk           (0x1UL << SDIO_STA_DBCKEND_Pos)          /*!< 0x00000400 */
+#define SDIO_STA_DBCKEND               SDIO_STA_DBCKEND_Msk                    /*!<Data block sent/received (CRC check passed)   */
+#define SDIO_STA_CMDACT_Pos            (11U)                                   
+#define SDIO_STA_CMDACT_Msk            (0x1UL << SDIO_STA_CMDACT_Pos)           /*!< 0x00000800 */
+#define SDIO_STA_CMDACT                SDIO_STA_CMDACT_Msk                     /*!<Command transfer in progress                  */
+#define SDIO_STA_TXACT_Pos             (12U)                                   
+#define SDIO_STA_TXACT_Msk             (0x1UL << SDIO_STA_TXACT_Pos)            /*!< 0x00001000 */
+#define SDIO_STA_TXACT                 SDIO_STA_TXACT_Msk                      /*!<Data transmit in progress                     */
+#define SDIO_STA_RXACT_Pos             (13U)                                   
+#define SDIO_STA_RXACT_Msk             (0x1UL << SDIO_STA_RXACT_Pos)            /*!< 0x00002000 */
+#define SDIO_STA_RXACT                 SDIO_STA_RXACT_Msk                      /*!<Data receive in progress                      */
+#define SDIO_STA_TXFIFOHE_Pos          (14U)                                   
+#define SDIO_STA_TXFIFOHE_Msk          (0x1UL << SDIO_STA_TXFIFOHE_Pos)         /*!< 0x00004000 */
+#define SDIO_STA_TXFIFOHE              SDIO_STA_TXFIFOHE_Msk                   /*!<Transmit FIFO Half Empty: at least 8 words can be written into the FIFO */
+#define SDIO_STA_RXFIFOHF_Pos          (15U)                                   
+#define SDIO_STA_RXFIFOHF_Msk          (0x1UL << SDIO_STA_RXFIFOHF_Pos)         /*!< 0x00008000 */
+#define SDIO_STA_RXFIFOHF              SDIO_STA_RXFIFOHF_Msk                   /*!<Receive FIFO Half Full: there are at least 8 words in the FIFO */
+#define SDIO_STA_TXFIFOF_Pos           (16U)                                   
+#define SDIO_STA_TXFIFOF_Msk           (0x1UL << SDIO_STA_TXFIFOF_Pos)          /*!< 0x00010000 */
+#define SDIO_STA_TXFIFOF               SDIO_STA_TXFIFOF_Msk                    /*!<Transmit FIFO full                            */
+#define SDIO_STA_RXFIFOF_Pos           (17U)                                   
+#define SDIO_STA_RXFIFOF_Msk           (0x1UL << SDIO_STA_RXFIFOF_Pos)          /*!< 0x00020000 */
+#define SDIO_STA_RXFIFOF               SDIO_STA_RXFIFOF_Msk                    /*!<Receive FIFO full                             */
+#define SDIO_STA_TXFIFOE_Pos           (18U)                                   
+#define SDIO_STA_TXFIFOE_Msk           (0x1UL << SDIO_STA_TXFIFOE_Pos)          /*!< 0x00040000 */
+#define SDIO_STA_TXFIFOE               SDIO_STA_TXFIFOE_Msk                    /*!<Transmit FIFO empty                           */
+#define SDIO_STA_RXFIFOE_Pos           (19U)                                   
+#define SDIO_STA_RXFIFOE_Msk           (0x1UL << SDIO_STA_RXFIFOE_Pos)          /*!< 0x00080000 */
+#define SDIO_STA_RXFIFOE               SDIO_STA_RXFIFOE_Msk                    /*!<Receive FIFO empty                            */
+#define SDIO_STA_TXDAVL_Pos            (20U)                                   
+#define SDIO_STA_TXDAVL_Msk            (0x1UL << SDIO_STA_TXDAVL_Pos)           /*!< 0x00100000 */
+#define SDIO_STA_TXDAVL                SDIO_STA_TXDAVL_Msk                     /*!<Data available in transmit FIFO               */
+#define SDIO_STA_RXDAVL_Pos            (21U)                                   
+#define SDIO_STA_RXDAVL_Msk            (0x1UL << SDIO_STA_RXDAVL_Pos)           /*!< 0x00200000 */
+#define SDIO_STA_RXDAVL                SDIO_STA_RXDAVL_Msk                     /*!<Data available in receive FIFO                */
+#define SDIO_STA_SDIOIT_Pos            (22U)                                   
+#define SDIO_STA_SDIOIT_Msk            (0x1UL << SDIO_STA_SDIOIT_Pos)           /*!< 0x00400000 */
+#define SDIO_STA_SDIOIT                SDIO_STA_SDIOIT_Msk                     /*!<SDIO interrupt received                       */
+#define SDIO_STA_CEATAEND_Pos          (23U)                                   
+#define SDIO_STA_CEATAEND_Msk          (0x1UL << SDIO_STA_CEATAEND_Pos)         /*!< 0x00800000 */
+#define SDIO_STA_CEATAEND              SDIO_STA_CEATAEND_Msk                   /*!<CE-ATA command completion signal received for CMD61 */
+
+/*******************  Bit definition for SDIO_ICR register  *******************/
+#define SDIO_ICR_CCRCFAILC_Pos         (0U)                                    
+#define SDIO_ICR_CCRCFAILC_Msk         (0x1UL << SDIO_ICR_CCRCFAILC_Pos)        /*!< 0x00000001 */
+#define SDIO_ICR_CCRCFAILC             SDIO_ICR_CCRCFAILC_Msk                  /*!<CCRCFAIL flag clear bit */
+#define SDIO_ICR_DCRCFAILC_Pos         (1U)                                    
+#define SDIO_ICR_DCRCFAILC_Msk         (0x1UL << SDIO_ICR_DCRCFAILC_Pos)        /*!< 0x00000002 */
+#define SDIO_ICR_DCRCFAILC             SDIO_ICR_DCRCFAILC_Msk                  /*!<DCRCFAIL flag clear bit */
+#define SDIO_ICR_CTIMEOUTC_Pos         (2U)                                    
+#define SDIO_ICR_CTIMEOUTC_Msk         (0x1UL << SDIO_ICR_CTIMEOUTC_Pos)        /*!< 0x00000004 */
+#define SDIO_ICR_CTIMEOUTC             SDIO_ICR_CTIMEOUTC_Msk                  /*!<CTIMEOUT flag clear bit */
+#define SDIO_ICR_DTIMEOUTC_Pos         (3U)                                    
+#define SDIO_ICR_DTIMEOUTC_Msk         (0x1UL << SDIO_ICR_DTIMEOUTC_Pos)        /*!< 0x00000008 */
+#define SDIO_ICR_DTIMEOUTC             SDIO_ICR_DTIMEOUTC_Msk                  /*!<DTIMEOUT flag clear bit */
+#define SDIO_ICR_TXUNDERRC_Pos         (4U)                                    
+#define SDIO_ICR_TXUNDERRC_Msk         (0x1UL << SDIO_ICR_TXUNDERRC_Pos)        /*!< 0x00000010 */
+#define SDIO_ICR_TXUNDERRC             SDIO_ICR_TXUNDERRC_Msk                  /*!<TXUNDERR flag clear bit */
+#define SDIO_ICR_RXOVERRC_Pos          (5U)                                    
+#define SDIO_ICR_RXOVERRC_Msk          (0x1UL << SDIO_ICR_RXOVERRC_Pos)         /*!< 0x00000020 */
+#define SDIO_ICR_RXOVERRC              SDIO_ICR_RXOVERRC_Msk                   /*!<RXOVERR flag clear bit  */
+#define SDIO_ICR_CMDRENDC_Pos          (6U)                                    
+#define SDIO_ICR_CMDRENDC_Msk          (0x1UL << SDIO_ICR_CMDRENDC_Pos)         /*!< 0x00000040 */
+#define SDIO_ICR_CMDRENDC              SDIO_ICR_CMDRENDC_Msk                   /*!<CMDREND flag clear bit  */
+#define SDIO_ICR_CMDSENTC_Pos          (7U)                                    
+#define SDIO_ICR_CMDSENTC_Msk          (0x1UL << SDIO_ICR_CMDSENTC_Pos)         /*!< 0x00000080 */
+#define SDIO_ICR_CMDSENTC              SDIO_ICR_CMDSENTC_Msk                   /*!<CMDSENT flag clear bit  */
+#define SDIO_ICR_DATAENDC_Pos          (8U)                                    
+#define SDIO_ICR_DATAENDC_Msk          (0x1UL << SDIO_ICR_DATAENDC_Pos)         /*!< 0x00000100 */
+#define SDIO_ICR_DATAENDC              SDIO_ICR_DATAENDC_Msk                   /*!<DATAEND flag clear bit  */
+#define SDIO_ICR_STBITERRC_Pos         (9U)                                    
+#define SDIO_ICR_STBITERRC_Msk         (0x1UL << SDIO_ICR_STBITERRC_Pos)        /*!< 0x00000200 */
+#define SDIO_ICR_STBITERRC             SDIO_ICR_STBITERRC_Msk                  /*!<STBITERR flag clear bit */
+#define SDIO_ICR_DBCKENDC_Pos          (10U)                                   
+#define SDIO_ICR_DBCKENDC_Msk          (0x1UL << SDIO_ICR_DBCKENDC_Pos)         /*!< 0x00000400 */
+#define SDIO_ICR_DBCKENDC              SDIO_ICR_DBCKENDC_Msk                   /*!<DBCKEND flag clear bit  */
+#define SDIO_ICR_SDIOITC_Pos           (22U)                                   
+#define SDIO_ICR_SDIOITC_Msk           (0x1UL << SDIO_ICR_SDIOITC_Pos)          /*!< 0x00400000 */
+#define SDIO_ICR_SDIOITC               SDIO_ICR_SDIOITC_Msk                    /*!<SDIOIT flag clear bit   */
+#define SDIO_ICR_CEATAENDC_Pos         (23U)                                   
+#define SDIO_ICR_CEATAENDC_Msk         (0x1UL << SDIO_ICR_CEATAENDC_Pos)        /*!< 0x00800000 */
+#define SDIO_ICR_CEATAENDC             SDIO_ICR_CEATAENDC_Msk                  /*!<CEATAEND flag clear bit */
+
+/******************  Bit definition for SDIO_MASK register  *******************/
+#define SDIO_MASK_CCRCFAILIE_Pos       (0U)                                    
+#define SDIO_MASK_CCRCFAILIE_Msk       (0x1UL << SDIO_MASK_CCRCFAILIE_Pos)      /*!< 0x00000001 */
+#define SDIO_MASK_CCRCFAILIE           SDIO_MASK_CCRCFAILIE_Msk                /*!<Command CRC Fail Interrupt Enable          */
+#define SDIO_MASK_DCRCFAILIE_Pos       (1U)                                    
+#define SDIO_MASK_DCRCFAILIE_Msk       (0x1UL << SDIO_MASK_DCRCFAILIE_Pos)      /*!< 0x00000002 */
+#define SDIO_MASK_DCRCFAILIE           SDIO_MASK_DCRCFAILIE_Msk                /*!<Data CRC Fail Interrupt Enable             */
+#define SDIO_MASK_CTIMEOUTIE_Pos       (2U)                                    
+#define SDIO_MASK_CTIMEOUTIE_Msk       (0x1UL << SDIO_MASK_CTIMEOUTIE_Pos)      /*!< 0x00000004 */
+#define SDIO_MASK_CTIMEOUTIE           SDIO_MASK_CTIMEOUTIE_Msk                /*!<Command TimeOut Interrupt Enable           */
+#define SDIO_MASK_DTIMEOUTIE_Pos       (3U)                                    
+#define SDIO_MASK_DTIMEOUTIE_Msk       (0x1UL << SDIO_MASK_DTIMEOUTIE_Pos)      /*!< 0x00000008 */
+#define SDIO_MASK_DTIMEOUTIE           SDIO_MASK_DTIMEOUTIE_Msk                /*!<Data TimeOut Interrupt Enable              */
+#define SDIO_MASK_TXUNDERRIE_Pos       (4U)                                    
+#define SDIO_MASK_TXUNDERRIE_Msk       (0x1UL << SDIO_MASK_TXUNDERRIE_Pos)      /*!< 0x00000010 */
+#define SDIO_MASK_TXUNDERRIE           SDIO_MASK_TXUNDERRIE_Msk                /*!<Tx FIFO UnderRun Error Interrupt Enable    */
+#define SDIO_MASK_RXOVERRIE_Pos        (5U)                                    
+#define SDIO_MASK_RXOVERRIE_Msk        (0x1UL << SDIO_MASK_RXOVERRIE_Pos)       /*!< 0x00000020 */
+#define SDIO_MASK_RXOVERRIE            SDIO_MASK_RXOVERRIE_Msk                 /*!<Rx FIFO OverRun Error Interrupt Enable     */
+#define SDIO_MASK_CMDRENDIE_Pos        (6U)                                    
+#define SDIO_MASK_CMDRENDIE_Msk        (0x1UL << SDIO_MASK_CMDRENDIE_Pos)       /*!< 0x00000040 */
+#define SDIO_MASK_CMDRENDIE            SDIO_MASK_CMDRENDIE_Msk                 /*!<Command Response Received Interrupt Enable */
+#define SDIO_MASK_CMDSENTIE_Pos        (7U)                                    
+#define SDIO_MASK_CMDSENTIE_Msk        (0x1UL << SDIO_MASK_CMDSENTIE_Pos)       /*!< 0x00000080 */
+#define SDIO_MASK_CMDSENTIE            SDIO_MASK_CMDSENTIE_Msk                 /*!<Command Sent Interrupt Enable              */
+#define SDIO_MASK_DATAENDIE_Pos        (8U)                                    
+#define SDIO_MASK_DATAENDIE_Msk        (0x1UL << SDIO_MASK_DATAENDIE_Pos)       /*!< 0x00000100 */
+#define SDIO_MASK_DATAENDIE            SDIO_MASK_DATAENDIE_Msk                 /*!<Data End Interrupt Enable                  */
+#define SDIO_MASK_STBITERRIE_Pos       (9U)                                    
+#define SDIO_MASK_STBITERRIE_Msk       (0x1UL << SDIO_MASK_STBITERRIE_Pos)      /*!< 0x00000200 */
+#define SDIO_MASK_STBITERRIE           SDIO_MASK_STBITERRIE_Msk                /*!<Start Bit Error Interrupt Enable           */
+#define SDIO_MASK_DBCKENDIE_Pos        (10U)                                   
+#define SDIO_MASK_DBCKENDIE_Msk        (0x1UL << SDIO_MASK_DBCKENDIE_Pos)       /*!< 0x00000400 */
+#define SDIO_MASK_DBCKENDIE            SDIO_MASK_DBCKENDIE_Msk                 /*!<Data Block End Interrupt Enable            */
+#define SDIO_MASK_CMDACTIE_Pos         (11U)                                   
+#define SDIO_MASK_CMDACTIE_Msk         (0x1UL << SDIO_MASK_CMDACTIE_Pos)        /*!< 0x00000800 */
+#define SDIO_MASK_CMDACTIE             SDIO_MASK_CMDACTIE_Msk                  /*!<CCommand Acting Interrupt Enable           */
+#define SDIO_MASK_TXACTIE_Pos          (12U)                                   
+#define SDIO_MASK_TXACTIE_Msk          (0x1UL << SDIO_MASK_TXACTIE_Pos)         /*!< 0x00001000 */
+#define SDIO_MASK_TXACTIE              SDIO_MASK_TXACTIE_Msk                   /*!<Data Transmit Acting Interrupt Enable      */
+#define SDIO_MASK_RXACTIE_Pos          (13U)                                   
+#define SDIO_MASK_RXACTIE_Msk          (0x1UL << SDIO_MASK_RXACTIE_Pos)         /*!< 0x00002000 */
+#define SDIO_MASK_RXACTIE              SDIO_MASK_RXACTIE_Msk                   /*!<Data receive acting interrupt enabled      */
+#define SDIO_MASK_TXFIFOHEIE_Pos       (14U)                                   
+#define SDIO_MASK_TXFIFOHEIE_Msk       (0x1UL << SDIO_MASK_TXFIFOHEIE_Pos)      /*!< 0x00004000 */
+#define SDIO_MASK_TXFIFOHEIE           SDIO_MASK_TXFIFOHEIE_Msk                /*!<Tx FIFO Half Empty interrupt Enable        */
+#define SDIO_MASK_RXFIFOHFIE_Pos       (15U)                                   
+#define SDIO_MASK_RXFIFOHFIE_Msk       (0x1UL << SDIO_MASK_RXFIFOHFIE_Pos)      /*!< 0x00008000 */
+#define SDIO_MASK_RXFIFOHFIE           SDIO_MASK_RXFIFOHFIE_Msk                /*!<Rx FIFO Half Full interrupt Enable         */
+#define SDIO_MASK_TXFIFOFIE_Pos        (16U)                                   
+#define SDIO_MASK_TXFIFOFIE_Msk        (0x1UL << SDIO_MASK_TXFIFOFIE_Pos)       /*!< 0x00010000 */
+#define SDIO_MASK_TXFIFOFIE            SDIO_MASK_TXFIFOFIE_Msk                 /*!<Tx FIFO Full interrupt Enable              */
+#define SDIO_MASK_RXFIFOFIE_Pos        (17U)                                   
+#define SDIO_MASK_RXFIFOFIE_Msk        (0x1UL << SDIO_MASK_RXFIFOFIE_Pos)       /*!< 0x00020000 */
+#define SDIO_MASK_RXFIFOFIE            SDIO_MASK_RXFIFOFIE_Msk                 /*!<Rx FIFO Full interrupt Enable              */
+#define SDIO_MASK_TXFIFOEIE_Pos        (18U)                                   
+#define SDIO_MASK_TXFIFOEIE_Msk        (0x1UL << SDIO_MASK_TXFIFOEIE_Pos)       /*!< 0x00040000 */
+#define SDIO_MASK_TXFIFOEIE            SDIO_MASK_TXFIFOEIE_Msk                 /*!<Tx FIFO Empty interrupt Enable             */
+#define SDIO_MASK_RXFIFOEIE_Pos        (19U)                                   
+#define SDIO_MASK_RXFIFOEIE_Msk        (0x1UL << SDIO_MASK_RXFIFOEIE_Pos)       /*!< 0x00080000 */
+#define SDIO_MASK_RXFIFOEIE            SDIO_MASK_RXFIFOEIE_Msk                 /*!<Rx FIFO Empty interrupt Enable             */
+#define SDIO_MASK_TXDAVLIE_Pos         (20U)                                   
+#define SDIO_MASK_TXDAVLIE_Msk         (0x1UL << SDIO_MASK_TXDAVLIE_Pos)        /*!< 0x00100000 */
+#define SDIO_MASK_TXDAVLIE             SDIO_MASK_TXDAVLIE_Msk                  /*!<Data available in Tx FIFO interrupt Enable */
+#define SDIO_MASK_RXDAVLIE_Pos         (21U)                                   
+#define SDIO_MASK_RXDAVLIE_Msk         (0x1UL << SDIO_MASK_RXDAVLIE_Pos)        /*!< 0x00200000 */
+#define SDIO_MASK_RXDAVLIE             SDIO_MASK_RXDAVLIE_Msk                  /*!<Data available in Rx FIFO interrupt Enable */
+#define SDIO_MASK_SDIOITIE_Pos         (22U)                                   
+#define SDIO_MASK_SDIOITIE_Msk         (0x1UL << SDIO_MASK_SDIOITIE_Pos)        /*!< 0x00400000 */
+#define SDIO_MASK_SDIOITIE             SDIO_MASK_SDIOITIE_Msk                  /*!<SDIO Mode Interrupt Received interrupt Enable */
+#define SDIO_MASK_CEATAENDIE_Pos       (23U)                                   
+#define SDIO_MASK_CEATAENDIE_Msk       (0x1UL << SDIO_MASK_CEATAENDIE_Pos)      /*!< 0x00800000 */
+#define SDIO_MASK_CEATAENDIE           SDIO_MASK_CEATAENDIE_Msk                /*!<CE-ATA command completion signal received Interrupt Enable */
+
+/*****************  Bit definition for SDIO_FIFOCNT register  *****************/
+#define SDIO_FIFOCNT_FIFOCOUNT_Pos     (0U)                                    
+#define SDIO_FIFOCNT_FIFOCOUNT_Msk     (0xFFFFFFUL << SDIO_FIFOCNT_FIFOCOUNT_Pos) /*!< 0x00FFFFFF */
+#define SDIO_FIFOCNT_FIFOCOUNT         SDIO_FIFOCNT_FIFOCOUNT_Msk              /*!<Remaining number of words to be written to or read from the FIFO */
+
+/******************  Bit definition for SDIO_FIFO register  *******************/
+#define SDIO_FIFO_FIFODATA_Pos         (0U)                                    
+#define SDIO_FIFO_FIFODATA_Msk         (0xFFFFFFFFUL << SDIO_FIFO_FIFODATA_Pos) /*!< 0xFFFFFFFF */
+#define SDIO_FIFO_FIFODATA             SDIO_FIFO_FIFODATA_Msk                  /*!<Receive and transmit FIFO data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface                         */
+/*                                                                            */
+/******************************************************************************/
+#define SPI_I2S_FULLDUPLEX_SUPPORT                                             /*!< I2S Full-Duplex support */
+
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)                                       
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                 /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)                                       
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                 /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)                                       
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                 /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)                                       
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                   /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                   /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                   /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                   /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)                                       
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                  /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)                                       
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)             /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)                                       
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                  /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)                                       
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                  /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)                                      
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)               /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_DFF_Pos             (11U)                                      
+#define SPI_CR1_DFF_Msk             (0x1UL << SPI_CR1_DFF_Pos)                  /*!< 0x00000800 */
+#define SPI_CR1_DFF                 SPI_CR1_DFF_Msk                            /*!<Data Frame Format                   */
+#define SPI_CR1_CRCNEXT_Pos         (12U)                                      
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)              /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)                                      
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)                /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)                                      
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)               /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)                                      
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)             /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)                                       
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)              /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!<Rx Buffer DMA Enable                 */
+#define SPI_CR2_TXDMAEN_Pos         (1U)                                       
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)              /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!<Tx Buffer DMA Enable                 */
+#define SPI_CR2_SSOE_Pos            (2U)                                       
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                 /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!<SS Output Enable                     */
+#define SPI_CR2_FRF_Pos             (4U)                                       
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                  /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!<Frame Format                         */
+#define SPI_CR2_ERRIE_Pos           (5U)                                       
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)                /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!<Error Interrupt Enable               */
+#define SPI_CR2_RXNEIE_Pos          (6U)                                       
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)               /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!<RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)                                       
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)                /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!<Tx buffer Empty Interrupt Enable     */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)                                       
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                  /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!<Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)                                       
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                   /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!<Transmit buffer Empty    */
+#define SPI_SR_CHSIDE_Pos           (2U)                                       
+#define SPI_SR_CHSIDE_Msk           (0x1UL << SPI_SR_CHSIDE_Pos)                /*!< 0x00000004 */
+#define SPI_SR_CHSIDE               SPI_SR_CHSIDE_Msk                          /*!<Channel side             */
+#define SPI_SR_UDR_Pos              (3U)                                       
+#define SPI_SR_UDR_Msk              (0x1UL << SPI_SR_UDR_Pos)                   /*!< 0x00000008 */
+#define SPI_SR_UDR                  SPI_SR_UDR_Msk                             /*!<Underrun flag            */
+#define SPI_SR_CRCERR_Pos           (4U)                                       
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)                /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!<CRC Error flag           */
+#define SPI_SR_MODF_Pos             (5U)                                       
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                  /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!<Mode fault               */
+#define SPI_SR_OVR_Pos              (6U)                                       
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                   /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!<Overrun flag             */
+#define SPI_SR_BSY_Pos              (7U)                                       
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                   /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!<Busy flag                */
+#define SPI_SR_FRE_Pos              (8U)                                       
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                   /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!<Frame format error flag  */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)                                       
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                 /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)                                       
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)         /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)                                       
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)          /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)                                       
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)          /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN_Pos       (0U)                                       
+#define SPI_I2SCFGR_CHLEN_Msk       (0x1UL << SPI_I2SCFGR_CHLEN_Pos)            /*!< 0x00000001 */
+#define SPI_I2SCFGR_CHLEN           SPI_I2SCFGR_CHLEN_Msk                      /*!<Channel length (number of bits per audio channel) */
+
+#define SPI_I2SCFGR_DATLEN_Pos      (1U)                                       
+#define SPI_I2SCFGR_DATLEN_Msk      (0x3UL << SPI_I2SCFGR_DATLEN_Pos)           /*!< 0x00000006 */
+#define SPI_I2SCFGR_DATLEN          SPI_I2SCFGR_DATLEN_Msk                     /*!<DATLEN[1:0] bits (Data length to be transferred)  */
+#define SPI_I2SCFGR_DATLEN_0        (0x1UL << SPI_I2SCFGR_DATLEN_Pos)           /*!< 0x00000002 */
+#define SPI_I2SCFGR_DATLEN_1        (0x2UL << SPI_I2SCFGR_DATLEN_Pos)           /*!< 0x00000004 */
+
+#define SPI_I2SCFGR_CKPOL_Pos       (3U)                                       
+#define SPI_I2SCFGR_CKPOL_Msk       (0x1UL << SPI_I2SCFGR_CKPOL_Pos)            /*!< 0x00000008 */
+#define SPI_I2SCFGR_CKPOL           SPI_I2SCFGR_CKPOL_Msk                      /*!<steady state clock polarity               */
+
+#define SPI_I2SCFGR_I2SSTD_Pos      (4U)                                       
+#define SPI_I2SCFGR_I2SSTD_Msk      (0x3UL << SPI_I2SCFGR_I2SSTD_Pos)           /*!< 0x00000030 */
+#define SPI_I2SCFGR_I2SSTD          SPI_I2SCFGR_I2SSTD_Msk                     /*!<I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0        (0x1UL << SPI_I2SCFGR_I2SSTD_Pos)           /*!< 0x00000010 */
+#define SPI_I2SCFGR_I2SSTD_1        (0x2UL << SPI_I2SCFGR_I2SSTD_Pos)           /*!< 0x00000020 */
+
+#define SPI_I2SCFGR_PCMSYNC_Pos     (7U)                                       
+#define SPI_I2SCFGR_PCMSYNC_Msk     (0x1UL << SPI_I2SCFGR_PCMSYNC_Pos)          /*!< 0x00000080 */
+#define SPI_I2SCFGR_PCMSYNC         SPI_I2SCFGR_PCMSYNC_Msk                    /*!<PCM frame synchronization                 */
+
+#define SPI_I2SCFGR_I2SCFG_Pos      (8U)                                       
+#define SPI_I2SCFGR_I2SCFG_Msk      (0x3UL << SPI_I2SCFGR_I2SCFG_Pos)           /*!< 0x00000300 */
+#define SPI_I2SCFGR_I2SCFG          SPI_I2SCFGR_I2SCFG_Msk                     /*!<I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0        (0x1UL << SPI_I2SCFGR_I2SCFG_Pos)           /*!< 0x00000100 */
+#define SPI_I2SCFGR_I2SCFG_1        (0x2UL << SPI_I2SCFGR_I2SCFG_Pos)           /*!< 0x00000200 */
+
+#define SPI_I2SCFGR_I2SE_Pos        (10U)                                      
+#define SPI_I2SCFGR_I2SE_Msk        (0x1UL << SPI_I2SCFGR_I2SE_Pos)             /*!< 0x00000400 */
+#define SPI_I2SCFGR_I2SE            SPI_I2SCFGR_I2SE_Msk                       /*!<I2S Enable         */
+#define SPI_I2SCFGR_I2SMOD_Pos      (11U)                                      
+#define SPI_I2SCFGR_I2SMOD_Msk      (0x1UL << SPI_I2SCFGR_I2SMOD_Pos)           /*!< 0x00000800 */
+#define SPI_I2SCFGR_I2SMOD          SPI_I2SCFGR_I2SMOD_Msk                     /*!<I2S mode selection */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV_Pos        (0U)                                       
+#define SPI_I2SPR_I2SDIV_Msk        (0xFFUL << SPI_I2SPR_I2SDIV_Pos)            /*!< 0x000000FF */
+#define SPI_I2SPR_I2SDIV            SPI_I2SPR_I2SDIV_Msk                       /*!<I2S Linear prescaler         */
+#define SPI_I2SPR_ODD_Pos           (8U)                                       
+#define SPI_I2SPR_ODD_Msk           (0x1UL << SPI_I2SPR_ODD_Pos)                /*!< 0x00000100 */
+#define SPI_I2SPR_ODD               SPI_I2SPR_ODD_Msk                          /*!<Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE_Pos         (9U)                                       
+#define SPI_I2SPR_MCKOE_Msk         (0x1UL << SPI_I2SPR_MCKOE_Pos)              /*!< 0x00000200 */
+#define SPI_I2SPR_MCKOE             SPI_I2SPR_MCKOE_Msk                        /*!<Master Clock Output Enable   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SYSCFG_MEMRMP register  ***************/
+#define SYSCFG_MEMRMP_MEM_MODE_Pos           (0U)                              
+#define SYSCFG_MEMRMP_MEM_MODE_Msk           (0x3UL << SYSCFG_MEMRMP_MEM_MODE_Pos) /*!< 0x00000003 */
+#define SYSCFG_MEMRMP_MEM_MODE               SYSCFG_MEMRMP_MEM_MODE_Msk        /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_MEMRMP_MEM_MODE_0             (0x1UL << SYSCFG_MEMRMP_MEM_MODE_Pos) /*!< 0x00000001 */
+#define SYSCFG_MEMRMP_MEM_MODE_1             (0x2UL << SYSCFG_MEMRMP_MEM_MODE_Pos) /*!< 0x00000002 */
+/******************  Bit definition for SYSCFG_PMC register  ******************/
+#define SYSCFG_PMC_ADC1DC2_Pos               (16U)                             
+#define SYSCFG_PMC_ADC1DC2_Msk               (0x1UL << SYSCFG_PMC_ADC1DC2_Pos)  /*!< 0x00010000 */
+#define SYSCFG_PMC_ADC1DC2                   SYSCFG_PMC_ADC1DC2_Msk            /*!< Refer to AN4073 on how to use this bit  */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  ***************/
+#define SYSCFG_EXTICR1_EXTI0_Pos             (0U)                              
+#define SYSCFG_EXTICR1_EXTI0_Msk             (0xFUL << SYSCFG_EXTICR1_EXTI0_Pos) /*!< 0x0000000F */
+#define SYSCFG_EXTICR1_EXTI0                 SYSCFG_EXTICR1_EXTI0_Msk          /*!<EXTI 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1_Pos             (4U)                              
+#define SYSCFG_EXTICR1_EXTI1_Msk             (0xFUL << SYSCFG_EXTICR1_EXTI1_Pos) /*!< 0x000000F0 */
+#define SYSCFG_EXTICR1_EXTI1                 SYSCFG_EXTICR1_EXTI1_Msk          /*!<EXTI 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2_Pos             (8U)                              
+#define SYSCFG_EXTICR1_EXTI2_Msk             (0xFUL << SYSCFG_EXTICR1_EXTI2_Pos) /*!< 0x00000F00 */
+#define SYSCFG_EXTICR1_EXTI2                 SYSCFG_EXTICR1_EXTI2_Msk          /*!<EXTI 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3_Pos             (12U)                             
+#define SYSCFG_EXTICR1_EXTI3_Msk             (0xFUL << SYSCFG_EXTICR1_EXTI3_Pos) /*!< 0x0000F000 */
+#define SYSCFG_EXTICR1_EXTI3                 SYSCFG_EXTICR1_EXTI3_Msk          /*!<EXTI 3 configuration */
+/**
+  * @brief   EXTI0 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA              0x0000U                           /*!<PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB              0x0001U                           /*!<PB[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PC              0x0002U                           /*!<PC[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PD              0x0003U                           /*!<PD[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PE              0x0004U                           /*!<PE[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PH              0x0007U                           /*!<PH[0] pin */
+
+/**
+  * @brief   EXTI1 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA              0x0000U                           /*!<PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB              0x0010U                           /*!<PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC              0x0020U                           /*!<PC[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PD              0x0030U                           /*!<PD[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PE              0x0040U                           /*!<PE[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PH              0x0070U                           /*!<PH[1] pin */
+
+/**
+  * @brief   EXTI2 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA              0x0000U                           /*!<PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB              0x0100U                           /*!<PB[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PC              0x0200U                           /*!<PC[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PD              0x0300U                           /*!<PD[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PE              0x0400U                           /*!<PE[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PH              0x0700U                           /*!<PH[2] pin */
+
+/**
+  * @brief   EXTI3 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA              0x0000U                           /*!<PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB              0x1000U                           /*!<PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PC              0x2000U                           /*!<PC[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PD              0x3000U                           /*!<PD[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PE              0x4000U                           /*!<PE[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH              0x7000U                           /*!<PH[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  ***************/
+#define SYSCFG_EXTICR2_EXTI4_Pos             (0U)                              
+#define SYSCFG_EXTICR2_EXTI4_Msk             (0xFUL << SYSCFG_EXTICR2_EXTI4_Pos) /*!< 0x0000000F */
+#define SYSCFG_EXTICR2_EXTI4                 SYSCFG_EXTICR2_EXTI4_Msk          /*!<EXTI 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5_Pos             (4U)                              
+#define SYSCFG_EXTICR2_EXTI5_Msk             (0xFUL << SYSCFG_EXTICR2_EXTI5_Pos) /*!< 0x000000F0 */
+#define SYSCFG_EXTICR2_EXTI5                 SYSCFG_EXTICR2_EXTI5_Msk          /*!<EXTI 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6_Pos             (8U)                              
+#define SYSCFG_EXTICR2_EXTI6_Msk             (0xFUL << SYSCFG_EXTICR2_EXTI6_Pos) /*!< 0x00000F00 */
+#define SYSCFG_EXTICR2_EXTI6                 SYSCFG_EXTICR2_EXTI6_Msk          /*!<EXTI 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7_Pos             (12U)                             
+#define SYSCFG_EXTICR2_EXTI7_Msk             (0xFUL << SYSCFG_EXTICR2_EXTI7_Pos) /*!< 0x0000F000 */
+#define SYSCFG_EXTICR2_EXTI7                 SYSCFG_EXTICR2_EXTI7_Msk          /*!<EXTI 7 configuration */
+
+/**
+  * @brief   EXTI4 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA              0x0000U                           /*!<PA[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PB              0x0001U                           /*!<PB[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PC              0x0002U                           /*!<PC[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PD              0x0003U                           /*!<PD[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PE              0x0004U                           /*!<PE[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PH              0x0007U                           /*!<PH[4] pin */
+
+/**
+  * @brief   EXTI5 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA              0x0000U                           /*!<PA[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PB              0x0010U                           /*!<PB[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PC              0x0020U                           /*!<PC[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PD              0x0030U                           /*!<PD[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PE              0x0040U                           /*!<PE[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PH              0x0070U                           /*!<PH[5] pin */
+
+/**
+  * @brief   EXTI6 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA              0x0000U                           /*!<PA[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PB              0x0100U                           /*!<PB[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PC              0x0200U                           /*!<PC[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PD              0x0300U                           /*!<PD[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PE              0x0400U                           /*!<PE[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PH              0x0700U                           /*!<PH[6] pin */
+
+/**
+  * @brief   EXTI7 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA              0x0000U                           /*!<PA[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PB              0x1000U                           /*!<PB[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PC              0x2000U                           /*!<PC[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PD              0x3000U                           /*!<PD[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PE              0x4000U                           /*!<PE[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PH              0x7000U                           /*!<PH[7] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  ***************/
+#define SYSCFG_EXTICR3_EXTI8_Pos             (0U)                              
+#define SYSCFG_EXTICR3_EXTI8_Msk             (0xFUL << SYSCFG_EXTICR3_EXTI8_Pos) /*!< 0x0000000F */
+#define SYSCFG_EXTICR3_EXTI8                 SYSCFG_EXTICR3_EXTI8_Msk          /*!<EXTI 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9_Pos             (4U)                              
+#define SYSCFG_EXTICR3_EXTI9_Msk             (0xFUL << SYSCFG_EXTICR3_EXTI9_Pos) /*!< 0x000000F0 */
+#define SYSCFG_EXTICR3_EXTI9                 SYSCFG_EXTICR3_EXTI9_Msk          /*!<EXTI 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10_Pos            (8U)                              
+#define SYSCFG_EXTICR3_EXTI10_Msk            (0xFUL << SYSCFG_EXTICR3_EXTI10_Pos) /*!< 0x00000F00 */
+#define SYSCFG_EXTICR3_EXTI10                SYSCFG_EXTICR3_EXTI10_Msk         /*!<EXTI 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11_Pos            (12U)                             
+#define SYSCFG_EXTICR3_EXTI11_Msk            (0xFUL << SYSCFG_EXTICR3_EXTI11_Pos) /*!< 0x0000F000 */
+#define SYSCFG_EXTICR3_EXTI11                SYSCFG_EXTICR3_EXTI11_Msk         /*!<EXTI 11 configuration */
+
+/**
+  * @brief   EXTI8 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA              0x0000U                           /*!<PA[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PB              0x0001U                           /*!<PB[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PC              0x0002U                           /*!<PC[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PD              0x0003U                           /*!<PD[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PE              0x0004U                           /*!<PE[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PH              0x0007U                           /*!<PH[8] pin */
+
+/**
+  * @brief   EXTI9 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA              0x0000U                           /*!<PA[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PB              0x0010U                           /*!<PB[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PC              0x0020U                           /*!<PC[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PD              0x0030U                           /*!<PD[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PE              0x0040U                           /*!<PE[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PH              0x0070U                           /*!<PH[9] pin */
+
+/**
+  * @brief   EXTI10 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA             0x0000U                           /*!<PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB             0x0100U                           /*!<PB[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PC             0x0200U                           /*!<PC[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PD             0x0300U                           /*!<PD[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PE             0x0400U                           /*!<PE[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PH             0x0700U                           /*!<PH[10] pin */
+
+/**
+  * @brief   EXTI11 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA             0x0000U                           /*!<PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB             0x1000U                           /*!<PB[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PC             0x2000U                           /*!<PC[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PD             0x3000U                           /*!<PD[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PE             0x4000U                           /*!<PE[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PH             0x7000U                           /*!<PH[11] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  ***************/
+#define SYSCFG_EXTICR4_EXTI12_Pos            (0U)                              
+#define SYSCFG_EXTICR4_EXTI12_Msk            (0xFUL << SYSCFG_EXTICR4_EXTI12_Pos) /*!< 0x0000000F */
+#define SYSCFG_EXTICR4_EXTI12                SYSCFG_EXTICR4_EXTI12_Msk         /*!<EXTI 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13_Pos            (4U)                              
+#define SYSCFG_EXTICR4_EXTI13_Msk            (0xFUL << SYSCFG_EXTICR4_EXTI13_Pos) /*!< 0x000000F0 */
+#define SYSCFG_EXTICR4_EXTI13                SYSCFG_EXTICR4_EXTI13_Msk         /*!<EXTI 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14_Pos            (8U)                              
+#define SYSCFG_EXTICR4_EXTI14_Msk            (0xFUL << SYSCFG_EXTICR4_EXTI14_Pos) /*!< 0x00000F00 */
+#define SYSCFG_EXTICR4_EXTI14                SYSCFG_EXTICR4_EXTI14_Msk         /*!<EXTI 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15_Pos            (12U)                             
+#define SYSCFG_EXTICR4_EXTI15_Msk            (0xFUL << SYSCFG_EXTICR4_EXTI15_Pos) /*!< 0x0000F000 */
+#define SYSCFG_EXTICR4_EXTI15                SYSCFG_EXTICR4_EXTI15_Msk         /*!<EXTI 15 configuration */
+
+/**
+  * @brief   EXTI12 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA             0x0000U                           /*!<PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB             0x0001U                           /*!<PB[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PC             0x0002U                           /*!<PC[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PD             0x0003U                           /*!<PD[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PE             0x0004U                           /*!<PE[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PH             0x0007U                           /*!<PH[12] pin */
+
+/**
+  * @brief   EXTI13 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA             0x0000U                           /*!<PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB             0x0010U                           /*!<PB[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PC             0x0020U                           /*!<PC[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PD             0x0030U                           /*!<PD[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PE             0x0040U                           /*!<PE[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PH             0x0070U                           /*!<PH[13] pin */
+
+/**
+  * @brief   EXTI14 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA             0x0000U                           /*!<PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB             0x0100U                           /*!<PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC             0x0200U                           /*!<PC[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PD             0x0300U                           /*!<PD[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PE             0x0400U                           /*!<PE[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PH             0x0700U                           /*!<PH[14] pin */
+
+/**
+  * @brief   EXTI15 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA             0x0000U                           /*!<PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB             0x1000U                           /*!<PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC             0x2000U                           /*!<PC[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PD             0x3000U                           /*!<PD[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PE             0x4000U                           /*!<PE[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PH             0x7000U                           /*!<PH[15] pin */
+
+/******************  Bit definition for SYSCFG_CMPCR register  ****************/
+#define SYSCFG_CMPCR_CMP_PD_Pos              (0U)                              
+#define SYSCFG_CMPCR_CMP_PD_Msk              (0x1UL << SYSCFG_CMPCR_CMP_PD_Pos) /*!< 0x00000001 */
+#define SYSCFG_CMPCR_CMP_PD                  SYSCFG_CMPCR_CMP_PD_Msk           /*!<Compensation cell ready flag */
+#define SYSCFG_CMPCR_READY_Pos               (8U)                              
+#define SYSCFG_CMPCR_READY_Msk               (0x1UL << SYSCFG_CMPCR_READY_Pos)  /*!< 0x00000100 */
+#define SYSCFG_CMPCR_READY                   SYSCFG_CMPCR_READY_Msk            /*!<Compensation cell power-down */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)                                         
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                    /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable        */
+#define TIM_CR1_UDIS_Pos          (1U)                                         
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                   /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable        */
+#define TIM_CR1_URS_Pos           (2U)                                         
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                    /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)                                         
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                    /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode        */
+#define TIM_CR1_DIR_Pos           (4U)                                         
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                    /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction             */
+
+#define TIM_CR1_CMS_Pos           (5U)                                         
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                    /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1UL << TIM_CR1_CMS_Pos)                    /*!< 0x0020 */
+#define TIM_CR1_CMS_1             (0x2UL << TIM_CR1_CMS_Pos)                    /*!< 0x0040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)                                         
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                   /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable     */
+
+#define TIM_CR1_CKD_Pos           (8U)                                         
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                    /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1UL << TIM_CR1_CKD_Pos)                    /*!< 0x0100 */
+#define TIM_CR1_CKD_1             (0x2UL << TIM_CR1_CKD_Pos)                    /*!< 0x0200 */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)                                         
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                   /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control        */
+#define TIM_CR2_CCUS_Pos          (2U)                                         
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)                                         
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                   /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection            */
+
+#define TIM_CR2_MMS_Pos           (4U)                                         
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                    /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1UL << TIM_CR2_MMS_Pos)                    /*!< 0x0010 */
+#define TIM_CR2_MMS_1             (0x2UL << TIM_CR2_MMS_Pos)                    /*!< 0x0020 */
+#define TIM_CR2_MMS_2             (0x4UL << TIM_CR2_MMS_Pos)                    /*!< 0x0040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)                                         
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                   /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)                                         
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                   /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output)  */
+#define TIM_CR2_OIS1N_Pos         (9U)                                         
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                  /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)                                        
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                   /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output)  */
+#define TIM_CR2_OIS2N_Pos         (11U)                                        
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                  /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)                                        
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                   /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output)  */
+#define TIM_CR2_OIS3N_Pos         (13U)                                        
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                  /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)                                        
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                   /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output)  */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)                                         
+#define TIM_SMCR_SMS_Msk          (0x7UL << TIM_SMCR_SMS_Pos)                   /*!< 0x00000007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection)    */
+#define TIM_SMCR_SMS_0            (0x1UL << TIM_SMCR_SMS_Pos)                   /*!< 0x0001 */
+#define TIM_SMCR_SMS_1            (0x2UL << TIM_SMCR_SMS_Pos)                   /*!< 0x0002 */
+#define TIM_SMCR_SMS_2            (0x4UL << TIM_SMCR_SMS_Pos)                   /*!< 0x0004 */
+
+#define TIM_SMCR_TS_Pos           (4U)                                         
+#define TIM_SMCR_TS_Msk           (0x7UL << TIM_SMCR_TS_Pos)                    /*!< 0x00000070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection)        */
+#define TIM_SMCR_TS_0             (0x1UL << TIM_SMCR_TS_Pos)                    /*!< 0x0010 */
+#define TIM_SMCR_TS_1             (0x2UL << TIM_SMCR_TS_Pos)                    /*!< 0x0020 */
+#define TIM_SMCR_TS_2             (0x4UL << TIM_SMCR_TS_Pos)                    /*!< 0x0040 */
+
+#define TIM_SMCR_MSM_Pos          (7U)                                         
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                   /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode                       */
+
+#define TIM_SMCR_ETF_Pos          (8U)                                         
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                   /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1UL << TIM_SMCR_ETF_Pos)                   /*!< 0x0100 */
+#define TIM_SMCR_ETF_1            (0x2UL << TIM_SMCR_ETF_Pos)                   /*!< 0x0200 */
+#define TIM_SMCR_ETF_2            (0x4UL << TIM_SMCR_ETF_Pos)                   /*!< 0x0400 */
+#define TIM_SMCR_ETF_3            (0x8UL << TIM_SMCR_ETF_Pos)                   /*!< 0x0800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)                                        
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                  /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1UL << TIM_SMCR_ETPS_Pos)                  /*!< 0x1000 */
+#define TIM_SMCR_ETPS_1           (0x2UL << TIM_SMCR_ETPS_Pos)                  /*!< 0x2000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)                                        
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                   /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable     */
+#define TIM_SMCR_ETP_Pos          (15U)                                        
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                   /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)                                         
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                   /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)                                         
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                 /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable   */
+#define TIM_DIER_CC2IE_Pos        (2U)                                         
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                 /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable   */
+#define TIM_DIER_CC3IE_Pos        (3U)                                         
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                 /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable   */
+#define TIM_DIER_CC4IE_Pos        (4U)                                         
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                 /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable   */
+#define TIM_DIER_COMIE_Pos        (5U)                                         
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                 /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable                 */
+#define TIM_DIER_TIE_Pos          (6U)                                         
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                   /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable             */
+#define TIM_DIER_BIE_Pos          (7U)                                         
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                   /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable               */
+#define TIM_DIER_UDE_Pos          (8U)                                         
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                   /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable            */
+#define TIM_DIER_CC1DE_Pos        (9U)                                         
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                 /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)                                        
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                 /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)                                        
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                 /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)                                        
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                 /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)                                        
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                 /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable               */
+#define TIM_DIER_TDE_Pos          (14U)                                        
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                   /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable           */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)                                         
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                     /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag              */
+#define TIM_SR_CC1IF_Pos          (1U)                                         
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                   /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag   */
+#define TIM_SR_CC2IF_Pos          (2U)                                         
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                   /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag   */
+#define TIM_SR_CC3IF_Pos          (3U)                                         
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                   /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag   */
+#define TIM_SR_CC4IF_Pos          (4U)                                         
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                   /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag   */
+#define TIM_SR_COMIF_Pos          (5U)                                         
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                   /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag                 */
+#define TIM_SR_TIF_Pos            (6U)                                         
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                     /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag             */
+#define TIM_SR_BIF_Pos            (7U)                                         
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                     /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag               */
+#define TIM_SR_CC1OF_Pos          (9U)                                         
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                   /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)                                        
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                   /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)                                        
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                   /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)                                        
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                   /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)                                         
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                     /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation                         */
+#define TIM_EGR_CC1G_Pos          (1U)                                         
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                   /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation              */
+#define TIM_EGR_CC2G_Pos          (2U)                                         
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                   /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation              */
+#define TIM_EGR_CC3G_Pos          (3U)                                         
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                   /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation              */
+#define TIM_EGR_CC4G_Pos          (4U)                                         
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                   /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation              */
+#define TIM_EGR_COMG_Pos          (5U)                                         
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                   /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)                                         
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                     /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation                        */
+#define TIM_EGR_BG_Pos            (7U)                                         
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                     /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation                          */
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)                                         
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1UL << TIM_CCMR1_CC1S_Pos)                 /*!< 0x0001 */
+#define TIM_CCMR1_CC1S_1          (0x2UL << TIM_CCMR1_CC1S_Pos)                 /*!< 0x0002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)                                         
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)                /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable                 */
+#define TIM_CCMR1_OC1PE_Pos       (3U)                                         
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)                /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable              */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)                                         
+#define TIM_CCMR1_OC1M_Msk        (0x7UL << TIM_CCMR1_OC1M_Pos)                 /*!< 0x00000070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode)       */
+#define TIM_CCMR1_OC1M_0          (0x1UL << TIM_CCMR1_OC1M_Pos)                 /*!< 0x0010 */
+#define TIM_CCMR1_OC1M_1          (0x2UL << TIM_CCMR1_OC1M_Pos)                 /*!< 0x0020 */
+#define TIM_CCMR1_OC1M_2          (0x4UL << TIM_CCMR1_OC1M_Pos)                 /*!< 0x0040 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)                                         
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)                /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1Clear Enable                 */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)                                         
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1UL << TIM_CCMR1_CC2S_Pos)                 /*!< 0x0100 */
+#define TIM_CCMR1_CC2S_1          (0x2UL << TIM_CCMR1_CC2S_Pos)                 /*!< 0x0200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)                                        
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)                /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable                 */
+#define TIM_CCMR1_OC2PE_Pos       (11U)                                        
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)                /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable              */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)                                        
+#define TIM_CCMR1_OC2M_Msk        (0x7UL << TIM_CCMR1_OC2M_Pos)                 /*!< 0x00007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode)       */
+#define TIM_CCMR1_OC2M_0          (0x1UL << TIM_CCMR1_OC2M_Pos)                 /*!< 0x1000 */
+#define TIM_CCMR1_OC2M_1          (0x2UL << TIM_CCMR1_OC2M_Pos)                 /*!< 0x2000 */
+#define TIM_CCMR1_OC2M_2          (0x4UL << TIM_CCMR1_OC2M_Pos)                 /*!< 0x4000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)                                        
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)                /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define TIM_CCMR1_IC1PSC_Pos      (2U)                                         
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1UL << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x0004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2UL << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x0008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)                                         
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                 /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter)      */
+#define TIM_CCMR1_IC1F_0          (0x1UL << TIM_CCMR1_IC1F_Pos)                 /*!< 0x0010 */
+#define TIM_CCMR1_IC1F_1          (0x2UL << TIM_CCMR1_IC1F_Pos)                 /*!< 0x0020 */
+#define TIM_CCMR1_IC1F_2          (0x4UL << TIM_CCMR1_IC1F_Pos)                 /*!< 0x0040 */
+#define TIM_CCMR1_IC1F_3          (0x8UL << TIM_CCMR1_IC1F_Pos)                 /*!< 0x0080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)                                        
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler)  */
+#define TIM_CCMR1_IC2PSC_0        (0x1UL << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x0400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2UL << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x0800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)                                        
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                 /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter)       */
+#define TIM_CCMR1_IC2F_0          (0x1UL << TIM_CCMR1_IC2F_Pos)                 /*!< 0x1000 */
+#define TIM_CCMR1_IC2F_1          (0x2UL << TIM_CCMR1_IC2F_Pos)                 /*!< 0x2000 */
+#define TIM_CCMR1_IC2F_2          (0x4UL << TIM_CCMR1_IC2F_Pos)                 /*!< 0x4000 */
+#define TIM_CCMR1_IC2F_3          (0x8UL << TIM_CCMR1_IC2F_Pos)                 /*!< 0x8000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)                                         
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection)  */
+#define TIM_CCMR2_CC3S_0          (0x1UL << TIM_CCMR2_CC3S_Pos)                 /*!< 0x0001 */
+#define TIM_CCMR2_CC3S_1          (0x2UL << TIM_CCMR2_CC3S_Pos)                 /*!< 0x0002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)                                         
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)                /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable           */
+#define TIM_CCMR2_OC3PE_Pos       (3U)                                         
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)                /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable        */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)                                         
+#define TIM_CCMR2_OC3M_Msk        (0x7UL << TIM_CCMR2_OC3M_Pos)                 /*!< 0x00000070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x1UL << TIM_CCMR2_OC3M_Pos)                 /*!< 0x0010 */
+#define TIM_CCMR2_OC3M_1          (0x2UL << TIM_CCMR2_OC3M_Pos)                 /*!< 0x0020 */
+#define TIM_CCMR2_OC3M_2          (0x4UL << TIM_CCMR2_OC3M_Pos)                 /*!< 0x0040 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)                                         
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)                /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)                                         
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1UL << TIM_CCMR2_CC4S_Pos)                 /*!< 0x0100 */
+#define TIM_CCMR2_CC4S_1          (0x2UL << TIM_CCMR2_CC4S_Pos)                 /*!< 0x0200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)                                        
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)                /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable    */
+#define TIM_CCMR2_OC4PE_Pos       (11U)                                        
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)                /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)                                        
+#define TIM_CCMR2_OC4M_Msk        (0x7UL << TIM_CCMR2_OC4M_Pos)                 /*!< 0x00007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x1UL << TIM_CCMR2_OC4M_Pos)                 /*!< 0x1000 */
+#define TIM_CCMR2_OC4M_1          (0x2UL << TIM_CCMR2_OC4M_Pos)                 /*!< 0x2000 */
+#define TIM_CCMR2_OC4M_2          (0x4UL << TIM_CCMR2_OC4M_Pos)                 /*!< 0x4000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)                                        
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)                /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define TIM_CCMR2_IC3PSC_Pos      (2U)                                         
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1UL << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x0004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2UL << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x0008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)                                         
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                 /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1UL << TIM_CCMR2_IC3F_Pos)                 /*!< 0x0010 */
+#define TIM_CCMR2_IC3F_1          (0x2UL << TIM_CCMR2_IC3F_Pos)                 /*!< 0x0020 */
+#define TIM_CCMR2_IC3F_2          (0x4UL << TIM_CCMR2_IC3F_Pos)                 /*!< 0x0040 */
+#define TIM_CCMR2_IC3F_3          (0x8UL << TIM_CCMR2_IC3F_Pos)                 /*!< 0x0080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)                                        
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1UL << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x0400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2UL << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x0800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)                                        
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                 /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1UL << TIM_CCMR2_IC4F_Pos)                 /*!< 0x1000 */
+#define TIM_CCMR2_IC4F_1          (0x2UL << TIM_CCMR2_IC4F_Pos)                 /*!< 0x2000 */
+#define TIM_CCMR2_IC4F_2          (0x4UL << TIM_CCMR2_IC4F_Pos)                 /*!< 0x4000 */
+#define TIM_CCMR2_IC4F_3          (0x8UL << TIM_CCMR2_IC4F_Pos)                 /*!< 0x8000 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)                                         
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                  /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable                 */
+#define TIM_CCER_CC1P_Pos         (1U)                                         
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                  /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity               */
+#define TIM_CCER_CC1NE_Pos        (2U)                                         
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                 /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable   */
+#define TIM_CCER_CC1NP_Pos        (3U)                                         
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                 /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)                                         
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                  /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable                 */
+#define TIM_CCER_CC2P_Pos         (5U)                                         
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                  /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity               */
+#define TIM_CCER_CC2NE_Pos        (6U)                                         
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                 /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable   */
+#define TIM_CCER_CC2NP_Pos        (7U)                                         
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                 /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)                                         
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                  /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable                 */
+#define TIM_CCER_CC3P_Pos         (9U)                                         
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                  /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity               */
+#define TIM_CCER_CC3NE_Pos        (10U)                                        
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                 /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable   */
+#define TIM_CCER_CC3NP_Pos        (11U)                                        
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                 /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)                                        
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                  /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable                 */
+#define TIM_CCER_CC4P_Pos         (13U)                                        
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                  /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity               */
+#define TIM_CCER_CC4NP_Pos        (15U)                                        
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                 /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)                                             
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)                 /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                                  /*!<Counter Value            */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)                                         
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                 /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value          */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)                                         
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)             /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)                                         
+#define TIM_RCR_REP_Msk           (0xFFUL << TIM_RCR_REP_Pos)                   /*!< 0x000000FF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)                                         
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)               /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value  */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)                                         
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)               /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value  */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)                                         
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)               /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value  */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)                                         
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)               /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value  */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)                                         
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                  /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0001 */
+#define TIM_BDTR_DTG_1            (0x02UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0002 */
+#define TIM_BDTR_DTG_2            (0x04UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0004 */
+#define TIM_BDTR_DTG_3            (0x08UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0008 */
+#define TIM_BDTR_DTG_4            (0x10UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0010 */
+#define TIM_BDTR_DTG_5            (0x20UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0020 */
+#define TIM_BDTR_DTG_6            (0x40UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0040 */
+#define TIM_BDTR_DTG_7            (0x80UL << TIM_BDTR_DTG_Pos)                  /*!< 0x0080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)                                         
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1UL << TIM_BDTR_LOCK_Pos)                  /*!< 0x0100 */
+#define TIM_BDTR_LOCK_1           (0x2UL << TIM_BDTR_LOCK_Pos)                  /*!< 0x0200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)                                        
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                  /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)                                        
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                  /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode  */
+#define TIM_BDTR_BKE_Pos          (12U)                                        
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                   /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable                      */
+#define TIM_BDTR_BKP_Pos          (13U)                                        
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                   /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity                    */
+#define TIM_BDTR_AOE_Pos          (14U)                                        
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                   /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable           */
+#define TIM_BDTR_MOE_Pos          (15U)                                        
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                   /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable                */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)                                         
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                   /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01UL << TIM_DCR_DBA_Pos)                   /*!< 0x0001 */
+#define TIM_DCR_DBA_1             (0x02UL << TIM_DCR_DBA_Pos)                   /*!< 0x0002 */
+#define TIM_DCR_DBA_2             (0x04UL << TIM_DCR_DBA_Pos)                   /*!< 0x0004 */
+#define TIM_DCR_DBA_3             (0x08UL << TIM_DCR_DBA_Pos)                   /*!< 0x0008 */
+#define TIM_DCR_DBA_4             (0x10UL << TIM_DCR_DBA_Pos)                   /*!< 0x0010 */
+
+#define TIM_DCR_DBL_Pos           (8U)                                         
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                   /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01UL << TIM_DCR_DBL_Pos)                   /*!< 0x0100 */
+#define TIM_DCR_DBL_1             (0x02UL << TIM_DCR_DBL_Pos)                   /*!< 0x0200 */
+#define TIM_DCR_DBL_2             (0x04UL << TIM_DCR_DBL_Pos)                   /*!< 0x0400 */
+#define TIM_DCR_DBL_3             (0x08UL << TIM_DCR_DBL_Pos)                   /*!< 0x0800 */
+#define TIM_DCR_DBL_4             (0x10UL << TIM_DCR_DBL_Pos)                   /*!< 0x1000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)                                         
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)               /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses                    */
+
+/*******************  Bit definition for TIM_OR register  *********************/
+#define TIM_OR_TI1_RMP_Pos        (0U)                                          
+#define TIM_OR_TI1_RMP_Msk        (0x3UL << TIM_OR_TI1_RMP_Pos)                 /*!< 0x00000003 */
+#define TIM_OR_TI1_RMP            TIM_OR_TI1_RMP_Msk                           /*!< TI1_RMP[1:0] bits (TIM11 Input Capture 1 remap) */
+#define TIM_OR_TI1_RMP_0          (0x1UL << TIM_OR_TI1_RMP_Pos)                 /*!< 0x00000001 */
+#define TIM_OR_TI1_RMP_1          (0x2UL << TIM_OR_TI1_RMP_Pos)                 /*!< 0x00000002 */
+
+#define TIM_OR_TI4_RMP_Pos        (6U)                                         
+#define TIM_OR_TI4_RMP_Msk        (0x3UL << TIM_OR_TI4_RMP_Pos)                 /*!< 0x000000C0 */
+#define TIM_OR_TI4_RMP            TIM_OR_TI4_RMP_Msk                           /*!<TI4_RMP[1:0] bits (TIM5 Input 4 remap)             */
+#define TIM_OR_TI4_RMP_0          (0x1UL << TIM_OR_TI4_RMP_Pos)                 /*!< 0x0040 */
+#define TIM_OR_TI4_RMP_1          (0x2UL << TIM_OR_TI4_RMP_Pos)                 /*!< 0x0080 */
+#define TIM_OR_ITR1_RMP_Pos       (10U)                                        
+#define TIM_OR_ITR1_RMP_Msk       (0x3UL << TIM_OR_ITR1_RMP_Pos)                /*!< 0x00000C00 */
+#define TIM_OR_ITR1_RMP           TIM_OR_ITR1_RMP_Msk                          /*!<ITR1_RMP[1:0] bits (TIM2 Internal trigger 1 remap) */
+#define TIM_OR_ITR1_RMP_0         (0x1UL << TIM_OR_ITR1_RMP_Pos)                /*!< 0x0400 */
+#define TIM_OR_ITR1_RMP_1         (0x2UL << TIM_OR_ITR1_RMP_Pos)                /*!< 0x0800 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*         Universal Synchronous Asynchronous Receiver Transmitter            */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for USART_SR register  *******************/
+#define USART_SR_PE_Pos               (0U)                                     
+#define USART_SR_PE_Msk               (0x1UL << USART_SR_PE_Pos)                /*!< 0x00000001 */
+#define USART_SR_PE                   USART_SR_PE_Msk                          /*!<Parity Error                 */
+#define USART_SR_FE_Pos               (1U)                                     
+#define USART_SR_FE_Msk               (0x1UL << USART_SR_FE_Pos)                /*!< 0x00000002 */
+#define USART_SR_FE                   USART_SR_FE_Msk                          /*!<Framing Error                */
+#define USART_SR_NE_Pos               (2U)                                     
+#define USART_SR_NE_Msk               (0x1UL << USART_SR_NE_Pos)                /*!< 0x00000004 */
+#define USART_SR_NE                   USART_SR_NE_Msk                          /*!<Noise Error Flag             */
+#define USART_SR_ORE_Pos              (3U)                                     
+#define USART_SR_ORE_Msk              (0x1UL << USART_SR_ORE_Pos)               /*!< 0x00000008 */
+#define USART_SR_ORE                  USART_SR_ORE_Msk                         /*!<OverRun Error                */
+#define USART_SR_IDLE_Pos             (4U)                                     
+#define USART_SR_IDLE_Msk             (0x1UL << USART_SR_IDLE_Pos)              /*!< 0x00000010 */
+#define USART_SR_IDLE                 USART_SR_IDLE_Msk                        /*!<IDLE line detected           */
+#define USART_SR_RXNE_Pos             (5U)                                     
+#define USART_SR_RXNE_Msk             (0x1UL << USART_SR_RXNE_Pos)              /*!< 0x00000020 */
+#define USART_SR_RXNE                 USART_SR_RXNE_Msk                        /*!<Read Data Register Not Empty */
+#define USART_SR_TC_Pos               (6U)                                     
+#define USART_SR_TC_Msk               (0x1UL << USART_SR_TC_Pos)                /*!< 0x00000040 */
+#define USART_SR_TC                   USART_SR_TC_Msk                          /*!<Transmission Complete        */
+#define USART_SR_TXE_Pos              (7U)                                     
+#define USART_SR_TXE_Msk              (0x1UL << USART_SR_TXE_Pos)               /*!< 0x00000080 */
+#define USART_SR_TXE                  USART_SR_TXE_Msk                         /*!<Transmit Data Register Empty */
+#define USART_SR_LBD_Pos              (8U)                                     
+#define USART_SR_LBD_Msk              (0x1UL << USART_SR_LBD_Pos)               /*!< 0x00000100 */
+#define USART_SR_LBD                  USART_SR_LBD_Msk                         /*!<LIN Break Detection Flag     */
+#define USART_SR_CTS_Pos              (9U)                                     
+#define USART_SR_CTS_Msk              (0x1UL << USART_SR_CTS_Pos)               /*!< 0x00000200 */
+#define USART_SR_CTS                  USART_SR_CTS_Msk                         /*!<CTS Flag                     */
+
+/*******************  Bit definition for USART_DR register  *******************/
+#define USART_DR_DR_Pos               (0U)                                     
+#define USART_DR_DR_Msk               (0x1FFUL << USART_DR_DR_Pos)              /*!< 0x000001FF */
+#define USART_DR_DR                   USART_DR_DR_Msk                          /*!<Data value */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_DIV_Fraction_Pos    (0U)                                     
+#define USART_BRR_DIV_Fraction_Msk    (0xFUL << USART_BRR_DIV_Fraction_Pos)     /*!< 0x0000000F */
+#define USART_BRR_DIV_Fraction        USART_BRR_DIV_Fraction_Msk               /*!<Fraction of USARTDIV */
+#define USART_BRR_DIV_Mantissa_Pos    (4U)                                     
+#define USART_BRR_DIV_Mantissa_Msk    (0xFFFUL << USART_BRR_DIV_Mantissa_Pos)   /*!< 0x0000FFF0 */
+#define USART_BRR_DIV_Mantissa        USART_BRR_DIV_Mantissa_Msk               /*!<Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_SBK_Pos             (0U)                                     
+#define USART_CR1_SBK_Msk             (0x1UL << USART_CR1_SBK_Pos)              /*!< 0x00000001 */
+#define USART_CR1_SBK                 USART_CR1_SBK_Msk                        /*!<Send Break                             */
+#define USART_CR1_RWU_Pos             (1U)                                     
+#define USART_CR1_RWU_Msk             (0x1UL << USART_CR1_RWU_Pos)              /*!< 0x00000002 */
+#define USART_CR1_RWU                 USART_CR1_RWU_Msk                        /*!<Receiver wakeup                        */
+#define USART_CR1_RE_Pos              (2U)                                     
+#define USART_CR1_RE_Msk              (0x1UL << USART_CR1_RE_Pos)               /*!< 0x00000004 */
+#define USART_CR1_RE                  USART_CR1_RE_Msk                         /*!<Receiver Enable                        */
+#define USART_CR1_TE_Pos              (3U)                                     
+#define USART_CR1_TE_Msk              (0x1UL << USART_CR1_TE_Pos)               /*!< 0x00000008 */
+#define USART_CR1_TE                  USART_CR1_TE_Msk                         /*!<Transmitter Enable                     */
+#define USART_CR1_IDLEIE_Pos          (4U)                                     
+#define USART_CR1_IDLEIE_Msk          (0x1UL << USART_CR1_IDLEIE_Pos)           /*!< 0x00000010 */
+#define USART_CR1_IDLEIE              USART_CR1_IDLEIE_Msk                     /*!<IDLE Interrupt Enable                  */
+#define USART_CR1_RXNEIE_Pos          (5U)                                     
+#define USART_CR1_RXNEIE_Msk          (0x1UL << USART_CR1_RXNEIE_Pos)           /*!< 0x00000020 */
+#define USART_CR1_RXNEIE              USART_CR1_RXNEIE_Msk                     /*!<RXNE Interrupt Enable                  */
+#define USART_CR1_TCIE_Pos            (6U)                                     
+#define USART_CR1_TCIE_Msk            (0x1UL << USART_CR1_TCIE_Pos)             /*!< 0x00000040 */
+#define USART_CR1_TCIE                USART_CR1_TCIE_Msk                       /*!<Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_Pos           (7U)                                     
+#define USART_CR1_TXEIE_Msk           (0x1UL << USART_CR1_TXEIE_Pos)            /*!< 0x00000080 */
+#define USART_CR1_TXEIE               USART_CR1_TXEIE_Msk                      /*!<TXE Interrupt Enable                   */
+#define USART_CR1_PEIE_Pos            (8U)                                     
+#define USART_CR1_PEIE_Msk            (0x1UL << USART_CR1_PEIE_Pos)             /*!< 0x00000100 */
+#define USART_CR1_PEIE                USART_CR1_PEIE_Msk                       /*!<PE Interrupt Enable                    */
+#define USART_CR1_PS_Pos              (9U)                                     
+#define USART_CR1_PS_Msk              (0x1UL << USART_CR1_PS_Pos)               /*!< 0x00000200 */
+#define USART_CR1_PS                  USART_CR1_PS_Msk                         /*!<Parity Selection                       */
+#define USART_CR1_PCE_Pos             (10U)                                    
+#define USART_CR1_PCE_Msk             (0x1UL << USART_CR1_PCE_Pos)              /*!< 0x00000400 */
+#define USART_CR1_PCE                 USART_CR1_PCE_Msk                        /*!<Parity Control Enable                  */
+#define USART_CR1_WAKE_Pos            (11U)                                    
+#define USART_CR1_WAKE_Msk            (0x1UL << USART_CR1_WAKE_Pos)             /*!< 0x00000800 */
+#define USART_CR1_WAKE                USART_CR1_WAKE_Msk                       /*!<Wakeup method                          */
+#define USART_CR1_M_Pos               (12U)                                    
+#define USART_CR1_M_Msk               (0x1UL << USART_CR1_M_Pos)                /*!< 0x00001000 */
+#define USART_CR1_M                   USART_CR1_M_Msk                          /*!<Word length                            */
+#define USART_CR1_UE_Pos              (13U)                                    
+#define USART_CR1_UE_Msk              (0x1UL << USART_CR1_UE_Pos)               /*!< 0x00002000 */
+#define USART_CR1_UE                  USART_CR1_UE_Msk                         /*!<USART Enable                           */
+#define USART_CR1_OVER8_Pos           (15U)                                    
+#define USART_CR1_OVER8_Msk           (0x1UL << USART_CR1_OVER8_Pos)            /*!< 0x00008000 */
+#define USART_CR1_OVER8               USART_CR1_OVER8_Msk                      /*!<USART Oversampling by 8 enable         */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_ADD_Pos             (0U)                                     
+#define USART_CR2_ADD_Msk             (0xFUL << USART_CR2_ADD_Pos)              /*!< 0x0000000F */
+#define USART_CR2_ADD                 USART_CR2_ADD_Msk                        /*!<Address of the USART node            */
+#define USART_CR2_LBDL_Pos            (5U)                                     
+#define USART_CR2_LBDL_Msk            (0x1UL << USART_CR2_LBDL_Pos)             /*!< 0x00000020 */
+#define USART_CR2_LBDL                USART_CR2_LBDL_Msk                       /*!<LIN Break Detection Length           */
+#define USART_CR2_LBDIE_Pos           (6U)                                     
+#define USART_CR2_LBDIE_Msk           (0x1UL << USART_CR2_LBDIE_Pos)            /*!< 0x00000040 */
+#define USART_CR2_LBDIE               USART_CR2_LBDIE_Msk                      /*!<LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos            (8U)                                     
+#define USART_CR2_LBCL_Msk            (0x1UL << USART_CR2_LBCL_Pos)             /*!< 0x00000100 */
+#define USART_CR2_LBCL                USART_CR2_LBCL_Msk                       /*!<Last Bit Clock pulse                 */
+#define USART_CR2_CPHA_Pos            (9U)                                     
+#define USART_CR2_CPHA_Msk            (0x1UL << USART_CR2_CPHA_Pos)             /*!< 0x00000200 */
+#define USART_CR2_CPHA                USART_CR2_CPHA_Msk                       /*!<Clock Phase                          */
+#define USART_CR2_CPOL_Pos            (10U)                                    
+#define USART_CR2_CPOL_Msk            (0x1UL << USART_CR2_CPOL_Pos)             /*!< 0x00000400 */
+#define USART_CR2_CPOL                USART_CR2_CPOL_Msk                       /*!<Clock Polarity                       */
+#define USART_CR2_CLKEN_Pos           (11U)                                    
+#define USART_CR2_CLKEN_Msk           (0x1UL << USART_CR2_CLKEN_Pos)            /*!< 0x00000800 */
+#define USART_CR2_CLKEN               USART_CR2_CLKEN_Msk                      /*!<Clock Enable                         */
+
+#define USART_CR2_STOP_Pos            (12U)                                    
+#define USART_CR2_STOP_Msk            (0x3UL << USART_CR2_STOP_Pos)             /*!< 0x00003000 */
+#define USART_CR2_STOP                USART_CR2_STOP_Msk                       /*!<STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0              (0x1UL << USART_CR2_STOP_Pos)             /*!< 0x1000 */
+#define USART_CR2_STOP_1              (0x2UL << USART_CR2_STOP_Pos)             /*!< 0x2000 */
+
+#define USART_CR2_LINEN_Pos           (14U)                                    
+#define USART_CR2_LINEN_Msk           (0x1UL << USART_CR2_LINEN_Pos)            /*!< 0x00004000 */
+#define USART_CR2_LINEN               USART_CR2_LINEN_Msk                      /*!<LIN mode enable */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos             (0U)                                     
+#define USART_CR3_EIE_Msk             (0x1UL << USART_CR3_EIE_Pos)              /*!< 0x00000001 */
+#define USART_CR3_EIE                 USART_CR3_EIE_Msk                        /*!<Error Interrupt Enable      */
+#define USART_CR3_IREN_Pos            (1U)                                     
+#define USART_CR3_IREN_Msk            (0x1UL << USART_CR3_IREN_Pos)             /*!< 0x00000002 */
+#define USART_CR3_IREN                USART_CR3_IREN_Msk                       /*!<IrDA mode Enable            */
+#define USART_CR3_IRLP_Pos            (2U)                                     
+#define USART_CR3_IRLP_Msk            (0x1UL << USART_CR3_IRLP_Pos)             /*!< 0x00000004 */
+#define USART_CR3_IRLP                USART_CR3_IRLP_Msk                       /*!<IrDA Low-Power              */
+#define USART_CR3_HDSEL_Pos           (3U)                                     
+#define USART_CR3_HDSEL_Msk           (0x1UL << USART_CR3_HDSEL_Pos)            /*!< 0x00000008 */
+#define USART_CR3_HDSEL               USART_CR3_HDSEL_Msk                      /*!<Half-Duplex Selection       */
+#define USART_CR3_NACK_Pos            (4U)                                     
+#define USART_CR3_NACK_Msk            (0x1UL << USART_CR3_NACK_Pos)             /*!< 0x00000010 */
+#define USART_CR3_NACK                USART_CR3_NACK_Msk                       /*!<Smartcard NACK enable       */
+#define USART_CR3_SCEN_Pos            (5U)                                     
+#define USART_CR3_SCEN_Msk            (0x1UL << USART_CR3_SCEN_Pos)             /*!< 0x00000020 */
+#define USART_CR3_SCEN                USART_CR3_SCEN_Msk                       /*!<Smartcard mode enable       */
+#define USART_CR3_DMAR_Pos            (6U)                                     
+#define USART_CR3_DMAR_Msk            (0x1UL << USART_CR3_DMAR_Pos)             /*!< 0x00000040 */
+#define USART_CR3_DMAR                USART_CR3_DMAR_Msk                       /*!<DMA Enable Receiver         */
+#define USART_CR3_DMAT_Pos            (7U)                                     
+#define USART_CR3_DMAT_Msk            (0x1UL << USART_CR3_DMAT_Pos)             /*!< 0x00000080 */
+#define USART_CR3_DMAT                USART_CR3_DMAT_Msk                       /*!<DMA Enable Transmitter      */
+#define USART_CR3_RTSE_Pos            (8U)                                     
+#define USART_CR3_RTSE_Msk            (0x1UL << USART_CR3_RTSE_Pos)             /*!< 0x00000100 */
+#define USART_CR3_RTSE                USART_CR3_RTSE_Msk                       /*!<RTS Enable                  */
+#define USART_CR3_CTSE_Pos            (9U)                                     
+#define USART_CR3_CTSE_Msk            (0x1UL << USART_CR3_CTSE_Pos)             /*!< 0x00000200 */
+#define USART_CR3_CTSE                USART_CR3_CTSE_Msk                       /*!<CTS Enable                  */
+#define USART_CR3_CTSIE_Pos           (10U)                                    
+#define USART_CR3_CTSIE_Msk           (0x1UL << USART_CR3_CTSIE_Pos)            /*!< 0x00000400 */
+#define USART_CR3_CTSIE               USART_CR3_CTSIE_Msk                      /*!<CTS Interrupt Enable        */
+#define USART_CR3_ONEBIT_Pos          (11U)                                    
+#define USART_CR3_ONEBIT_Msk          (0x1UL << USART_CR3_ONEBIT_Pos)           /*!< 0x00000800 */
+#define USART_CR3_ONEBIT              USART_CR3_ONEBIT_Msk                     /*!<USART One bit method enable */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos            (0U)                                     
+#define USART_GTPR_PSC_Msk            (0xFFUL << USART_GTPR_PSC_Pos)            /*!< 0x000000FF */
+#define USART_GTPR_PSC                USART_GTPR_PSC_Msk                       /*!<PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_PSC_0              (0x01UL << USART_GTPR_PSC_Pos)            /*!< 0x0001 */
+#define USART_GTPR_PSC_1              (0x02UL << USART_GTPR_PSC_Pos)            /*!< 0x0002 */
+#define USART_GTPR_PSC_2              (0x04UL << USART_GTPR_PSC_Pos)            /*!< 0x0004 */
+#define USART_GTPR_PSC_3              (0x08UL << USART_GTPR_PSC_Pos)            /*!< 0x0008 */
+#define USART_GTPR_PSC_4              (0x10UL << USART_GTPR_PSC_Pos)            /*!< 0x0010 */
+#define USART_GTPR_PSC_5              (0x20UL << USART_GTPR_PSC_Pos)            /*!< 0x0020 */
+#define USART_GTPR_PSC_6              (0x40UL << USART_GTPR_PSC_Pos)            /*!< 0x0040 */
+#define USART_GTPR_PSC_7              (0x80UL << USART_GTPR_PSC_Pos)            /*!< 0x0080 */
+
+#define USART_GTPR_GT_Pos             (8U)                                     
+#define USART_GTPR_GT_Msk             (0xFFUL << USART_GTPR_GT_Pos)             /*!< 0x0000FF00 */
+#define USART_GTPR_GT                 USART_GTPR_GT_Msk                        /*!<Guard time value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)                                           
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                       /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01UL << WWDG_CR_T_Pos)                       /*!< 0x01 */
+#define WWDG_CR_T_1             (0x02UL << WWDG_CR_T_Pos)                       /*!< 0x02 */
+#define WWDG_CR_T_2             (0x04UL << WWDG_CR_T_Pos)                       /*!< 0x04 */
+#define WWDG_CR_T_3             (0x08UL << WWDG_CR_T_Pos)                       /*!< 0x08 */
+#define WWDG_CR_T_4             (0x10UL << WWDG_CR_T_Pos)                       /*!< 0x10 */
+#define WWDG_CR_T_5             (0x20UL << WWDG_CR_T_Pos)                       /*!< 0x20 */
+#define WWDG_CR_T_6             (0x40UL << WWDG_CR_T_Pos)                       /*!< 0x40 */
+/* Legacy defines */
+#define  WWDG_CR_T0                          WWDG_CR_T_0
+#define  WWDG_CR_T1                          WWDG_CR_T_1
+#define  WWDG_CR_T2                          WWDG_CR_T_2
+#define  WWDG_CR_T3                          WWDG_CR_T_3
+#define  WWDG_CR_T4                          WWDG_CR_T_4
+#define  WWDG_CR_T5                          WWDG_CR_T_5
+#define  WWDG_CR_T6                          WWDG_CR_T_6
+
+#define WWDG_CR_WDGA_Pos        (7U)                                           
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                     /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)                                           
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                      /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01UL << WWDG_CFR_W_Pos)                      /*!< 0x0001 */
+#define WWDG_CFR_W_1            (0x02UL << WWDG_CFR_W_Pos)                      /*!< 0x0002 */
+#define WWDG_CFR_W_2            (0x04UL << WWDG_CFR_W_Pos)                      /*!< 0x0004 */
+#define WWDG_CFR_W_3            (0x08UL << WWDG_CFR_W_Pos)                      /*!< 0x0008 */
+#define WWDG_CFR_W_4            (0x10UL << WWDG_CFR_W_Pos)                      /*!< 0x0010 */
+#define WWDG_CFR_W_5            (0x20UL << WWDG_CFR_W_Pos)                      /*!< 0x0020 */
+#define WWDG_CFR_W_6            (0x40UL << WWDG_CFR_W_Pos)                      /*!< 0x0040 */
+/* Legacy defines */
+#define  WWDG_CFR_W0                         WWDG_CFR_W_0
+#define  WWDG_CFR_W1                         WWDG_CFR_W_1
+#define  WWDG_CFR_W2                         WWDG_CFR_W_2
+#define  WWDG_CFR_W3                         WWDG_CFR_W_3
+#define  WWDG_CFR_W4                         WWDG_CFR_W_4
+#define  WWDG_CFR_W5                         WWDG_CFR_W_5
+#define  WWDG_CFR_W6                         WWDG_CFR_W_6
+
+#define WWDG_CFR_WDGTB_Pos      (7U)                                           
+#define WWDG_CFR_WDGTB_Msk      (0x3UL << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00000180 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[1:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1UL << WWDG_CFR_WDGTB_Pos)                   /*!< 0x0080 */
+#define WWDG_CFR_WDGTB_1        (0x2UL << WWDG_CFR_WDGTB_Pos)                   /*!< 0x0100 */
+/* Legacy defines */
+#define  WWDG_CFR_WDGTB0                     WWDG_CFR_WDGTB_0
+#define  WWDG_CFR_WDGTB1                     WWDG_CFR_WDGTB_1
+
+#define WWDG_CFR_EWI_Pos        (9U)                                           
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                     /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)                                           
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                     /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                DBG                                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define DBGMCU_IDCODE_DEV_ID_Pos                     (0U)                      
+#define DBGMCU_IDCODE_DEV_ID_Msk                     (0xFFFUL << DBGMCU_IDCODE_DEV_ID_Pos) /*!< 0x00000FFF */
+#define DBGMCU_IDCODE_DEV_ID                         DBGMCU_IDCODE_DEV_ID_Msk  
+#define DBGMCU_IDCODE_REV_ID_Pos                     (16U)                     
+#define DBGMCU_IDCODE_REV_ID_Msk                     (0xFFFFUL << DBGMCU_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBGMCU_IDCODE_REV_ID                         DBGMCU_IDCODE_REV_ID_Msk  
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define DBGMCU_CR_DBG_SLEEP_Pos                      (0U)                      
+#define DBGMCU_CR_DBG_SLEEP_Msk                      (0x1UL << DBGMCU_CR_DBG_SLEEP_Pos) /*!< 0x00000001 */
+#define DBGMCU_CR_DBG_SLEEP                          DBGMCU_CR_DBG_SLEEP_Msk   
+#define DBGMCU_CR_DBG_STOP_Pos                       (1U)                      
+#define DBGMCU_CR_DBG_STOP_Msk                       (0x1UL << DBGMCU_CR_DBG_STOP_Pos) /*!< 0x00000002 */
+#define DBGMCU_CR_DBG_STOP                           DBGMCU_CR_DBG_STOP_Msk    
+#define DBGMCU_CR_DBG_STANDBY_Pos                    (2U)                      
+#define DBGMCU_CR_DBG_STANDBY_Msk                    (0x1UL << DBGMCU_CR_DBG_STANDBY_Pos) /*!< 0x00000004 */
+#define DBGMCU_CR_DBG_STANDBY                        DBGMCU_CR_DBG_STANDBY_Msk 
+#define DBGMCU_CR_TRACE_IOEN_Pos                     (5U)                      
+#define DBGMCU_CR_TRACE_IOEN_Msk                     (0x1UL << DBGMCU_CR_TRACE_IOEN_Pos) /*!< 0x00000020 */
+#define DBGMCU_CR_TRACE_IOEN                         DBGMCU_CR_TRACE_IOEN_Msk  
+
+#define DBGMCU_CR_TRACE_MODE_Pos                     (6U)                      
+#define DBGMCU_CR_TRACE_MODE_Msk                     (0x3UL << DBGMCU_CR_TRACE_MODE_Pos) /*!< 0x000000C0 */
+#define DBGMCU_CR_TRACE_MODE                         DBGMCU_CR_TRACE_MODE_Msk  
+#define DBGMCU_CR_TRACE_MODE_0                       (0x1UL << DBGMCU_CR_TRACE_MODE_Pos) /*!< 0x00000040 */
+#define DBGMCU_CR_TRACE_MODE_1                       (0x2UL << DBGMCU_CR_TRACE_MODE_Pos) /*!< 0x00000080 */
+
+/********************  Bit definition for DBGMCU_APB1_FZ register  ************/
+#define DBGMCU_APB1_FZ_DBG_TIM2_STOP_Pos             (0U)                      
+#define DBGMCU_APB1_FZ_DBG_TIM2_STOP_Msk             (0x1UL << DBGMCU_APB1_FZ_DBG_TIM2_STOP_Pos) /*!< 0x00000001 */
+#define DBGMCU_APB1_FZ_DBG_TIM2_STOP                 DBGMCU_APB1_FZ_DBG_TIM2_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_TIM3_STOP_Pos             (1U)                      
+#define DBGMCU_APB1_FZ_DBG_TIM3_STOP_Msk             (0x1UL << DBGMCU_APB1_FZ_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
+#define DBGMCU_APB1_FZ_DBG_TIM3_STOP                 DBGMCU_APB1_FZ_DBG_TIM3_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_TIM4_STOP_Pos             (2U)                      
+#define DBGMCU_APB1_FZ_DBG_TIM4_STOP_Msk             (0x1UL << DBGMCU_APB1_FZ_DBG_TIM4_STOP_Pos) /*!< 0x00000004 */
+#define DBGMCU_APB1_FZ_DBG_TIM4_STOP                 DBGMCU_APB1_FZ_DBG_TIM4_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_TIM5_STOP_Pos             (3U)                      
+#define DBGMCU_APB1_FZ_DBG_TIM5_STOP_Msk             (0x1UL << DBGMCU_APB1_FZ_DBG_TIM5_STOP_Pos) /*!< 0x00000008 */
+#define DBGMCU_APB1_FZ_DBG_TIM5_STOP                 DBGMCU_APB1_FZ_DBG_TIM5_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_RTC_STOP_Pos              (10U)                     
+#define DBGMCU_APB1_FZ_DBG_RTC_STOP_Msk              (0x1UL << DBGMCU_APB1_FZ_DBG_RTC_STOP_Pos) /*!< 0x00000400 */
+#define DBGMCU_APB1_FZ_DBG_RTC_STOP                  DBGMCU_APB1_FZ_DBG_RTC_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_WWDG_STOP_Pos             (11U)                     
+#define DBGMCU_APB1_FZ_DBG_WWDG_STOP_Msk             (0x1UL << DBGMCU_APB1_FZ_DBG_WWDG_STOP_Pos) /*!< 0x00000800 */
+#define DBGMCU_APB1_FZ_DBG_WWDG_STOP                 DBGMCU_APB1_FZ_DBG_WWDG_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_IWDG_STOP_Pos             (12U)                     
+#define DBGMCU_APB1_FZ_DBG_IWDG_STOP_Msk             (0x1UL << DBGMCU_APB1_FZ_DBG_IWDG_STOP_Pos) /*!< 0x00001000 */
+#define DBGMCU_APB1_FZ_DBG_IWDG_STOP                 DBGMCU_APB1_FZ_DBG_IWDG_STOP_Msk 
+#define DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT_Pos    (21U)                     
+#define DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT_Msk    (0x1UL << DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT_Pos) /*!< 0x00200000 */
+#define DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT        DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT_Msk 
+#define DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT_Pos    (22U)                     
+#define DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT_Msk    (0x1UL << DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT_Pos) /*!< 0x00400000 */
+#define DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT        DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT_Msk 
+#define DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT_Pos    (23U)                     
+#define DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT_Msk    (0x1UL << DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT_Pos) /*!< 0x00800000 */
+#define DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT        DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT_Msk 
+/* Old IWDGSTOP bit definition, maintained for legacy purpose */
+#define  DBGMCU_APB1_FZ_DBG_IWDEG_STOP           DBGMCU_APB1_FZ_DBG_IWDG_STOP
+
+/********************  Bit definition for DBGMCU_APB2_FZ register  ************/
+#define DBGMCU_APB2_FZ_DBG_TIM1_STOP_Pos             (0U)                      
+#define DBGMCU_APB2_FZ_DBG_TIM1_STOP_Msk             (0x1UL << DBGMCU_APB2_FZ_DBG_TIM1_STOP_Pos) /*!< 0x00000001 */
+#define DBGMCU_APB2_FZ_DBG_TIM1_STOP                 DBGMCU_APB2_FZ_DBG_TIM1_STOP_Msk 
+#define DBGMCU_APB2_FZ_DBG_TIM9_STOP_Pos             (16U)                     
+#define DBGMCU_APB2_FZ_DBG_TIM9_STOP_Msk             (0x1UL << DBGMCU_APB2_FZ_DBG_TIM9_STOP_Pos) /*!< 0x00010000 */
+#define DBGMCU_APB2_FZ_DBG_TIM9_STOP                 DBGMCU_APB2_FZ_DBG_TIM9_STOP_Msk 
+#define DBGMCU_APB2_FZ_DBG_TIM10_STOP_Pos            (17U)                     
+#define DBGMCU_APB2_FZ_DBG_TIM10_STOP_Msk            (0x1UL << DBGMCU_APB2_FZ_DBG_TIM10_STOP_Pos) /*!< 0x00020000 */
+#define DBGMCU_APB2_FZ_DBG_TIM10_STOP                DBGMCU_APB2_FZ_DBG_TIM10_STOP_Msk 
+#define DBGMCU_APB2_FZ_DBG_TIM11_STOP_Pos            (18U)                     
+#define DBGMCU_APB2_FZ_DBG_TIM11_STOP_Msk            (0x1UL << DBGMCU_APB2_FZ_DBG_TIM11_STOP_Pos) /*!< 0x00040000 */
+#define DBGMCU_APB2_FZ_DBG_TIM11_STOP                DBGMCU_APB2_FZ_DBG_TIM11_STOP_Msk 
+
+/******************************************************************************/
+/*                                                                            */
+/*                                       USB_OTG                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for USB_OTG_GOTGCTL register  ***********/
+#define USB_OTG_GOTGCTL_SRQSCS_Pos               (0U)                          
+#define USB_OTG_GOTGCTL_SRQSCS_Msk               (0x1UL << USB_OTG_GOTGCTL_SRQSCS_Pos) /*!< 0x00000001 */
+#define USB_OTG_GOTGCTL_SRQSCS                   USB_OTG_GOTGCTL_SRQSCS_Msk    /*!< Session request success */
+#define USB_OTG_GOTGCTL_SRQ_Pos                  (1U)                          
+#define USB_OTG_GOTGCTL_SRQ_Msk                  (0x1UL << USB_OTG_GOTGCTL_SRQ_Pos) /*!< 0x00000002 */
+#define USB_OTG_GOTGCTL_SRQ                      USB_OTG_GOTGCTL_SRQ_Msk       /*!< Session request */
+#define USB_OTG_GOTGCTL_HNGSCS_Pos               (8U)                          
+#define USB_OTG_GOTGCTL_HNGSCS_Msk               (0x1UL << USB_OTG_GOTGCTL_HNGSCS_Pos) /*!< 0x00000100 */
+#define USB_OTG_GOTGCTL_HNGSCS                   USB_OTG_GOTGCTL_HNGSCS_Msk    /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_HNPRQ_Pos                (9U)                          
+#define USB_OTG_GOTGCTL_HNPRQ_Msk                (0x1UL << USB_OTG_GOTGCTL_HNPRQ_Pos) /*!< 0x00000200 */
+#define USB_OTG_GOTGCTL_HNPRQ                    USB_OTG_GOTGCTL_HNPRQ_Msk     /*!< HNP request */
+#define USB_OTG_GOTGCTL_HSHNPEN_Pos              (10U)                         
+#define USB_OTG_GOTGCTL_HSHNPEN_Msk              (0x1UL << USB_OTG_GOTGCTL_HSHNPEN_Pos) /*!< 0x00000400 */
+#define USB_OTG_GOTGCTL_HSHNPEN                  USB_OTG_GOTGCTL_HSHNPEN_Msk   /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_DHNPEN_Pos               (11U)                         
+#define USB_OTG_GOTGCTL_DHNPEN_Msk               (0x1UL << USB_OTG_GOTGCTL_DHNPEN_Pos) /*!< 0x00000800 */
+#define USB_OTG_GOTGCTL_DHNPEN                   USB_OTG_GOTGCTL_DHNPEN_Msk    /*!< Device HNP enabled */
+#define USB_OTG_GOTGCTL_CIDSTS_Pos               (16U)                         
+#define USB_OTG_GOTGCTL_CIDSTS_Msk               (0x1UL << USB_OTG_GOTGCTL_CIDSTS_Pos) /*!< 0x00010000 */
+#define USB_OTG_GOTGCTL_CIDSTS                   USB_OTG_GOTGCTL_CIDSTS_Msk    /*!< Connector ID status */
+#define USB_OTG_GOTGCTL_DBCT_Pos                 (17U)                         
+#define USB_OTG_GOTGCTL_DBCT_Msk                 (0x1UL << USB_OTG_GOTGCTL_DBCT_Pos) /*!< 0x00020000 */
+#define USB_OTG_GOTGCTL_DBCT                     USB_OTG_GOTGCTL_DBCT_Msk      /*!< Long/short debounce time */
+#define USB_OTG_GOTGCTL_ASVLD_Pos                (18U)                         
+#define USB_OTG_GOTGCTL_ASVLD_Msk                (0x1UL << USB_OTG_GOTGCTL_ASVLD_Pos) /*!< 0x00040000 */
+#define USB_OTG_GOTGCTL_ASVLD                    USB_OTG_GOTGCTL_ASVLD_Msk     /*!< A-session valid  */
+#define USB_OTG_GOTGCTL_BSVLD_Pos                (19U)                         
+#define USB_OTG_GOTGCTL_BSVLD_Msk                (0x1UL << USB_OTG_GOTGCTL_BSVLD_Pos) /*!< 0x00080000 */
+#define USB_OTG_GOTGCTL_BSVLD                    USB_OTG_GOTGCTL_BSVLD_Msk     /*!< B-session valid */
+
+/********************  Bit definition forUSB_OTG_HCFG register  ********************/
+
+#define USB_OTG_HCFG_FSLSPCS_Pos                 (0U)                          
+#define USB_OTG_HCFG_FSLSPCS_Msk                 (0x3UL << USB_OTG_HCFG_FSLSPCS_Pos) /*!< 0x00000003 */
+#define USB_OTG_HCFG_FSLSPCS                     USB_OTG_HCFG_FSLSPCS_Msk      /*!< FS/LS PHY clock select  */
+#define USB_OTG_HCFG_FSLSPCS_0                   (0x1UL << USB_OTG_HCFG_FSLSPCS_Pos) /*!< 0x00000001 */
+#define USB_OTG_HCFG_FSLSPCS_1                   (0x2UL << USB_OTG_HCFG_FSLSPCS_Pos) /*!< 0x00000002 */
+#define USB_OTG_HCFG_FSLSS_Pos                   (2U)                          
+#define USB_OTG_HCFG_FSLSS_Msk                   (0x1UL << USB_OTG_HCFG_FSLSS_Pos) /*!< 0x00000004 */
+#define USB_OTG_HCFG_FSLSS                       USB_OTG_HCFG_FSLSS_Msk        /*!< FS- and LS-only support */
+
+/********************  Bit definition for USB_OTG_DCFG register  ********************/
+
+#define USB_OTG_DCFG_DSPD_Pos                    (0U)                          
+#define USB_OTG_DCFG_DSPD_Msk                    (0x3UL << USB_OTG_DCFG_DSPD_Pos) /*!< 0x00000003 */
+#define USB_OTG_DCFG_DSPD                        USB_OTG_DCFG_DSPD_Msk         /*!< Device speed */
+#define USB_OTG_DCFG_DSPD_0                      (0x1UL << USB_OTG_DCFG_DSPD_Pos) /*!< 0x00000001 */
+#define USB_OTG_DCFG_DSPD_1                      (0x2UL << USB_OTG_DCFG_DSPD_Pos) /*!< 0x00000002 */
+#define USB_OTG_DCFG_NZLSOHSK_Pos                (2U)                          
+#define USB_OTG_DCFG_NZLSOHSK_Msk                (0x1UL << USB_OTG_DCFG_NZLSOHSK_Pos) /*!< 0x00000004 */
+#define USB_OTG_DCFG_NZLSOHSK                    USB_OTG_DCFG_NZLSOHSK_Msk     /*!< Nonzero-length status OUT handshake */
+
+#define USB_OTG_DCFG_DAD_Pos                     (4U)                          
+#define USB_OTG_DCFG_DAD_Msk                     (0x7FUL << USB_OTG_DCFG_DAD_Pos) /*!< 0x000007F0 */
+#define USB_OTG_DCFG_DAD                         USB_OTG_DCFG_DAD_Msk          /*!< Device address */
+#define USB_OTG_DCFG_DAD_0                       (0x01UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000010 */
+#define USB_OTG_DCFG_DAD_1                       (0x02UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000020 */
+#define USB_OTG_DCFG_DAD_2                       (0x04UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000040 */
+#define USB_OTG_DCFG_DAD_3                       (0x08UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000080 */
+#define USB_OTG_DCFG_DAD_4                       (0x10UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000100 */
+#define USB_OTG_DCFG_DAD_5                       (0x20UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000200 */
+#define USB_OTG_DCFG_DAD_6                       (0x40UL << USB_OTG_DCFG_DAD_Pos) /*!< 0x00000400 */
+
+#define USB_OTG_DCFG_PFIVL_Pos                   (11U)                         
+#define USB_OTG_DCFG_PFIVL_Msk                   (0x3UL << USB_OTG_DCFG_PFIVL_Pos) /*!< 0x00001800 */
+#define USB_OTG_DCFG_PFIVL                       USB_OTG_DCFG_PFIVL_Msk        /*!< Periodic (micro)frame interval */
+#define USB_OTG_DCFG_PFIVL_0                     (0x1UL << USB_OTG_DCFG_PFIVL_Pos) /*!< 0x00000800 */
+#define USB_OTG_DCFG_PFIVL_1                     (0x2UL << USB_OTG_DCFG_PFIVL_Pos) /*!< 0x00001000 */
+
+#define USB_OTG_DCFG_XCVRDLY_Pos                 (14U)                         
+#define USB_OTG_DCFG_XCVRDLY_Msk                 (0x1UL << USB_OTG_DCFG_XCVRDLY_Pos) /*!< 0x00004000 */
+#define USB_OTG_DCFG_XCVRDLY                     USB_OTG_DCFG_XCVRDLY_Msk        /*!< Transceiver delay */
+
+#define USB_OTG_DCFG_ERRATIM_Pos                 (15U)                         
+#define USB_OTG_DCFG_ERRATIM_Msk                 (0x1UL << USB_OTG_DCFG_ERRATIM_Pos) /*!< 0x00008000 */
+#define USB_OTG_DCFG_ERRATIM                     USB_OTG_DCFG_ERRATIM_Msk        /*!< Erratic error interrupt mask */
+
+#define USB_OTG_DCFG_PERSCHIVL_Pos               (24U)                         
+#define USB_OTG_DCFG_PERSCHIVL_Msk               (0x3UL << USB_OTG_DCFG_PERSCHIVL_Pos) /*!< 0x03000000 */
+#define USB_OTG_DCFG_PERSCHIVL                   USB_OTG_DCFG_PERSCHIVL_Msk    /*!< Periodic scheduling interval */
+#define USB_OTG_DCFG_PERSCHIVL_0                 (0x1UL << USB_OTG_DCFG_PERSCHIVL_Pos) /*!< 0x01000000 */
+#define USB_OTG_DCFG_PERSCHIVL_1                 (0x2UL << USB_OTG_DCFG_PERSCHIVL_Pos) /*!< 0x02000000 */
+
+/********************  Bit definition for USB_OTG_PCGCR register  ********************/
+#define USB_OTG_PCGCR_STPPCLK_Pos                (0U)                          
+#define USB_OTG_PCGCR_STPPCLK_Msk                (0x1UL << USB_OTG_PCGCR_STPPCLK_Pos) /*!< 0x00000001 */
+#define USB_OTG_PCGCR_STPPCLK                    USB_OTG_PCGCR_STPPCLK_Msk     /*!< Stop PHY clock */
+#define USB_OTG_PCGCR_GATEHCLK_Pos               (1U)                          
+#define USB_OTG_PCGCR_GATEHCLK_Msk               (0x1UL << USB_OTG_PCGCR_GATEHCLK_Pos) /*!< 0x00000002 */
+#define USB_OTG_PCGCR_GATEHCLK                   USB_OTG_PCGCR_GATEHCLK_Msk    /*!< Gate HCLK */
+#define USB_OTG_PCGCR_PHYSUSP_Pos                (4U)                          
+#define USB_OTG_PCGCR_PHYSUSP_Msk                (0x1UL << USB_OTG_PCGCR_PHYSUSP_Pos) /*!< 0x00000010 */
+#define USB_OTG_PCGCR_PHYSUSP                    USB_OTG_PCGCR_PHYSUSP_Msk     /*!< PHY suspended */
+
+/********************  Bit definition for USB_OTG_GOTGINT register  ********************/
+#define USB_OTG_GOTGINT_SEDET_Pos                (2U)                          
+#define USB_OTG_GOTGINT_SEDET_Msk                (0x1UL << USB_OTG_GOTGINT_SEDET_Pos) /*!< 0x00000004 */
+#define USB_OTG_GOTGINT_SEDET                    USB_OTG_GOTGINT_SEDET_Msk     /*!< Session end detected                   */
+#define USB_OTG_GOTGINT_SRSSCHG_Pos              (8U)                          
+#define USB_OTG_GOTGINT_SRSSCHG_Msk              (0x1UL << USB_OTG_GOTGINT_SRSSCHG_Pos) /*!< 0x00000100 */
+#define USB_OTG_GOTGINT_SRSSCHG                  USB_OTG_GOTGINT_SRSSCHG_Msk   /*!< Session request success status change  */
+#define USB_OTG_GOTGINT_HNSSCHG_Pos              (9U)                          
+#define USB_OTG_GOTGINT_HNSSCHG_Msk              (0x1UL << USB_OTG_GOTGINT_HNSSCHG_Pos) /*!< 0x00000200 */
+#define USB_OTG_GOTGINT_HNSSCHG                  USB_OTG_GOTGINT_HNSSCHG_Msk   /*!< Host negotiation success status change */
+#define USB_OTG_GOTGINT_HNGDET_Pos               (17U)                         
+#define USB_OTG_GOTGINT_HNGDET_Msk               (0x1UL << USB_OTG_GOTGINT_HNGDET_Pos) /*!< 0x00020000 */
+#define USB_OTG_GOTGINT_HNGDET                   USB_OTG_GOTGINT_HNGDET_Msk    /*!< Host negotiation detected              */
+#define USB_OTG_GOTGINT_ADTOCHG_Pos              (18U)                         
+#define USB_OTG_GOTGINT_ADTOCHG_Msk              (0x1UL << USB_OTG_GOTGINT_ADTOCHG_Pos) /*!< 0x00040000 */
+#define USB_OTG_GOTGINT_ADTOCHG                  USB_OTG_GOTGINT_ADTOCHG_Msk   /*!< A-device timeout change                */
+#define USB_OTG_GOTGINT_DBCDNE_Pos               (19U)                         
+#define USB_OTG_GOTGINT_DBCDNE_Msk               (0x1UL << USB_OTG_GOTGINT_DBCDNE_Pos) /*!< 0x00080000 */
+#define USB_OTG_GOTGINT_DBCDNE                   USB_OTG_GOTGINT_DBCDNE_Msk    /*!< Debounce done                          */
+
+/********************  Bit definition for USB_OTG_DCTL register  ********************/
+#define USB_OTG_DCTL_RWUSIG_Pos                  (0U)                          
+#define USB_OTG_DCTL_RWUSIG_Msk                  (0x1UL << USB_OTG_DCTL_RWUSIG_Pos) /*!< 0x00000001 */
+#define USB_OTG_DCTL_RWUSIG                      USB_OTG_DCTL_RWUSIG_Msk       /*!< Remote wakeup signaling */
+#define USB_OTG_DCTL_SDIS_Pos                    (1U)                          
+#define USB_OTG_DCTL_SDIS_Msk                    (0x1UL << USB_OTG_DCTL_SDIS_Pos) /*!< 0x00000002 */
+#define USB_OTG_DCTL_SDIS                        USB_OTG_DCTL_SDIS_Msk         /*!< Soft disconnect         */
+#define USB_OTG_DCTL_GINSTS_Pos                  (2U)                          
+#define USB_OTG_DCTL_GINSTS_Msk                  (0x1UL << USB_OTG_DCTL_GINSTS_Pos) /*!< 0x00000004 */
+#define USB_OTG_DCTL_GINSTS                      USB_OTG_DCTL_GINSTS_Msk       /*!< Global IN NAK status    */
+#define USB_OTG_DCTL_GONSTS_Pos                  (3U)                          
+#define USB_OTG_DCTL_GONSTS_Msk                  (0x1UL << USB_OTG_DCTL_GONSTS_Pos) /*!< 0x00000008 */
+#define USB_OTG_DCTL_GONSTS                      USB_OTG_DCTL_GONSTS_Msk       /*!< Global OUT NAK status   */
+
+#define USB_OTG_DCTL_TCTL_Pos                    (4U)                          
+#define USB_OTG_DCTL_TCTL_Msk                    (0x7UL << USB_OTG_DCTL_TCTL_Pos) /*!< 0x00000070 */
+#define USB_OTG_DCTL_TCTL                        USB_OTG_DCTL_TCTL_Msk         /*!< Test control */
+#define USB_OTG_DCTL_TCTL_0                      (0x1UL << USB_OTG_DCTL_TCTL_Pos) /*!< 0x00000010 */
+#define USB_OTG_DCTL_TCTL_1                      (0x2UL << USB_OTG_DCTL_TCTL_Pos) /*!< 0x00000020 */
+#define USB_OTG_DCTL_TCTL_2                      (0x4UL << USB_OTG_DCTL_TCTL_Pos) /*!< 0x00000040 */
+#define USB_OTG_DCTL_SGINAK_Pos                  (7U)                          
+#define USB_OTG_DCTL_SGINAK_Msk                  (0x1UL << USB_OTG_DCTL_SGINAK_Pos) /*!< 0x00000080 */
+#define USB_OTG_DCTL_SGINAK                      USB_OTG_DCTL_SGINAK_Msk       /*!< Set global IN NAK         */
+#define USB_OTG_DCTL_CGINAK_Pos                  (8U)                          
+#define USB_OTG_DCTL_CGINAK_Msk                  (0x1UL << USB_OTG_DCTL_CGINAK_Pos) /*!< 0x00000100 */
+#define USB_OTG_DCTL_CGINAK                      USB_OTG_DCTL_CGINAK_Msk       /*!< Clear global IN NAK       */
+#define USB_OTG_DCTL_SGONAK_Pos                  (9U)                          
+#define USB_OTG_DCTL_SGONAK_Msk                  (0x1UL << USB_OTG_DCTL_SGONAK_Pos) /*!< 0x00000200 */
+#define USB_OTG_DCTL_SGONAK                      USB_OTG_DCTL_SGONAK_Msk       /*!< Set global OUT NAK        */
+#define USB_OTG_DCTL_CGONAK_Pos                  (10U)                         
+#define USB_OTG_DCTL_CGONAK_Msk                  (0x1UL << USB_OTG_DCTL_CGONAK_Pos) /*!< 0x00000400 */
+#define USB_OTG_DCTL_CGONAK                      USB_OTG_DCTL_CGONAK_Msk       /*!< Clear global OUT NAK      */
+#define USB_OTG_DCTL_POPRGDNE_Pos                (11U)                         
+#define USB_OTG_DCTL_POPRGDNE_Msk                (0x1UL << USB_OTG_DCTL_POPRGDNE_Pos) /*!< 0x00000800 */
+#define USB_OTG_DCTL_POPRGDNE                    USB_OTG_DCTL_POPRGDNE_Msk     /*!< Power-on programming done */
+
+/********************  Bit definition for USB_OTG_HFIR register  ********************/
+#define USB_OTG_HFIR_FRIVL_Pos                   (0U)                          
+#define USB_OTG_HFIR_FRIVL_Msk                   (0xFFFFUL << USB_OTG_HFIR_FRIVL_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_HFIR_FRIVL                       USB_OTG_HFIR_FRIVL_Msk        /*!< Frame interval */
+
+/********************  Bit definition for USB_OTG_HFNUM register  ********************/
+#define USB_OTG_HFNUM_FRNUM_Pos                  (0U)                          
+#define USB_OTG_HFNUM_FRNUM_Msk                  (0xFFFFUL << USB_OTG_HFNUM_FRNUM_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_HFNUM_FRNUM                      USB_OTG_HFNUM_FRNUM_Msk       /*!< Frame number         */
+#define USB_OTG_HFNUM_FTREM_Pos                  (16U)                         
+#define USB_OTG_HFNUM_FTREM_Msk                  (0xFFFFUL << USB_OTG_HFNUM_FTREM_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_HFNUM_FTREM                      USB_OTG_HFNUM_FTREM_Msk       /*!< Frame time remaining */
+
+/********************  Bit definition for USB_OTG_DSTS register  ********************/
+#define USB_OTG_DSTS_SUSPSTS_Pos                 (0U)                          
+#define USB_OTG_DSTS_SUSPSTS_Msk                 (0x1UL << USB_OTG_DSTS_SUSPSTS_Pos) /*!< 0x00000001 */
+#define USB_OTG_DSTS_SUSPSTS                     USB_OTG_DSTS_SUSPSTS_Msk      /*!< Suspend status   */
+
+#define USB_OTG_DSTS_ENUMSPD_Pos                 (1U)                          
+#define USB_OTG_DSTS_ENUMSPD_Msk                 (0x3UL << USB_OTG_DSTS_ENUMSPD_Pos) /*!< 0x00000006 */
+#define USB_OTG_DSTS_ENUMSPD                     USB_OTG_DSTS_ENUMSPD_Msk      /*!< Enumerated speed */
+#define USB_OTG_DSTS_ENUMSPD_0                   (0x1UL << USB_OTG_DSTS_ENUMSPD_Pos) /*!< 0x00000002 */
+#define USB_OTG_DSTS_ENUMSPD_1                   (0x2UL << USB_OTG_DSTS_ENUMSPD_Pos) /*!< 0x00000004 */
+#define USB_OTG_DSTS_EERR_Pos                    (3U)                          
+#define USB_OTG_DSTS_EERR_Msk                    (0x1UL << USB_OTG_DSTS_EERR_Pos) /*!< 0x00000008 */
+#define USB_OTG_DSTS_EERR                        USB_OTG_DSTS_EERR_Msk         /*!< Erratic error     */
+#define USB_OTG_DSTS_FNSOF_Pos                   (8U)                          
+#define USB_OTG_DSTS_FNSOF_Msk                   (0x3FFFUL << USB_OTG_DSTS_FNSOF_Pos) /*!< 0x003FFF00 */
+#define USB_OTG_DSTS_FNSOF                       USB_OTG_DSTS_FNSOF_Msk        /*!< Frame number of the received SOF */
+
+/********************  Bit definition for USB_OTG_GAHBCFG register  ********************/
+#define USB_OTG_GAHBCFG_GINT_Pos                 (0U)                          
+#define USB_OTG_GAHBCFG_GINT_Msk                 (0x1UL << USB_OTG_GAHBCFG_GINT_Pos) /*!< 0x00000001 */
+#define USB_OTG_GAHBCFG_GINT                     USB_OTG_GAHBCFG_GINT_Msk      /*!< Global interrupt mask */
+#define USB_OTG_GAHBCFG_HBSTLEN_Pos              (1U)                          
+#define USB_OTG_GAHBCFG_HBSTLEN_Msk              (0xFUL << USB_OTG_GAHBCFG_HBSTLEN_Pos) /*!< 0x0000001E */
+#define USB_OTG_GAHBCFG_HBSTLEN                  USB_OTG_GAHBCFG_HBSTLEN_Msk   /*!< Burst length/type */
+#define USB_OTG_GAHBCFG_HBSTLEN_0                (0x0UL << USB_OTG_GAHBCFG_HBSTLEN_Pos) /*!< Single */
+#define USB_OTG_GAHBCFG_HBSTLEN_1                (0x1UL << USB_OTG_GAHBCFG_HBSTLEN_Pos) /*!< INCR */
+#define USB_OTG_GAHBCFG_HBSTLEN_2                (0x3UL << USB_OTG_GAHBCFG_HBSTLEN_Pos) /*!< INCR4 */
+#define USB_OTG_GAHBCFG_HBSTLEN_3                (0x5UL << USB_OTG_GAHBCFG_HBSTLEN_Pos) /*!< INCR8 */
+#define USB_OTG_GAHBCFG_HBSTLEN_4                (0x7UL << USB_OTG_GAHBCFG_HBSTLEN_Pos) /*!< INCR16 */
+#define USB_OTG_GAHBCFG_DMAEN_Pos                (5U)                          
+#define USB_OTG_GAHBCFG_DMAEN_Msk                (0x1UL << USB_OTG_GAHBCFG_DMAEN_Pos) /*!< 0x00000020 */
+#define USB_OTG_GAHBCFG_DMAEN                    USB_OTG_GAHBCFG_DMAEN_Msk     /*!< DMA enable */
+#define USB_OTG_GAHBCFG_TXFELVL_Pos              (7U)                          
+#define USB_OTG_GAHBCFG_TXFELVL_Msk              (0x1UL << USB_OTG_GAHBCFG_TXFELVL_Pos) /*!< 0x00000080 */
+#define USB_OTG_GAHBCFG_TXFELVL                  USB_OTG_GAHBCFG_TXFELVL_Msk   /*!< TxFIFO empty level */
+#define USB_OTG_GAHBCFG_PTXFELVL_Pos             (8U)                          
+#define USB_OTG_GAHBCFG_PTXFELVL_Msk             (0x1UL << USB_OTG_GAHBCFG_PTXFELVL_Pos) /*!< 0x00000100 */
+#define USB_OTG_GAHBCFG_PTXFELVL                 USB_OTG_GAHBCFG_PTXFELVL_Msk  /*!< Periodic TxFIFO empty level */
+
+/********************  Bit definition for USB_OTG_GUSBCFG register  ********************/
+
+#define USB_OTG_GUSBCFG_TOCAL_Pos                (0U)                          
+#define USB_OTG_GUSBCFG_TOCAL_Msk                (0x7UL << USB_OTG_GUSBCFG_TOCAL_Pos) /*!< 0x00000007 */
+#define USB_OTG_GUSBCFG_TOCAL                    USB_OTG_GUSBCFG_TOCAL_Msk     /*!< FS timeout calibration */
+#define USB_OTG_GUSBCFG_TOCAL_0                  (0x1UL << USB_OTG_GUSBCFG_TOCAL_Pos) /*!< 0x00000001 */
+#define USB_OTG_GUSBCFG_TOCAL_1                  (0x2UL << USB_OTG_GUSBCFG_TOCAL_Pos) /*!< 0x00000002 */
+#define USB_OTG_GUSBCFG_TOCAL_2                  (0x4UL << USB_OTG_GUSBCFG_TOCAL_Pos) /*!< 0x00000004 */
+#define USB_OTG_GUSBCFG_PHYSEL_Pos               (6U)                          
+#define USB_OTG_GUSBCFG_PHYSEL_Msk               (0x1UL << USB_OTG_GUSBCFG_PHYSEL_Pos) /*!< 0x00000040 */
+#define USB_OTG_GUSBCFG_PHYSEL                   USB_OTG_GUSBCFG_PHYSEL_Msk    /*!< USB 2.0 high-speed ULPI PHY or USB 1.1 full-speed serial transceiver select */
+#define USB_OTG_GUSBCFG_SRPCAP_Pos               (8U)                          
+#define USB_OTG_GUSBCFG_SRPCAP_Msk               (0x1UL << USB_OTG_GUSBCFG_SRPCAP_Pos) /*!< 0x00000100 */
+#define USB_OTG_GUSBCFG_SRPCAP                   USB_OTG_GUSBCFG_SRPCAP_Msk    /*!< SRP-capable */
+#define USB_OTG_GUSBCFG_HNPCAP_Pos               (9U)                          
+#define USB_OTG_GUSBCFG_HNPCAP_Msk               (0x1UL << USB_OTG_GUSBCFG_HNPCAP_Pos) /*!< 0x00000200 */
+#define USB_OTG_GUSBCFG_HNPCAP                   USB_OTG_GUSBCFG_HNPCAP_Msk    /*!< HNP-capable */
+#define USB_OTG_GUSBCFG_TRDT_Pos                 (10U)                         
+#define USB_OTG_GUSBCFG_TRDT_Msk                 (0xFUL << USB_OTG_GUSBCFG_TRDT_Pos) /*!< 0x00003C00 */
+#define USB_OTG_GUSBCFG_TRDT                     USB_OTG_GUSBCFG_TRDT_Msk      /*!< USB turnaround time */
+#define USB_OTG_GUSBCFG_TRDT_0                   (0x1UL << USB_OTG_GUSBCFG_TRDT_Pos) /*!< 0x00000400 */
+#define USB_OTG_GUSBCFG_TRDT_1                   (0x2UL << USB_OTG_GUSBCFG_TRDT_Pos) /*!< 0x00000800 */
+#define USB_OTG_GUSBCFG_TRDT_2                   (0x4UL << USB_OTG_GUSBCFG_TRDT_Pos) /*!< 0x00001000 */
+#define USB_OTG_GUSBCFG_TRDT_3                   (0x8UL << USB_OTG_GUSBCFG_TRDT_Pos) /*!< 0x00002000 */
+#define USB_OTG_GUSBCFG_PHYLPCS_Pos              (15U)                         
+#define USB_OTG_GUSBCFG_PHYLPCS_Msk              (0x1UL << USB_OTG_GUSBCFG_PHYLPCS_Pos) /*!< 0x00008000 */
+#define USB_OTG_GUSBCFG_PHYLPCS                  USB_OTG_GUSBCFG_PHYLPCS_Msk   /*!< PHY Low-power clock select */
+#define USB_OTG_GUSBCFG_ULPIFSLS_Pos             (17U)                         
+#define USB_OTG_GUSBCFG_ULPIFSLS_Msk             (0x1UL << USB_OTG_GUSBCFG_ULPIFSLS_Pos) /*!< 0x00020000 */
+#define USB_OTG_GUSBCFG_ULPIFSLS                 USB_OTG_GUSBCFG_ULPIFSLS_Msk  /*!< ULPI FS/LS select               */
+#define USB_OTG_GUSBCFG_ULPIAR_Pos               (18U)                         
+#define USB_OTG_GUSBCFG_ULPIAR_Msk               (0x1UL << USB_OTG_GUSBCFG_ULPIAR_Pos) /*!< 0x00040000 */
+#define USB_OTG_GUSBCFG_ULPIAR                   USB_OTG_GUSBCFG_ULPIAR_Msk    /*!< ULPI Auto-resume                */
+#define USB_OTG_GUSBCFG_ULPICSM_Pos              (19U)                         
+#define USB_OTG_GUSBCFG_ULPICSM_Msk              (0x1UL << USB_OTG_GUSBCFG_ULPICSM_Pos) /*!< 0x00080000 */
+#define USB_OTG_GUSBCFG_ULPICSM                  USB_OTG_GUSBCFG_ULPICSM_Msk   /*!< ULPI Clock SuspendM             */
+#define USB_OTG_GUSBCFG_ULPIEVBUSD_Pos           (20U)                         
+#define USB_OTG_GUSBCFG_ULPIEVBUSD_Msk           (0x1UL << USB_OTG_GUSBCFG_ULPIEVBUSD_Pos) /*!< 0x00100000 */
+#define USB_OTG_GUSBCFG_ULPIEVBUSD               USB_OTG_GUSBCFG_ULPIEVBUSD_Msk /*!< ULPI External VBUS Drive        */
+#define USB_OTG_GUSBCFG_ULPIEVBUSI_Pos           (21U)                         
+#define USB_OTG_GUSBCFG_ULPIEVBUSI_Msk           (0x1UL << USB_OTG_GUSBCFG_ULPIEVBUSI_Pos) /*!< 0x00200000 */
+#define USB_OTG_GUSBCFG_ULPIEVBUSI               USB_OTG_GUSBCFG_ULPIEVBUSI_Msk /*!< ULPI external VBUS indicator    */
+#define USB_OTG_GUSBCFG_TSDPS_Pos                (22U)                         
+#define USB_OTG_GUSBCFG_TSDPS_Msk                (0x1UL << USB_OTG_GUSBCFG_TSDPS_Pos) /*!< 0x00400000 */
+#define USB_OTG_GUSBCFG_TSDPS                    USB_OTG_GUSBCFG_TSDPS_Msk     /*!< TermSel DLine pulsing selection */
+#define USB_OTG_GUSBCFG_PCCI_Pos                 (23U)                         
+#define USB_OTG_GUSBCFG_PCCI_Msk                 (0x1UL << USB_OTG_GUSBCFG_PCCI_Pos) /*!< 0x00800000 */
+#define USB_OTG_GUSBCFG_PCCI                     USB_OTG_GUSBCFG_PCCI_Msk      /*!< Indicator complement            */
+#define USB_OTG_GUSBCFG_PTCI_Pos                 (24U)                         
+#define USB_OTG_GUSBCFG_PTCI_Msk                 (0x1UL << USB_OTG_GUSBCFG_PTCI_Pos) /*!< 0x01000000 */
+#define USB_OTG_GUSBCFG_PTCI                     USB_OTG_GUSBCFG_PTCI_Msk      /*!< Indicator pass through          */
+#define USB_OTG_GUSBCFG_ULPIIPD_Pos              (25U)                         
+#define USB_OTG_GUSBCFG_ULPIIPD_Msk              (0x1UL << USB_OTG_GUSBCFG_ULPIIPD_Pos) /*!< 0x02000000 */
+#define USB_OTG_GUSBCFG_ULPIIPD                  USB_OTG_GUSBCFG_ULPIIPD_Msk   /*!< ULPI interface protect disable  */
+#define USB_OTG_GUSBCFG_FHMOD_Pos                (29U)                         
+#define USB_OTG_GUSBCFG_FHMOD_Msk                (0x1UL << USB_OTG_GUSBCFG_FHMOD_Pos) /*!< 0x20000000 */
+#define USB_OTG_GUSBCFG_FHMOD                    USB_OTG_GUSBCFG_FHMOD_Msk     /*!< Forced host mode                */
+#define USB_OTG_GUSBCFG_FDMOD_Pos                (30U)                         
+#define USB_OTG_GUSBCFG_FDMOD_Msk                (0x1UL << USB_OTG_GUSBCFG_FDMOD_Pos) /*!< 0x40000000 */
+#define USB_OTG_GUSBCFG_FDMOD                    USB_OTG_GUSBCFG_FDMOD_Msk     /*!< Forced peripheral mode          */
+#define USB_OTG_GUSBCFG_CTXPKT_Pos               (31U)                         
+#define USB_OTG_GUSBCFG_CTXPKT_Msk               (0x1UL << USB_OTG_GUSBCFG_CTXPKT_Pos) /*!< 0x80000000 */
+#define USB_OTG_GUSBCFG_CTXPKT                   USB_OTG_GUSBCFG_CTXPKT_Msk    /*!< Corrupt Tx packet               */
+
+/********************  Bit definition for USB_OTG_GRSTCTL register  ********************/
+#define USB_OTG_GRSTCTL_CSRST_Pos                (0U)                          
+#define USB_OTG_GRSTCTL_CSRST_Msk                (0x1UL << USB_OTG_GRSTCTL_CSRST_Pos) /*!< 0x00000001 */
+#define USB_OTG_GRSTCTL_CSRST                    USB_OTG_GRSTCTL_CSRST_Msk     /*!< Core soft reset          */
+#define USB_OTG_GRSTCTL_HSRST_Pos                (1U)                          
+#define USB_OTG_GRSTCTL_HSRST_Msk                (0x1UL << USB_OTG_GRSTCTL_HSRST_Pos) /*!< 0x00000002 */
+#define USB_OTG_GRSTCTL_HSRST                    USB_OTG_GRSTCTL_HSRST_Msk     /*!< HCLK soft reset          */
+#define USB_OTG_GRSTCTL_FCRST_Pos                (2U)                          
+#define USB_OTG_GRSTCTL_FCRST_Msk                (0x1UL << USB_OTG_GRSTCTL_FCRST_Pos) /*!< 0x00000004 */
+#define USB_OTG_GRSTCTL_FCRST                    USB_OTG_GRSTCTL_FCRST_Msk     /*!< Host frame counter reset */
+#define USB_OTG_GRSTCTL_RXFFLSH_Pos              (4U)                          
+#define USB_OTG_GRSTCTL_RXFFLSH_Msk              (0x1UL << USB_OTG_GRSTCTL_RXFFLSH_Pos) /*!< 0x00000010 */
+#define USB_OTG_GRSTCTL_RXFFLSH                  USB_OTG_GRSTCTL_RXFFLSH_Msk   /*!< RxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFFLSH_Pos              (5U)                          
+#define USB_OTG_GRSTCTL_TXFFLSH_Msk              (0x1UL << USB_OTG_GRSTCTL_TXFFLSH_Pos) /*!< 0x00000020 */
+#define USB_OTG_GRSTCTL_TXFFLSH                  USB_OTG_GRSTCTL_TXFFLSH_Msk   /*!< TxFIFO flush             */
+
+
+#define USB_OTG_GRSTCTL_TXFNUM_Pos               (6U)                          
+#define USB_OTG_GRSTCTL_TXFNUM_Msk               (0x1FUL << USB_OTG_GRSTCTL_TXFNUM_Pos) /*!< 0x000007C0 */
+#define USB_OTG_GRSTCTL_TXFNUM                   USB_OTG_GRSTCTL_TXFNUM_Msk    /*!< TxFIFO number */
+#define USB_OTG_GRSTCTL_TXFNUM_0                 (0x01UL << USB_OTG_GRSTCTL_TXFNUM_Pos) /*!< 0x00000040 */
+#define USB_OTG_GRSTCTL_TXFNUM_1                 (0x02UL << USB_OTG_GRSTCTL_TXFNUM_Pos) /*!< 0x00000080 */
+#define USB_OTG_GRSTCTL_TXFNUM_2                 (0x04UL << USB_OTG_GRSTCTL_TXFNUM_Pos) /*!< 0x00000100 */
+#define USB_OTG_GRSTCTL_TXFNUM_3                 (0x08UL << USB_OTG_GRSTCTL_TXFNUM_Pos) /*!< 0x00000200 */
+#define USB_OTG_GRSTCTL_TXFNUM_4                 (0x10UL << USB_OTG_GRSTCTL_TXFNUM_Pos) /*!< 0x00000400 */
+#define USB_OTG_GRSTCTL_DMAREQ_Pos               (30U)                         
+#define USB_OTG_GRSTCTL_DMAREQ_Msk               (0x1UL << USB_OTG_GRSTCTL_DMAREQ_Pos) /*!< 0x40000000 */
+#define USB_OTG_GRSTCTL_DMAREQ                   USB_OTG_GRSTCTL_DMAREQ_Msk    /*!< DMA request signal */
+#define USB_OTG_GRSTCTL_AHBIDL_Pos               (31U)                         
+#define USB_OTG_GRSTCTL_AHBIDL_Msk               (0x1UL << USB_OTG_GRSTCTL_AHBIDL_Pos) /*!< 0x80000000 */
+#define USB_OTG_GRSTCTL_AHBIDL                   USB_OTG_GRSTCTL_AHBIDL_Msk    /*!< AHB master idle */
+
+/********************  Bit definition for USB_OTG_DIEPMSK register  ********************/
+#define USB_OTG_DIEPMSK_XFRCM_Pos                (0U)                          
+#define USB_OTG_DIEPMSK_XFRCM_Msk                (0x1UL << USB_OTG_DIEPMSK_XFRCM_Pos) /*!< 0x00000001 */
+#define USB_OTG_DIEPMSK_XFRCM                    USB_OTG_DIEPMSK_XFRCM_Msk     /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPMSK_EPDM_Pos                 (1U)                          
+#define USB_OTG_DIEPMSK_EPDM_Msk                 (0x1UL << USB_OTG_DIEPMSK_EPDM_Pos) /*!< 0x00000002 */
+#define USB_OTG_DIEPMSK_EPDM                     USB_OTG_DIEPMSK_EPDM_Msk      /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPMSK_TOM_Pos                  (3U)                          
+#define USB_OTG_DIEPMSK_TOM_Msk                  (0x1UL << USB_OTG_DIEPMSK_TOM_Pos) /*!< 0x00000008 */
+#define USB_OTG_DIEPMSK_TOM                      USB_OTG_DIEPMSK_TOM_Msk       /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPMSK_ITTXFEMSK_Pos            (4U)                          
+#define USB_OTG_DIEPMSK_ITTXFEMSK_Msk            (0x1UL << USB_OTG_DIEPMSK_ITTXFEMSK_Pos) /*!< 0x00000010 */
+#define USB_OTG_DIEPMSK_ITTXFEMSK                USB_OTG_DIEPMSK_ITTXFEMSK_Msk /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPMSK_INEPNMM_Pos              (5U)                          
+#define USB_OTG_DIEPMSK_INEPNMM_Msk              (0x1UL << USB_OTG_DIEPMSK_INEPNMM_Pos) /*!< 0x00000020 */
+#define USB_OTG_DIEPMSK_INEPNMM                  USB_OTG_DIEPMSK_INEPNMM_Msk   /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPMSK_INEPNEM_Pos              (6U)                          
+#define USB_OTG_DIEPMSK_INEPNEM_Msk              (0x1UL << USB_OTG_DIEPMSK_INEPNEM_Pos) /*!< 0x00000040 */
+#define USB_OTG_DIEPMSK_INEPNEM                  USB_OTG_DIEPMSK_INEPNEM_Msk   /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPMSK_TXFURM_Pos               (8U)                          
+#define USB_OTG_DIEPMSK_TXFURM_Msk               (0x1UL << USB_OTG_DIEPMSK_TXFURM_Pos) /*!< 0x00000100 */
+#define USB_OTG_DIEPMSK_TXFURM                   USB_OTG_DIEPMSK_TXFURM_Msk    /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPMSK_BIM_Pos                  (9U)                          
+#define USB_OTG_DIEPMSK_BIM_Msk                  (0x1UL << USB_OTG_DIEPMSK_BIM_Pos) /*!< 0x00000200 */
+#define USB_OTG_DIEPMSK_BIM                      USB_OTG_DIEPMSK_BIM_Msk       /*!< BNA interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPTXSTS register  ********************/
+#define USB_OTG_HPTXSTS_PTXFSAVL_Pos             (0U)                          
+#define USB_OTG_HPTXSTS_PTXFSAVL_Msk             (0xFFFFUL << USB_OTG_HPTXSTS_PTXFSAVL_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_HPTXSTS_PTXFSAVL                 USB_OTG_HPTXSTS_PTXFSAVL_Msk  /*!< Periodic transmit data FIFO space available     */
+#define USB_OTG_HPTXSTS_PTXQSAV_Pos              (16U)                         
+#define USB_OTG_HPTXSTS_PTXQSAV_Msk              (0xFFUL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00FF0000 */
+#define USB_OTG_HPTXSTS_PTXQSAV                  USB_OTG_HPTXSTS_PTXQSAV_Msk   /*!< Periodic transmit request queue space available */
+#define USB_OTG_HPTXSTS_PTXQSAV_0                (0x01UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00010000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_1                (0x02UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00020000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_2                (0x04UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00040000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_3                (0x08UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00080000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_4                (0x10UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00100000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_5                (0x20UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00200000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_6                (0x40UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00400000 */
+#define USB_OTG_HPTXSTS_PTXQSAV_7                (0x80UL << USB_OTG_HPTXSTS_PTXQSAV_Pos) /*!< 0x00800000 */
+
+#define USB_OTG_HPTXSTS_PTXQTOP_Pos              (24U)                         
+#define USB_OTG_HPTXSTS_PTXQTOP_Msk              (0xFFUL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0xFF000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP                  USB_OTG_HPTXSTS_PTXQTOP_Msk   /*!< Top of the periodic transmit request queue */
+#define USB_OTG_HPTXSTS_PTXQTOP_0                (0x01UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x01000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_1                (0x02UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x02000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_2                (0x04UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x04000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_3                (0x08UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x08000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_4                (0x10UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x10000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_5                (0x20UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x20000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_6                (0x40UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x40000000 */
+#define USB_OTG_HPTXSTS_PTXQTOP_7                (0x80UL << USB_OTG_HPTXSTS_PTXQTOP_Pos) /*!< 0x80000000 */
+
+/********************  Bit definition for USB_OTG_HAINT register  ********************/
+#define USB_OTG_HAINT_HAINT_Pos                  (0U)                          
+#define USB_OTG_HAINT_HAINT_Msk                  (0xFFFFUL << USB_OTG_HAINT_HAINT_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_HAINT_HAINT                      USB_OTG_HAINT_HAINT_Msk       /*!< Channel interrupts */
+
+/********************  Bit definition for USB_OTG_DOEPMSK register  ********************/
+#define USB_OTG_DOEPMSK_XFRCM_Pos                (0U)                          
+#define USB_OTG_DOEPMSK_XFRCM_Msk                (0x1UL << USB_OTG_DOEPMSK_XFRCM_Pos) /*!< 0x00000001 */
+#define USB_OTG_DOEPMSK_XFRCM                    USB_OTG_DOEPMSK_XFRCM_Msk     /*!< Transfer completed interrupt mask              */
+#define USB_OTG_DOEPMSK_EPDM_Pos                 (1U)                          
+#define USB_OTG_DOEPMSK_EPDM_Msk                 (0x1UL << USB_OTG_DOEPMSK_EPDM_Pos) /*!< 0x00000002 */
+#define USB_OTG_DOEPMSK_EPDM                     USB_OTG_DOEPMSK_EPDM_Msk      /*!< Endpoint disabled interrupt mask               */
+#define USB_OTG_DOEPMSK_AHBERRM_Pos              (2U)
+#define USB_OTG_DOEPMSK_AHBERRM_Msk              (0x1UL << USB_OTG_DOEPMSK_AHBERRM_Pos) /*!< 0x00000004 */
+#define USB_OTG_DOEPMSK_AHBERRM                  USB_OTG_DOEPMSK_AHBERRM_Msk   /*!< OUT transaction AHB Error interrupt mask       */
+#define USB_OTG_DOEPMSK_STUPM_Pos                (3U)                          
+#define USB_OTG_DOEPMSK_STUPM_Msk                (0x1UL << USB_OTG_DOEPMSK_STUPM_Pos) /*!< 0x00000008 */
+#define USB_OTG_DOEPMSK_STUPM                    USB_OTG_DOEPMSK_STUPM_Msk     /*!< SETUP phase done mask                          */
+#define USB_OTG_DOEPMSK_OTEPDM_Pos               (4U)                          
+#define USB_OTG_DOEPMSK_OTEPDM_Msk               (0x1UL << USB_OTG_DOEPMSK_OTEPDM_Pos) /*!< 0x00000010 */
+#define USB_OTG_DOEPMSK_OTEPDM                   USB_OTG_DOEPMSK_OTEPDM_Msk    /*!< OUT token received when endpoint disabled mask */
+#define USB_OTG_DOEPMSK_OTEPSPRM_Pos             (5U)                          
+#define USB_OTG_DOEPMSK_OTEPSPRM_Msk             (0x1UL << USB_OTG_DOEPMSK_OTEPSPRM_Pos) /*!< 0x00000020 */
+#define USB_OTG_DOEPMSK_OTEPSPRM                 USB_OTG_DOEPMSK_OTEPSPRM_Msk  /*!< Status Phase Received mask                     */
+#define USB_OTG_DOEPMSK_B2BSTUP_Pos              (6U)                          
+#define USB_OTG_DOEPMSK_B2BSTUP_Msk              (0x1UL << USB_OTG_DOEPMSK_B2BSTUP_Pos) /*!< 0x00000040 */
+#define USB_OTG_DOEPMSK_B2BSTUP                  USB_OTG_DOEPMSK_B2BSTUP_Msk   /*!< Back-to-back SETUP packets received mask       */
+#define USB_OTG_DOEPMSK_OPEM_Pos                 (8U)                          
+#define USB_OTG_DOEPMSK_OPEM_Msk                 (0x1UL << USB_OTG_DOEPMSK_OPEM_Pos) /*!< 0x00000100 */
+#define USB_OTG_DOEPMSK_OPEM                     USB_OTG_DOEPMSK_OPEM_Msk      /*!< OUT packet error mask                          */
+#define USB_OTG_DOEPMSK_BOIM_Pos                 (9U)                          
+#define USB_OTG_DOEPMSK_BOIM_Msk                 (0x1UL << USB_OTG_DOEPMSK_BOIM_Pos) /*!< 0x00000200 */
+#define USB_OTG_DOEPMSK_BOIM                     USB_OTG_DOEPMSK_BOIM_Msk      /*!< BNA interrupt mask                             */
+#define USB_OTG_DOEPMSK_BERRM_Pos                (12U)
+#define USB_OTG_DOEPMSK_BERRM_Msk                (0x1UL << USB_OTG_DOEPMSK_BERRM_Pos) /*!< 0x00001000 */
+#define USB_OTG_DOEPMSK_BERRM                    USB_OTG_DOEPMSK_BERRM_Msk      /*!< Babble error interrupt mask                   */
+#define USB_OTG_DOEPMSK_NAKM_Pos                 (13U)
+#define USB_OTG_DOEPMSK_NAKM_Msk                 (0x1UL << USB_OTG_DOEPMSK_NAKM_Pos) /*!< 0x00002000 */
+#define USB_OTG_DOEPMSK_NAKM                     USB_OTG_DOEPMSK_NAKM_Msk      /*!< OUT Packet NAK interrupt mask                  */
+#define USB_OTG_DOEPMSK_NYETM_Pos                (14U)
+#define USB_OTG_DOEPMSK_NYETM_Msk                (0x1UL << USB_OTG_DOEPMSK_NYETM_Pos) /*!< 0x00004000 */
+#define USB_OTG_DOEPMSK_NYETM                    USB_OTG_DOEPMSK_NYETM_Msk     /*!< NYET interrupt mask                            */
+/********************  Bit definition for USB_OTG_GINTSTS register  ********************/
+#define USB_OTG_GINTSTS_CMOD_Pos                 (0U)                          
+#define USB_OTG_GINTSTS_CMOD_Msk                 (0x1UL << USB_OTG_GINTSTS_CMOD_Pos) /*!< 0x00000001 */
+#define USB_OTG_GINTSTS_CMOD                     USB_OTG_GINTSTS_CMOD_Msk      /*!< Current mode of operation                      */
+#define USB_OTG_GINTSTS_MMIS_Pos                 (1U)                          
+#define USB_OTG_GINTSTS_MMIS_Msk                 (0x1UL << USB_OTG_GINTSTS_MMIS_Pos) /*!< 0x00000002 */
+#define USB_OTG_GINTSTS_MMIS                     USB_OTG_GINTSTS_MMIS_Msk      /*!< Mode mismatch interrupt                        */
+#define USB_OTG_GINTSTS_OTGINT_Pos               (2U)                          
+#define USB_OTG_GINTSTS_OTGINT_Msk               (0x1UL << USB_OTG_GINTSTS_OTGINT_Pos) /*!< 0x00000004 */
+#define USB_OTG_GINTSTS_OTGINT                   USB_OTG_GINTSTS_OTGINT_Msk    /*!< OTG interrupt                                  */
+#define USB_OTG_GINTSTS_SOF_Pos                  (3U)                          
+#define USB_OTG_GINTSTS_SOF_Msk                  (0x1UL << USB_OTG_GINTSTS_SOF_Pos) /*!< 0x00000008 */
+#define USB_OTG_GINTSTS_SOF                      USB_OTG_GINTSTS_SOF_Msk       /*!< Start of frame                                 */
+#define USB_OTG_GINTSTS_RXFLVL_Pos               (4U)                          
+#define USB_OTG_GINTSTS_RXFLVL_Msk               (0x1UL << USB_OTG_GINTSTS_RXFLVL_Pos) /*!< 0x00000010 */
+#define USB_OTG_GINTSTS_RXFLVL                   USB_OTG_GINTSTS_RXFLVL_Msk    /*!< RxFIFO nonempty                                */
+#define USB_OTG_GINTSTS_NPTXFE_Pos               (5U)                          
+#define USB_OTG_GINTSTS_NPTXFE_Msk               (0x1UL << USB_OTG_GINTSTS_NPTXFE_Pos) /*!< 0x00000020 */
+#define USB_OTG_GINTSTS_NPTXFE                   USB_OTG_GINTSTS_NPTXFE_Msk    /*!< Nonperiodic TxFIFO empty                       */
+#define USB_OTG_GINTSTS_GINAKEFF_Pos             (6U)                          
+#define USB_OTG_GINTSTS_GINAKEFF_Msk             (0x1UL << USB_OTG_GINTSTS_GINAKEFF_Pos) /*!< 0x00000040 */
+#define USB_OTG_GINTSTS_GINAKEFF                 USB_OTG_GINTSTS_GINAKEFF_Msk  /*!< Global IN nonperiodic NAK effective            */
+#define USB_OTG_GINTSTS_BOUTNAKEFF_Pos           (7U)                          
+#define USB_OTG_GINTSTS_BOUTNAKEFF_Msk           (0x1UL << USB_OTG_GINTSTS_BOUTNAKEFF_Pos) /*!< 0x00000080 */
+#define USB_OTG_GINTSTS_BOUTNAKEFF               USB_OTG_GINTSTS_BOUTNAKEFF_Msk /*!< Global OUT NAK effective                       */
+#define USB_OTG_GINTSTS_ESUSP_Pos                (10U)                         
+#define USB_OTG_GINTSTS_ESUSP_Msk                (0x1UL << USB_OTG_GINTSTS_ESUSP_Pos) /*!< 0x00000400 */
+#define USB_OTG_GINTSTS_ESUSP                    USB_OTG_GINTSTS_ESUSP_Msk     /*!< Early suspend                                  */
+#define USB_OTG_GINTSTS_USBSUSP_Pos              (11U)                         
+#define USB_OTG_GINTSTS_USBSUSP_Msk              (0x1UL << USB_OTG_GINTSTS_USBSUSP_Pos) /*!< 0x00000800 */
+#define USB_OTG_GINTSTS_USBSUSP                  USB_OTG_GINTSTS_USBSUSP_Msk   /*!< USB suspend                                    */
+#define USB_OTG_GINTSTS_USBRST_Pos               (12U)                         
+#define USB_OTG_GINTSTS_USBRST_Msk               (0x1UL << USB_OTG_GINTSTS_USBRST_Pos) /*!< 0x00001000 */
+#define USB_OTG_GINTSTS_USBRST                   USB_OTG_GINTSTS_USBRST_Msk    /*!< USB reset                                      */
+#define USB_OTG_GINTSTS_ENUMDNE_Pos              (13U)                         
+#define USB_OTG_GINTSTS_ENUMDNE_Msk              (0x1UL << USB_OTG_GINTSTS_ENUMDNE_Pos) /*!< 0x00002000 */
+#define USB_OTG_GINTSTS_ENUMDNE                  USB_OTG_GINTSTS_ENUMDNE_Msk   /*!< Enumeration done                               */
+#define USB_OTG_GINTSTS_ISOODRP_Pos              (14U)                         
+#define USB_OTG_GINTSTS_ISOODRP_Msk              (0x1UL << USB_OTG_GINTSTS_ISOODRP_Pos) /*!< 0x00004000 */
+#define USB_OTG_GINTSTS_ISOODRP                  USB_OTG_GINTSTS_ISOODRP_Msk   /*!< Isochronous OUT packet dropped interrupt       */
+#define USB_OTG_GINTSTS_EOPF_Pos                 (15U)                         
+#define USB_OTG_GINTSTS_EOPF_Msk                 (0x1UL << USB_OTG_GINTSTS_EOPF_Pos) /*!< 0x00008000 */
+#define USB_OTG_GINTSTS_EOPF                     USB_OTG_GINTSTS_EOPF_Msk      /*!< End of periodic frame interrupt                */
+#define USB_OTG_GINTSTS_IEPINT_Pos               (18U)                         
+#define USB_OTG_GINTSTS_IEPINT_Msk               (0x1UL << USB_OTG_GINTSTS_IEPINT_Pos) /*!< 0x00040000 */
+#define USB_OTG_GINTSTS_IEPINT                   USB_OTG_GINTSTS_IEPINT_Msk    /*!< IN endpoint interrupt                          */
+#define USB_OTG_GINTSTS_OEPINT_Pos               (19U)                         
+#define USB_OTG_GINTSTS_OEPINT_Msk               (0x1UL << USB_OTG_GINTSTS_OEPINT_Pos) /*!< 0x00080000 */
+#define USB_OTG_GINTSTS_OEPINT                   USB_OTG_GINTSTS_OEPINT_Msk    /*!< OUT endpoint interrupt                         */
+#define USB_OTG_GINTSTS_IISOIXFR_Pos             (20U)                         
+#define USB_OTG_GINTSTS_IISOIXFR_Msk             (0x1UL << USB_OTG_GINTSTS_IISOIXFR_Pos) /*!< 0x00100000 */
+#define USB_OTG_GINTSTS_IISOIXFR                 USB_OTG_GINTSTS_IISOIXFR_Msk  /*!< Incomplete isochronous IN transfer             */
+#define USB_OTG_GINTSTS_PXFR_INCOMPISOOUT_Pos    (21U)                         
+#define USB_OTG_GINTSTS_PXFR_INCOMPISOOUT_Msk    (0x1UL << USB_OTG_GINTSTS_PXFR_INCOMPISOOUT_Pos) /*!< 0x00200000 */
+#define USB_OTG_GINTSTS_PXFR_INCOMPISOOUT        USB_OTG_GINTSTS_PXFR_INCOMPISOOUT_Msk /*!< Incomplete periodic transfer                   */
+#define USB_OTG_GINTSTS_DATAFSUSP_Pos            (22U)                         
+#define USB_OTG_GINTSTS_DATAFSUSP_Msk            (0x1UL << USB_OTG_GINTSTS_DATAFSUSP_Pos) /*!< 0x00400000 */
+#define USB_OTG_GINTSTS_DATAFSUSP                USB_OTG_GINTSTS_DATAFSUSP_Msk /*!< Data fetch suspended                           */
+#define USB_OTG_GINTSTS_HPRTINT_Pos              (24U)                         
+#define USB_OTG_GINTSTS_HPRTINT_Msk              (0x1UL << USB_OTG_GINTSTS_HPRTINT_Pos) /*!< 0x01000000 */
+#define USB_OTG_GINTSTS_HPRTINT                  USB_OTG_GINTSTS_HPRTINT_Msk   /*!< Host port interrupt                            */
+#define USB_OTG_GINTSTS_HCINT_Pos                (25U)                         
+#define USB_OTG_GINTSTS_HCINT_Msk                (0x1UL << USB_OTG_GINTSTS_HCINT_Pos) /*!< 0x02000000 */
+#define USB_OTG_GINTSTS_HCINT                    USB_OTG_GINTSTS_HCINT_Msk     /*!< Host channels interrupt                        */
+#define USB_OTG_GINTSTS_PTXFE_Pos                (26U)                         
+#define USB_OTG_GINTSTS_PTXFE_Msk                (0x1UL << USB_OTG_GINTSTS_PTXFE_Pos) /*!< 0x04000000 */
+#define USB_OTG_GINTSTS_PTXFE                    USB_OTG_GINTSTS_PTXFE_Msk     /*!< Periodic TxFIFO empty                          */
+#define USB_OTG_GINTSTS_CIDSCHG_Pos              (28U)                         
+#define USB_OTG_GINTSTS_CIDSCHG_Msk              (0x1UL << USB_OTG_GINTSTS_CIDSCHG_Pos) /*!< 0x10000000 */
+#define USB_OTG_GINTSTS_CIDSCHG                  USB_OTG_GINTSTS_CIDSCHG_Msk   /*!< Connector ID status change                     */
+#define USB_OTG_GINTSTS_DISCINT_Pos              (29U)                         
+#define USB_OTG_GINTSTS_DISCINT_Msk              (0x1UL << USB_OTG_GINTSTS_DISCINT_Pos) /*!< 0x20000000 */
+#define USB_OTG_GINTSTS_DISCINT                  USB_OTG_GINTSTS_DISCINT_Msk   /*!< Disconnect detected interrupt                  */
+#define USB_OTG_GINTSTS_SRQINT_Pos               (30U)                         
+#define USB_OTG_GINTSTS_SRQINT_Msk               (0x1UL << USB_OTG_GINTSTS_SRQINT_Pos) /*!< 0x40000000 */
+#define USB_OTG_GINTSTS_SRQINT                   USB_OTG_GINTSTS_SRQINT_Msk    /*!< Session request/new session detected interrupt */
+#define USB_OTG_GINTSTS_WKUINT_Pos               (31U)                         
+#define USB_OTG_GINTSTS_WKUINT_Msk               (0x1UL << USB_OTG_GINTSTS_WKUINT_Pos) /*!< 0x80000000 */
+#define USB_OTG_GINTSTS_WKUINT                   USB_OTG_GINTSTS_WKUINT_Msk    /*!< Resume/remote wakeup detected interrupt        */
+
+/********************  Bit definition for USB_OTG_GINTMSK register  ********************/
+#define USB_OTG_GINTMSK_MMISM_Pos                (1U)                          
+#define USB_OTG_GINTMSK_MMISM_Msk                (0x1UL << USB_OTG_GINTMSK_MMISM_Pos) /*!< 0x00000002 */
+#define USB_OTG_GINTMSK_MMISM                    USB_OTG_GINTMSK_MMISM_Msk     /*!< Mode mismatch interrupt mask                        */
+#define USB_OTG_GINTMSK_OTGINT_Pos               (2U)                          
+#define USB_OTG_GINTMSK_OTGINT_Msk               (0x1UL << USB_OTG_GINTMSK_OTGINT_Pos) /*!< 0x00000004 */
+#define USB_OTG_GINTMSK_OTGINT                   USB_OTG_GINTMSK_OTGINT_Msk    /*!< OTG interrupt mask                                  */
+#define USB_OTG_GINTMSK_SOFM_Pos                 (3U)                          
+#define USB_OTG_GINTMSK_SOFM_Msk                 (0x1UL << USB_OTG_GINTMSK_SOFM_Pos) /*!< 0x00000008 */
+#define USB_OTG_GINTMSK_SOFM                     USB_OTG_GINTMSK_SOFM_Msk      /*!< Start of frame mask                                 */
+#define USB_OTG_GINTMSK_RXFLVLM_Pos              (4U)                          
+#define USB_OTG_GINTMSK_RXFLVLM_Msk              (0x1UL << USB_OTG_GINTMSK_RXFLVLM_Pos) /*!< 0x00000010 */
+#define USB_OTG_GINTMSK_RXFLVLM                  USB_OTG_GINTMSK_RXFLVLM_Msk   /*!< Receive FIFO nonempty mask                          */
+#define USB_OTG_GINTMSK_NPTXFEM_Pos              (5U)                          
+#define USB_OTG_GINTMSK_NPTXFEM_Msk              (0x1UL << USB_OTG_GINTMSK_NPTXFEM_Pos) /*!< 0x00000020 */
+#define USB_OTG_GINTMSK_NPTXFEM                  USB_OTG_GINTMSK_NPTXFEM_Msk   /*!< Nonperiodic TxFIFO empty mask                       */
+#define USB_OTG_GINTMSK_GINAKEFFM_Pos            (6U)                          
+#define USB_OTG_GINTMSK_GINAKEFFM_Msk            (0x1UL << USB_OTG_GINTMSK_GINAKEFFM_Pos) /*!< 0x00000040 */
+#define USB_OTG_GINTMSK_GINAKEFFM                USB_OTG_GINTMSK_GINAKEFFM_Msk /*!< Global nonperiodic IN NAK effective mask            */
+#define USB_OTG_GINTMSK_GONAKEFFM_Pos            (7U)                          
+#define USB_OTG_GINTMSK_GONAKEFFM_Msk            (0x1UL << USB_OTG_GINTMSK_GONAKEFFM_Pos) /*!< 0x00000080 */
+#define USB_OTG_GINTMSK_GONAKEFFM                USB_OTG_GINTMSK_GONAKEFFM_Msk /*!< Global OUT NAK effective mask                       */
+#define USB_OTG_GINTMSK_ESUSPM_Pos               (10U)                         
+#define USB_OTG_GINTMSK_ESUSPM_Msk               (0x1UL << USB_OTG_GINTMSK_ESUSPM_Pos) /*!< 0x00000400 */
+#define USB_OTG_GINTMSK_ESUSPM                   USB_OTG_GINTMSK_ESUSPM_Msk    /*!< Early suspend mask                                  */
+#define USB_OTG_GINTMSK_USBSUSPM_Pos             (11U)                         
+#define USB_OTG_GINTMSK_USBSUSPM_Msk             (0x1UL << USB_OTG_GINTMSK_USBSUSPM_Pos) /*!< 0x00000800 */
+#define USB_OTG_GINTMSK_USBSUSPM                 USB_OTG_GINTMSK_USBSUSPM_Msk  /*!< USB suspend mask                                    */
+#define USB_OTG_GINTMSK_USBRST_Pos               (12U)                         
+#define USB_OTG_GINTMSK_USBRST_Msk               (0x1UL << USB_OTG_GINTMSK_USBRST_Pos) /*!< 0x00001000 */
+#define USB_OTG_GINTMSK_USBRST                   USB_OTG_GINTMSK_USBRST_Msk    /*!< USB reset mask                                      */
+#define USB_OTG_GINTMSK_ENUMDNEM_Pos             (13U)                         
+#define USB_OTG_GINTMSK_ENUMDNEM_Msk             (0x1UL << USB_OTG_GINTMSK_ENUMDNEM_Pos) /*!< 0x00002000 */
+#define USB_OTG_GINTMSK_ENUMDNEM                 USB_OTG_GINTMSK_ENUMDNEM_Msk  /*!< Enumeration done mask                               */
+#define USB_OTG_GINTMSK_ISOODRPM_Pos             (14U)                         
+#define USB_OTG_GINTMSK_ISOODRPM_Msk             (0x1UL << USB_OTG_GINTMSK_ISOODRPM_Pos) /*!< 0x00004000 */
+#define USB_OTG_GINTMSK_ISOODRPM                 USB_OTG_GINTMSK_ISOODRPM_Msk  /*!< Isochronous OUT packet dropped interrupt mask       */
+#define USB_OTG_GINTMSK_EOPFM_Pos                (15U)                         
+#define USB_OTG_GINTMSK_EOPFM_Msk                (0x1UL << USB_OTG_GINTMSK_EOPFM_Pos) /*!< 0x00008000 */
+#define USB_OTG_GINTMSK_EOPFM                    USB_OTG_GINTMSK_EOPFM_Msk     /*!< End of periodic frame interrupt mask                */
+#define USB_OTG_GINTMSK_EPMISM_Pos               (17U)                         
+#define USB_OTG_GINTMSK_EPMISM_Msk               (0x1UL << USB_OTG_GINTMSK_EPMISM_Pos) /*!< 0x00020000 */
+#define USB_OTG_GINTMSK_EPMISM                   USB_OTG_GINTMSK_EPMISM_Msk    /*!< Endpoint mismatch interrupt mask                    */
+#define USB_OTG_GINTMSK_IEPINT_Pos               (18U)                         
+#define USB_OTG_GINTMSK_IEPINT_Msk               (0x1UL << USB_OTG_GINTMSK_IEPINT_Pos) /*!< 0x00040000 */
+#define USB_OTG_GINTMSK_IEPINT                   USB_OTG_GINTMSK_IEPINT_Msk    /*!< IN endpoints interrupt mask                         */
+#define USB_OTG_GINTMSK_OEPINT_Pos               (19U)                         
+#define USB_OTG_GINTMSK_OEPINT_Msk               (0x1UL << USB_OTG_GINTMSK_OEPINT_Pos) /*!< 0x00080000 */
+#define USB_OTG_GINTMSK_OEPINT                   USB_OTG_GINTMSK_OEPINT_Msk    /*!< OUT endpoints interrupt mask                        */
+#define USB_OTG_GINTMSK_IISOIXFRM_Pos            (20U)                         
+#define USB_OTG_GINTMSK_IISOIXFRM_Msk            (0x1UL << USB_OTG_GINTMSK_IISOIXFRM_Pos) /*!< 0x00100000 */
+#define USB_OTG_GINTMSK_IISOIXFRM                USB_OTG_GINTMSK_IISOIXFRM_Msk /*!< Incomplete isochronous IN transfer mask             */
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM_Pos      (21U)                         
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM_Msk      (0x1UL << USB_OTG_GINTMSK_PXFRM_IISOOXFRM_Pos) /*!< 0x00200000 */
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM          USB_OTG_GINTMSK_PXFRM_IISOOXFRM_Msk /*!< Incomplete periodic transfer mask                   */
+#define USB_OTG_GINTMSK_FSUSPM_Pos               (22U)                         
+#define USB_OTG_GINTMSK_FSUSPM_Msk               (0x1UL << USB_OTG_GINTMSK_FSUSPM_Pos) /*!< 0x00400000 */
+#define USB_OTG_GINTMSK_FSUSPM                   USB_OTG_GINTMSK_FSUSPM_Msk    /*!< Data fetch suspended mask                           */
+#define USB_OTG_GINTMSK_PRTIM_Pos                (24U)                         
+#define USB_OTG_GINTMSK_PRTIM_Msk                (0x1UL << USB_OTG_GINTMSK_PRTIM_Pos) /*!< 0x01000000 */
+#define USB_OTG_GINTMSK_PRTIM                    USB_OTG_GINTMSK_PRTIM_Msk     /*!< Host port interrupt mask                            */
+#define USB_OTG_GINTMSK_HCIM_Pos                 (25U)                         
+#define USB_OTG_GINTMSK_HCIM_Msk                 (0x1UL << USB_OTG_GINTMSK_HCIM_Pos) /*!< 0x02000000 */
+#define USB_OTG_GINTMSK_HCIM                     USB_OTG_GINTMSK_HCIM_Msk      /*!< Host channels interrupt mask                        */
+#define USB_OTG_GINTMSK_PTXFEM_Pos               (26U)                         
+#define USB_OTG_GINTMSK_PTXFEM_Msk               (0x1UL << USB_OTG_GINTMSK_PTXFEM_Pos) /*!< 0x04000000 */
+#define USB_OTG_GINTMSK_PTXFEM                   USB_OTG_GINTMSK_PTXFEM_Msk    /*!< Periodic TxFIFO empty mask                          */
+#define USB_OTG_GINTMSK_CIDSCHGM_Pos             (28U)                         
+#define USB_OTG_GINTMSK_CIDSCHGM_Msk             (0x1UL << USB_OTG_GINTMSK_CIDSCHGM_Pos) /*!< 0x10000000 */
+#define USB_OTG_GINTMSK_CIDSCHGM                 USB_OTG_GINTMSK_CIDSCHGM_Msk  /*!< Connector ID status change mask                     */
+#define USB_OTG_GINTMSK_DISCINT_Pos              (29U)                         
+#define USB_OTG_GINTMSK_DISCINT_Msk              (0x1UL << USB_OTG_GINTMSK_DISCINT_Pos) /*!< 0x20000000 */
+#define USB_OTG_GINTMSK_DISCINT                  USB_OTG_GINTMSK_DISCINT_Msk   /*!< Disconnect detected interrupt mask                  */
+#define USB_OTG_GINTMSK_SRQIM_Pos                (30U)                         
+#define USB_OTG_GINTMSK_SRQIM_Msk                (0x1UL << USB_OTG_GINTMSK_SRQIM_Pos) /*!< 0x40000000 */
+#define USB_OTG_GINTMSK_SRQIM                    USB_OTG_GINTMSK_SRQIM_Msk     /*!< Session request/new session detected interrupt mask */
+#define USB_OTG_GINTMSK_WUIM_Pos                 (31U)                         
+#define USB_OTG_GINTMSK_WUIM_Msk                 (0x1UL << USB_OTG_GINTMSK_WUIM_Pos) /*!< 0x80000000 */
+#define USB_OTG_GINTMSK_WUIM                     USB_OTG_GINTMSK_WUIM_Msk      /*!< Resume/remote wakeup detected interrupt mask        */
+
+/********************  Bit definition for USB_OTG_DAINT register  ********************/
+#define USB_OTG_DAINT_IEPINT_Pos                 (0U)                          
+#define USB_OTG_DAINT_IEPINT_Msk                 (0xFFFFUL << USB_OTG_DAINT_IEPINT_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_DAINT_IEPINT                     USB_OTG_DAINT_IEPINT_Msk      /*!< IN endpoint interrupt bits  */
+#define USB_OTG_DAINT_OEPINT_Pos                 (16U)                         
+#define USB_OTG_DAINT_OEPINT_Msk                 (0xFFFFUL << USB_OTG_DAINT_OEPINT_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_DAINT_OEPINT                     USB_OTG_DAINT_OEPINT_Msk      /*!< OUT endpoint interrupt bits */
+
+/********************  Bit definition for USB_OTG_HAINTMSK register  ********************/
+#define USB_OTG_HAINTMSK_HAINTM_Pos              (0U)                          
+#define USB_OTG_HAINTMSK_HAINTM_Msk              (0xFFFFUL << USB_OTG_HAINTMSK_HAINTM_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_HAINTMSK_HAINTM                  USB_OTG_HAINTMSK_HAINTM_Msk   /*!< Channel interrupt mask */
+
+/********************  Bit definition for USB_OTG_GRXSTSP register  ********************/
+#define USB_OTG_GRXSTSP_EPNUM_Pos                (0U)                          
+#define USB_OTG_GRXSTSP_EPNUM_Msk                (0xFUL << USB_OTG_GRXSTSP_EPNUM_Pos) /*!< 0x0000000F */
+#define USB_OTG_GRXSTSP_EPNUM                    USB_OTG_GRXSTSP_EPNUM_Msk     /*!< IN EP interrupt mask bits  */
+#define USB_OTG_GRXSTSP_BCNT_Pos                 (4U)                          
+#define USB_OTG_GRXSTSP_BCNT_Msk                 (0x7FFUL << USB_OTG_GRXSTSP_BCNT_Pos) /*!< 0x00007FF0 */
+#define USB_OTG_GRXSTSP_BCNT                     USB_OTG_GRXSTSP_BCNT_Msk      /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_DPID_Pos                 (15U)                         
+#define USB_OTG_GRXSTSP_DPID_Msk                 (0x3UL << USB_OTG_GRXSTSP_DPID_Pos) /*!< 0x00018000 */
+#define USB_OTG_GRXSTSP_DPID                     USB_OTG_GRXSTSP_DPID_Msk      /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_PKTSTS_Pos               (17U)                         
+#define USB_OTG_GRXSTSP_PKTSTS_Msk               (0xFUL << USB_OTG_GRXSTSP_PKTSTS_Pos) /*!< 0x001E0000 */
+#define USB_OTG_GRXSTSP_PKTSTS                   USB_OTG_GRXSTSP_PKTSTS_Msk    /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DAINTMSK register  ********************/
+#define USB_OTG_DAINTMSK_IEPM_Pos                (0U)                          
+#define USB_OTG_DAINTMSK_IEPM_Msk                (0xFFFFUL << USB_OTG_DAINTMSK_IEPM_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_DAINTMSK_IEPM                    USB_OTG_DAINTMSK_IEPM_Msk     /*!< IN EP interrupt mask bits */
+#define USB_OTG_DAINTMSK_OEPM_Pos                (16U)                         
+#define USB_OTG_DAINTMSK_OEPM_Msk                (0xFFFFUL << USB_OTG_DAINTMSK_OEPM_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_DAINTMSK_OEPM                    USB_OTG_DAINTMSK_OEPM_Msk     /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_GRXFSIZ register  ********************/
+#define USB_OTG_GRXFSIZ_RXFD_Pos                 (0U)                          
+#define USB_OTG_GRXFSIZ_RXFD_Msk                 (0xFFFFUL << USB_OTG_GRXFSIZ_RXFD_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_GRXFSIZ_RXFD                     USB_OTG_GRXFSIZ_RXFD_Msk      /*!< RxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DVBUSDIS register  ********************/
+#define USB_OTG_DVBUSDIS_VBUSDT_Pos              (0U)                          
+#define USB_OTG_DVBUSDIS_VBUSDT_Msk              (0xFFFFUL << USB_OTG_DVBUSDIS_VBUSDT_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_DVBUSDIS_VBUSDT                  USB_OTG_DVBUSDIS_VBUSDT_Msk   /*!< Device VBUS discharge time */
+
+/********************  Bit definition for OTG register  ********************/
+#define USB_OTG_NPTXFSA_Pos                      (0U)                          
+#define USB_OTG_NPTXFSA_Msk                      (0xFFFFUL << USB_OTG_NPTXFSA_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_NPTXFSA                          USB_OTG_NPTXFSA_Msk           /*!< Nonperiodic transmit RAM start address */
+#define USB_OTG_NPTXFD_Pos                       (16U)                         
+#define USB_OTG_NPTXFD_Msk                       (0xFFFFUL << USB_OTG_NPTXFD_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_NPTXFD                           USB_OTG_NPTXFD_Msk            /*!< Nonperiodic TxFIFO depth               */
+#define USB_OTG_TX0FSA_Pos                       (0U)                          
+#define USB_OTG_TX0FSA_Msk                       (0xFFFFUL << USB_OTG_TX0FSA_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_TX0FSA                           USB_OTG_TX0FSA_Msk            /*!< Endpoint 0 transmit RAM start address  */
+#define USB_OTG_TX0FD_Pos                        (16U)                         
+#define USB_OTG_TX0FD_Msk                        (0xFFFFUL << USB_OTG_TX0FD_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_TX0FD                            USB_OTG_TX0FD_Msk             /*!< Endpoint 0 TxFIFO depth                */
+
+/********************  Bit definition forUSB_OTG_DVBUSPULSE register  ********************/
+#define USB_OTG_DVBUSPULSE_DVBUSP_Pos            (0U)                          
+#define USB_OTG_DVBUSPULSE_DVBUSP_Msk            (0xFFFUL << USB_OTG_DVBUSPULSE_DVBUSP_Pos) /*!< 0x00000FFF */
+#define USB_OTG_DVBUSPULSE_DVBUSP                USB_OTG_DVBUSPULSE_DVBUSP_Msk /*!< Device VBUS pulsing time */
+
+/********************  Bit definition for USB_OTG_GNPTXSTS register  ********************/
+#define USB_OTG_GNPTXSTS_NPTXFSAV_Pos            (0U)                          
+#define USB_OTG_GNPTXSTS_NPTXFSAV_Msk            (0xFFFFUL << USB_OTG_GNPTXSTS_NPTXFSAV_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_GNPTXSTS_NPTXFSAV                USB_OTG_GNPTXSTS_NPTXFSAV_Msk /*!< Nonperiodic TxFIFO space available */
+
+#define USB_OTG_GNPTXSTS_NPTQXSAV_Pos            (16U)                         
+#define USB_OTG_GNPTXSTS_NPTQXSAV_Msk            (0xFFUL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00FF0000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV                USB_OTG_GNPTXSTS_NPTQXSAV_Msk /*!< Nonperiodic transmit request queue space available */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_0              (0x01UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00010000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_1              (0x02UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00020000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_2              (0x04UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00040000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_3              (0x08UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00080000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_4              (0x10UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00100000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_5              (0x20UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00200000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_6              (0x40UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00400000 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_7              (0x80UL << USB_OTG_GNPTXSTS_NPTQXSAV_Pos) /*!< 0x00800000 */
+
+#define USB_OTG_GNPTXSTS_NPTXQTOP_Pos            (24U)                         
+#define USB_OTG_GNPTXSTS_NPTXQTOP_Msk            (0x7FUL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x7F000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP                USB_OTG_GNPTXSTS_NPTXQTOP_Msk /*!< Top of the nonperiodic transmit request queue */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_0              (0x01UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x01000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_1              (0x02UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x02000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_2              (0x04UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x04000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_3              (0x08UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x08000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_4              (0x10UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x10000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_5              (0x20UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x20000000 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_6              (0x40UL << USB_OTG_GNPTXSTS_NPTXQTOP_Pos) /*!< 0x40000000 */
+
+/********************  Bit definition for USB_OTG_DTHRCTL register  ********************/
+#define USB_OTG_DTHRCTL_NONISOTHREN_Pos          (0U)                          
+#define USB_OTG_DTHRCTL_NONISOTHREN_Msk          (0x1UL << USB_OTG_DTHRCTL_NONISOTHREN_Pos) /*!< 0x00000001 */
+#define USB_OTG_DTHRCTL_NONISOTHREN              USB_OTG_DTHRCTL_NONISOTHREN_Msk /*!< Nonisochronous IN endpoints threshold enable */
+#define USB_OTG_DTHRCTL_ISOTHREN_Pos             (1U)                          
+#define USB_OTG_DTHRCTL_ISOTHREN_Msk             (0x1UL << USB_OTG_DTHRCTL_ISOTHREN_Pos) /*!< 0x00000002 */
+#define USB_OTG_DTHRCTL_ISOTHREN                 USB_OTG_DTHRCTL_ISOTHREN_Msk  /*!< ISO IN endpoint threshold enable */
+
+#define USB_OTG_DTHRCTL_TXTHRLEN_Pos             (2U)                          
+#define USB_OTG_DTHRCTL_TXTHRLEN_Msk             (0x1FFUL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x000007FC */
+#define USB_OTG_DTHRCTL_TXTHRLEN                 USB_OTG_DTHRCTL_TXTHRLEN_Msk  /*!< Transmit threshold length */
+#define USB_OTG_DTHRCTL_TXTHRLEN_0               (0x001UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000004 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_1               (0x002UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000008 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_2               (0x004UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000010 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_3               (0x008UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000020 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_4               (0x010UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000040 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_5               (0x020UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000080 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_6               (0x040UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000100 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_7               (0x080UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000200 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_8               (0x100UL << USB_OTG_DTHRCTL_TXTHRLEN_Pos) /*!< 0x00000400 */
+#define USB_OTG_DTHRCTL_RXTHREN_Pos              (16U)                         
+#define USB_OTG_DTHRCTL_RXTHREN_Msk              (0x1UL << USB_OTG_DTHRCTL_RXTHREN_Pos) /*!< 0x00010000 */
+#define USB_OTG_DTHRCTL_RXTHREN                  USB_OTG_DTHRCTL_RXTHREN_Msk   /*!< Receive threshold enable */
+
+#define USB_OTG_DTHRCTL_RXTHRLEN_Pos             (17U)                         
+#define USB_OTG_DTHRCTL_RXTHRLEN_Msk             (0x1FFUL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x03FE0000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN                 USB_OTG_DTHRCTL_RXTHRLEN_Msk  /*!< Receive threshold length */
+#define USB_OTG_DTHRCTL_RXTHRLEN_0               (0x001UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00020000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_1               (0x002UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00040000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_2               (0x004UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00080000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_3               (0x008UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00100000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_4               (0x010UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00200000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_5               (0x020UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00400000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_6               (0x040UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x00800000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_7               (0x080UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x01000000 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_8               (0x100UL << USB_OTG_DTHRCTL_RXTHRLEN_Pos) /*!< 0x02000000 */
+#define USB_OTG_DTHRCTL_ARPEN_Pos                (27U)                         
+#define USB_OTG_DTHRCTL_ARPEN_Msk                (0x1UL << USB_OTG_DTHRCTL_ARPEN_Pos) /*!< 0x08000000 */
+#define USB_OTG_DTHRCTL_ARPEN                    USB_OTG_DTHRCTL_ARPEN_Msk     /*!< Arbiter parking enable */
+
+/********************  Bit definition for USB_OTG_DIEPEMPMSK register  ********************/
+#define USB_OTG_DIEPEMPMSK_INEPTXFEM_Pos         (0U)                          
+#define USB_OTG_DIEPEMPMSK_INEPTXFEM_Msk         (0xFFFFUL << USB_OTG_DIEPEMPMSK_INEPTXFEM_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_DIEPEMPMSK_INEPTXFEM             USB_OTG_DIEPEMPMSK_INEPTXFEM_Msk /*!< IN EP Tx FIFO empty interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DEACHINT register  ********************/
+#define USB_OTG_DEACHINT_IEP1INT_Pos             (1U)                          
+#define USB_OTG_DEACHINT_IEP1INT_Msk             (0x1UL << USB_OTG_DEACHINT_IEP1INT_Pos) /*!< 0x00000002 */
+#define USB_OTG_DEACHINT_IEP1INT                 USB_OTG_DEACHINT_IEP1INT_Msk  /*!< IN endpoint 1interrupt bit   */
+#define USB_OTG_DEACHINT_OEP1INT_Pos             (17U)                         
+#define USB_OTG_DEACHINT_OEP1INT_Msk             (0x1UL << USB_OTG_DEACHINT_OEP1INT_Pos) /*!< 0x00020000 */
+#define USB_OTG_DEACHINT_OEP1INT                 USB_OTG_DEACHINT_OEP1INT_Msk  /*!< OUT endpoint 1 interrupt bit */
+
+/********************  Bit definition for USB_OTG_GCCFG register  ********************/
+#define USB_OTG_GCCFG_PWRDWN_Pos                 (16U)                         
+#define USB_OTG_GCCFG_PWRDWN_Msk                 (0x1UL << USB_OTG_GCCFG_PWRDWN_Pos) /*!< 0x00010000 */
+#define USB_OTG_GCCFG_PWRDWN                     USB_OTG_GCCFG_PWRDWN_Msk      /*!< Power down */
+#define USB_OTG_GCCFG_I2CPADEN_Pos               (17U)                         
+#define USB_OTG_GCCFG_I2CPADEN_Msk               (0x1UL << USB_OTG_GCCFG_I2CPADEN_Pos) /*!< 0x00020000 */
+#define USB_OTG_GCCFG_I2CPADEN                   USB_OTG_GCCFG_I2CPADEN_Msk    /*!< Enable I2C bus connection for the external I2C PHY interface*/ 
+#define USB_OTG_GCCFG_VBUSASEN_Pos               (18U)                         
+#define USB_OTG_GCCFG_VBUSASEN_Msk               (0x1UL << USB_OTG_GCCFG_VBUSASEN_Pos) /*!< 0x00040000 */
+#define USB_OTG_GCCFG_VBUSASEN                   USB_OTG_GCCFG_VBUSASEN_Msk    /*!< Enable the VBUS sensing device */
+#define USB_OTG_GCCFG_VBUSBSEN_Pos               (19U)                         
+#define USB_OTG_GCCFG_VBUSBSEN_Msk               (0x1UL << USB_OTG_GCCFG_VBUSBSEN_Pos) /*!< 0x00080000 */
+#define USB_OTG_GCCFG_VBUSBSEN                   USB_OTG_GCCFG_VBUSBSEN_Msk    /*!< Enable the VBUS sensing device */
+#define USB_OTG_GCCFG_SOFOUTEN_Pos               (20U)                         
+#define USB_OTG_GCCFG_SOFOUTEN_Msk               (0x1UL << USB_OTG_GCCFG_SOFOUTEN_Pos) /*!< 0x00100000 */
+#define USB_OTG_GCCFG_SOFOUTEN                   USB_OTG_GCCFG_SOFOUTEN_Msk    /*!< SOF output enable */
+#define USB_OTG_GCCFG_NOVBUSSENS_Pos             (21U)                         
+#define USB_OTG_GCCFG_NOVBUSSENS_Msk             (0x1UL << USB_OTG_GCCFG_NOVBUSSENS_Pos) /*!< 0x00200000 */
+#define USB_OTG_GCCFG_NOVBUSSENS                 USB_OTG_GCCFG_NOVBUSSENS_Msk  /*!< VBUS sensing disable option*/ 
+
+/********************  Bit definition forUSB_OTG_DEACHINTMSK register  ********************/
+#define USB_OTG_DEACHINTMSK_IEP1INTM_Pos         (1U)                          
+#define USB_OTG_DEACHINTMSK_IEP1INTM_Msk         (0x1UL << USB_OTG_DEACHINTMSK_IEP1INTM_Pos) /*!< 0x00000002 */
+#define USB_OTG_DEACHINTMSK_IEP1INTM             USB_OTG_DEACHINTMSK_IEP1INTM_Msk /*!< IN Endpoint 1 interrupt mask bit  */
+#define USB_OTG_DEACHINTMSK_OEP1INTM_Pos         (17U)                         
+#define USB_OTG_DEACHINTMSK_OEP1INTM_Msk         (0x1UL << USB_OTG_DEACHINTMSK_OEP1INTM_Pos) /*!< 0x00020000 */
+#define USB_OTG_DEACHINTMSK_OEP1INTM             USB_OTG_DEACHINTMSK_OEP1INTM_Msk /*!< OUT Endpoint 1 interrupt mask bit */
+
+/********************  Bit definition for USB_OTG_CID register  ********************/
+#define USB_OTG_CID_PRODUCT_ID_Pos               (0U)                          
+#define USB_OTG_CID_PRODUCT_ID_Msk               (0xFFFFFFFFUL << USB_OTG_CID_PRODUCT_ID_Pos) /*!< 0xFFFFFFFF */
+#define USB_OTG_CID_PRODUCT_ID                   USB_OTG_CID_PRODUCT_ID_Msk    /*!< Product ID field */
+
+/********************  Bit definition for USB_OTG_DIEPEACHMSK1 register  ********************/
+#define USB_OTG_DIEPEACHMSK1_XFRCM_Pos           (0U)                          
+#define USB_OTG_DIEPEACHMSK1_XFRCM_Msk           (0x1UL << USB_OTG_DIEPEACHMSK1_XFRCM_Pos) /*!< 0x00000001 */
+#define USB_OTG_DIEPEACHMSK1_XFRCM               USB_OTG_DIEPEACHMSK1_XFRCM_Msk /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPEACHMSK1_EPDM_Pos            (1U)                          
+#define USB_OTG_DIEPEACHMSK1_EPDM_Msk            (0x1UL << USB_OTG_DIEPEACHMSK1_EPDM_Pos) /*!< 0x00000002 */
+#define USB_OTG_DIEPEACHMSK1_EPDM                USB_OTG_DIEPEACHMSK1_EPDM_Msk /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPEACHMSK1_TOM_Pos             (3U)                          
+#define USB_OTG_DIEPEACHMSK1_TOM_Msk             (0x1UL << USB_OTG_DIEPEACHMSK1_TOM_Pos) /*!< 0x00000008 */
+#define USB_OTG_DIEPEACHMSK1_TOM                 USB_OTG_DIEPEACHMSK1_TOM_Msk  /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPEACHMSK1_ITTXFEMSK_Pos       (4U)                          
+#define USB_OTG_DIEPEACHMSK1_ITTXFEMSK_Msk       (0x1UL << USB_OTG_DIEPEACHMSK1_ITTXFEMSK_Pos) /*!< 0x00000010 */
+#define USB_OTG_DIEPEACHMSK1_ITTXFEMSK           USB_OTG_DIEPEACHMSK1_ITTXFEMSK_Msk /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPEACHMSK1_INEPNMM_Pos         (5U)                          
+#define USB_OTG_DIEPEACHMSK1_INEPNMM_Msk         (0x1UL << USB_OTG_DIEPEACHMSK1_INEPNMM_Pos) /*!< 0x00000020 */
+#define USB_OTG_DIEPEACHMSK1_INEPNMM             USB_OTG_DIEPEACHMSK1_INEPNMM_Msk /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPEACHMSK1_INEPNEM_Pos         (6U)                          
+#define USB_OTG_DIEPEACHMSK1_INEPNEM_Msk         (0x1UL << USB_OTG_DIEPEACHMSK1_INEPNEM_Pos) /*!< 0x00000040 */
+#define USB_OTG_DIEPEACHMSK1_INEPNEM             USB_OTG_DIEPEACHMSK1_INEPNEM_Msk /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPEACHMSK1_TXFURM_Pos          (8U)                          
+#define USB_OTG_DIEPEACHMSK1_TXFURM_Msk          (0x1UL << USB_OTG_DIEPEACHMSK1_TXFURM_Pos) /*!< 0x00000100 */
+#define USB_OTG_DIEPEACHMSK1_TXFURM              USB_OTG_DIEPEACHMSK1_TXFURM_Msk /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPEACHMSK1_BIM_Pos             (9U)                          
+#define USB_OTG_DIEPEACHMSK1_BIM_Msk             (0x1UL << USB_OTG_DIEPEACHMSK1_BIM_Pos) /*!< 0x00000200 */
+#define USB_OTG_DIEPEACHMSK1_BIM                 USB_OTG_DIEPEACHMSK1_BIM_Msk  /*!< BNA interrupt mask                                */
+#define USB_OTG_DIEPEACHMSK1_NAKM_Pos            (13U)                         
+#define USB_OTG_DIEPEACHMSK1_NAKM_Msk            (0x1UL << USB_OTG_DIEPEACHMSK1_NAKM_Pos) /*!< 0x00002000 */
+#define USB_OTG_DIEPEACHMSK1_NAKM                USB_OTG_DIEPEACHMSK1_NAKM_Msk /*!< NAK interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPRT register  ********************/
+#define USB_OTG_HPRT_PCSTS_Pos                   (0U)                          
+#define USB_OTG_HPRT_PCSTS_Msk                   (0x1UL << USB_OTG_HPRT_PCSTS_Pos) /*!< 0x00000001 */
+#define USB_OTG_HPRT_PCSTS                       USB_OTG_HPRT_PCSTS_Msk        /*!< Port connect status        */
+#define USB_OTG_HPRT_PCDET_Pos                   (1U)                          
+#define USB_OTG_HPRT_PCDET_Msk                   (0x1UL << USB_OTG_HPRT_PCDET_Pos) /*!< 0x00000002 */
+#define USB_OTG_HPRT_PCDET                       USB_OTG_HPRT_PCDET_Msk        /*!< Port connect detected      */
+#define USB_OTG_HPRT_PENA_Pos                    (2U)                          
+#define USB_OTG_HPRT_PENA_Msk                    (0x1UL << USB_OTG_HPRT_PENA_Pos) /*!< 0x00000004 */
+#define USB_OTG_HPRT_PENA                        USB_OTG_HPRT_PENA_Msk         /*!< Port enable                */
+#define USB_OTG_HPRT_PENCHNG_Pos                 (3U)                          
+#define USB_OTG_HPRT_PENCHNG_Msk                 (0x1UL << USB_OTG_HPRT_PENCHNG_Pos) /*!< 0x00000008 */
+#define USB_OTG_HPRT_PENCHNG                     USB_OTG_HPRT_PENCHNG_Msk      /*!< Port enable/disable change */
+#define USB_OTG_HPRT_POCA_Pos                    (4U)                          
+#define USB_OTG_HPRT_POCA_Msk                    (0x1UL << USB_OTG_HPRT_POCA_Pos) /*!< 0x00000010 */
+#define USB_OTG_HPRT_POCA                        USB_OTG_HPRT_POCA_Msk         /*!< Port overcurrent active    */
+#define USB_OTG_HPRT_POCCHNG_Pos                 (5U)                          
+#define USB_OTG_HPRT_POCCHNG_Msk                 (0x1UL << USB_OTG_HPRT_POCCHNG_Pos) /*!< 0x00000020 */
+#define USB_OTG_HPRT_POCCHNG                     USB_OTG_HPRT_POCCHNG_Msk      /*!< Port overcurrent change    */
+#define USB_OTG_HPRT_PRES_Pos                    (6U)                          
+#define USB_OTG_HPRT_PRES_Msk                    (0x1UL << USB_OTG_HPRT_PRES_Pos) /*!< 0x00000040 */
+#define USB_OTG_HPRT_PRES                        USB_OTG_HPRT_PRES_Msk         /*!< Port resume                */
+#define USB_OTG_HPRT_PSUSP_Pos                   (7U)                          
+#define USB_OTG_HPRT_PSUSP_Msk                   (0x1UL << USB_OTG_HPRT_PSUSP_Pos) /*!< 0x00000080 */
+#define USB_OTG_HPRT_PSUSP                       USB_OTG_HPRT_PSUSP_Msk        /*!< Port suspend               */
+#define USB_OTG_HPRT_PRST_Pos                    (8U)                          
+#define USB_OTG_HPRT_PRST_Msk                    (0x1UL << USB_OTG_HPRT_PRST_Pos) /*!< 0x00000100 */
+#define USB_OTG_HPRT_PRST                        USB_OTG_HPRT_PRST_Msk         /*!< Port reset                 */
+
+#define USB_OTG_HPRT_PLSTS_Pos                   (10U)                         
+#define USB_OTG_HPRT_PLSTS_Msk                   (0x3UL << USB_OTG_HPRT_PLSTS_Pos) /*!< 0x00000C00 */
+#define USB_OTG_HPRT_PLSTS                       USB_OTG_HPRT_PLSTS_Msk        /*!< Port line status           */
+#define USB_OTG_HPRT_PLSTS_0                     (0x1UL << USB_OTG_HPRT_PLSTS_Pos) /*!< 0x00000400 */
+#define USB_OTG_HPRT_PLSTS_1                     (0x2UL << USB_OTG_HPRT_PLSTS_Pos) /*!< 0x00000800 */
+#define USB_OTG_HPRT_PPWR_Pos                    (12U)                         
+#define USB_OTG_HPRT_PPWR_Msk                    (0x1UL << USB_OTG_HPRT_PPWR_Pos) /*!< 0x00001000 */
+#define USB_OTG_HPRT_PPWR                        USB_OTG_HPRT_PPWR_Msk         /*!< Port power                 */
+
+#define USB_OTG_HPRT_PTCTL_Pos                   (13U)                         
+#define USB_OTG_HPRT_PTCTL_Msk                   (0xFUL << USB_OTG_HPRT_PTCTL_Pos) /*!< 0x0001E000 */
+#define USB_OTG_HPRT_PTCTL                       USB_OTG_HPRT_PTCTL_Msk        /*!< Port test control          */
+#define USB_OTG_HPRT_PTCTL_0                     (0x1UL << USB_OTG_HPRT_PTCTL_Pos) /*!< 0x00002000 */
+#define USB_OTG_HPRT_PTCTL_1                     (0x2UL << USB_OTG_HPRT_PTCTL_Pos) /*!< 0x00004000 */
+#define USB_OTG_HPRT_PTCTL_2                     (0x4UL << USB_OTG_HPRT_PTCTL_Pos) /*!< 0x00008000 */
+#define USB_OTG_HPRT_PTCTL_3                     (0x8UL << USB_OTG_HPRT_PTCTL_Pos) /*!< 0x00010000 */
+
+#define USB_OTG_HPRT_PSPD_Pos                    (17U)                         
+#define USB_OTG_HPRT_PSPD_Msk                    (0x3UL << USB_OTG_HPRT_PSPD_Pos) /*!< 0x00060000 */
+#define USB_OTG_HPRT_PSPD                        USB_OTG_HPRT_PSPD_Msk         /*!< Port speed                 */
+#define USB_OTG_HPRT_PSPD_0                      (0x1UL << USB_OTG_HPRT_PSPD_Pos) /*!< 0x00020000 */
+#define USB_OTG_HPRT_PSPD_1                      (0x2UL << USB_OTG_HPRT_PSPD_Pos) /*!< 0x00040000 */
+
+/********************  Bit definition for USB_OTG_DOEPEACHMSK1 register  ********************/
+#define USB_OTG_DOEPEACHMSK1_XFRCM_Pos           (0U)                          
+#define USB_OTG_DOEPEACHMSK1_XFRCM_Msk           (0x1UL << USB_OTG_DOEPEACHMSK1_XFRCM_Pos) /*!< 0x00000001 */
+#define USB_OTG_DOEPEACHMSK1_XFRCM               USB_OTG_DOEPEACHMSK1_XFRCM_Msk /*!< Transfer completed interrupt mask         */
+#define USB_OTG_DOEPEACHMSK1_EPDM_Pos            (1U)                          
+#define USB_OTG_DOEPEACHMSK1_EPDM_Msk            (0x1UL << USB_OTG_DOEPEACHMSK1_EPDM_Pos) /*!< 0x00000002 */
+#define USB_OTG_DOEPEACHMSK1_EPDM                USB_OTG_DOEPEACHMSK1_EPDM_Msk /*!< Endpoint disabled interrupt mask          */
+#define USB_OTG_DOEPEACHMSK1_TOM_Pos             (3U)                          
+#define USB_OTG_DOEPEACHMSK1_TOM_Msk             (0x1UL << USB_OTG_DOEPEACHMSK1_TOM_Pos) /*!< 0x00000008 */
+#define USB_OTG_DOEPEACHMSK1_TOM                 USB_OTG_DOEPEACHMSK1_TOM_Msk  /*!< Timeout condition mask                    */
+#define USB_OTG_DOEPEACHMSK1_ITTXFEMSK_Pos       (4U)                          
+#define USB_OTG_DOEPEACHMSK1_ITTXFEMSK_Msk       (0x1UL << USB_OTG_DOEPEACHMSK1_ITTXFEMSK_Pos) /*!< 0x00000010 */
+#define USB_OTG_DOEPEACHMSK1_ITTXFEMSK           USB_OTG_DOEPEACHMSK1_ITTXFEMSK_Msk /*!< IN token received when TxFIFO empty mask  */
+#define USB_OTG_DOEPEACHMSK1_INEPNMM_Pos         (5U)                          
+#define USB_OTG_DOEPEACHMSK1_INEPNMM_Msk         (0x1UL << USB_OTG_DOEPEACHMSK1_INEPNMM_Pos) /*!< 0x00000020 */
+#define USB_OTG_DOEPEACHMSK1_INEPNMM             USB_OTG_DOEPEACHMSK1_INEPNMM_Msk /*!< IN token received with EP mismatch mask   */
+#define USB_OTG_DOEPEACHMSK1_INEPNEM_Pos         (6U)                          
+#define USB_OTG_DOEPEACHMSK1_INEPNEM_Msk         (0x1UL << USB_OTG_DOEPEACHMSK1_INEPNEM_Pos) /*!< 0x00000040 */
+#define USB_OTG_DOEPEACHMSK1_INEPNEM             USB_OTG_DOEPEACHMSK1_INEPNEM_Msk /*!< IN endpoint NAK effective mask            */
+#define USB_OTG_DOEPEACHMSK1_TXFURM_Pos          (8U)                          
+#define USB_OTG_DOEPEACHMSK1_TXFURM_Msk          (0x1UL << USB_OTG_DOEPEACHMSK1_TXFURM_Pos) /*!< 0x00000100 */
+#define USB_OTG_DOEPEACHMSK1_TXFURM              USB_OTG_DOEPEACHMSK1_TXFURM_Msk /*!< OUT packet error mask                     */
+#define USB_OTG_DOEPEACHMSK1_BIM_Pos             (9U)                          
+#define USB_OTG_DOEPEACHMSK1_BIM_Msk             (0x1UL << USB_OTG_DOEPEACHMSK1_BIM_Pos) /*!< 0x00000200 */
+#define USB_OTG_DOEPEACHMSK1_BIM                 USB_OTG_DOEPEACHMSK1_BIM_Msk  /*!< BNA interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_BERRM_Pos           (12U)                         
+#define USB_OTG_DOEPEACHMSK1_BERRM_Msk           (0x1UL << USB_OTG_DOEPEACHMSK1_BERRM_Pos) /*!< 0x00001000 */
+#define USB_OTG_DOEPEACHMSK1_BERRM               USB_OTG_DOEPEACHMSK1_BERRM_Msk /*!< Bubble error interrupt mask               */
+#define USB_OTG_DOEPEACHMSK1_NAKM_Pos            (13U)                         
+#define USB_OTG_DOEPEACHMSK1_NAKM_Msk            (0x1UL << USB_OTG_DOEPEACHMSK1_NAKM_Pos) /*!< 0x00002000 */
+#define USB_OTG_DOEPEACHMSK1_NAKM                USB_OTG_DOEPEACHMSK1_NAKM_Msk /*!< NAK interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_NYETM_Pos           (14U)                         
+#define USB_OTG_DOEPEACHMSK1_NYETM_Msk           (0x1UL << USB_OTG_DOEPEACHMSK1_NYETM_Pos) /*!< 0x00004000 */
+#define USB_OTG_DOEPEACHMSK1_NYETM               USB_OTG_DOEPEACHMSK1_NYETM_Msk /*!< NYET interrupt mask                       */
+
+/********************  Bit definition for USB_OTG_HPTXFSIZ register  ********************/
+#define USB_OTG_HPTXFSIZ_PTXSA_Pos               (0U)                          
+#define USB_OTG_HPTXFSIZ_PTXSA_Msk               (0xFFFFUL << USB_OTG_HPTXFSIZ_PTXSA_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_HPTXFSIZ_PTXSA                   USB_OTG_HPTXFSIZ_PTXSA_Msk    /*!< Host periodic TxFIFO start address            */
+#define USB_OTG_HPTXFSIZ_PTXFD_Pos               (16U)                         
+#define USB_OTG_HPTXFSIZ_PTXFD_Msk               (0xFFFFUL << USB_OTG_HPTXFSIZ_PTXFD_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_HPTXFSIZ_PTXFD                   USB_OTG_HPTXFSIZ_PTXFD_Msk    /*!< Host periodic TxFIFO depth                    */
+
+/********************  Bit definition for USB_OTG_DIEPCTL register  ********************/
+#define USB_OTG_DIEPCTL_MPSIZ_Pos                (0U)                          
+#define USB_OTG_DIEPCTL_MPSIZ_Msk                (0x7FFUL << USB_OTG_DIEPCTL_MPSIZ_Pos) /*!< 0x000007FF */
+#define USB_OTG_DIEPCTL_MPSIZ                    USB_OTG_DIEPCTL_MPSIZ_Msk     /*!< Maximum packet size              */
+#define USB_OTG_DIEPCTL_USBAEP_Pos               (15U)                         
+#define USB_OTG_DIEPCTL_USBAEP_Msk               (0x1UL << USB_OTG_DIEPCTL_USBAEP_Pos) /*!< 0x00008000 */
+#define USB_OTG_DIEPCTL_USBAEP                   USB_OTG_DIEPCTL_USBAEP_Msk    /*!< USB active endpoint              */
+#define USB_OTG_DIEPCTL_EONUM_DPID_Pos           (16U)                         
+#define USB_OTG_DIEPCTL_EONUM_DPID_Msk           (0x1UL << USB_OTG_DIEPCTL_EONUM_DPID_Pos) /*!< 0x00010000 */
+#define USB_OTG_DIEPCTL_EONUM_DPID               USB_OTG_DIEPCTL_EONUM_DPID_Msk /*!< Even/odd frame                   */
+#define USB_OTG_DIEPCTL_NAKSTS_Pos               (17U)                         
+#define USB_OTG_DIEPCTL_NAKSTS_Msk               (0x1UL << USB_OTG_DIEPCTL_NAKSTS_Pos) /*!< 0x00020000 */
+#define USB_OTG_DIEPCTL_NAKSTS                   USB_OTG_DIEPCTL_NAKSTS_Msk    /*!< NAK status                       */
+
+#define USB_OTG_DIEPCTL_EPTYP_Pos                (18U)                         
+#define USB_OTG_DIEPCTL_EPTYP_Msk                (0x3UL << USB_OTG_DIEPCTL_EPTYP_Pos) /*!< 0x000C0000 */
+#define USB_OTG_DIEPCTL_EPTYP                    USB_OTG_DIEPCTL_EPTYP_Msk     /*!< Endpoint type                    */
+#define USB_OTG_DIEPCTL_EPTYP_0                  (0x1UL << USB_OTG_DIEPCTL_EPTYP_Pos) /*!< 0x00040000 */
+#define USB_OTG_DIEPCTL_EPTYP_1                  (0x2UL << USB_OTG_DIEPCTL_EPTYP_Pos) /*!< 0x00080000 */
+#define USB_OTG_DIEPCTL_STALL_Pos                (21U)                         
+#define USB_OTG_DIEPCTL_STALL_Msk                (0x1UL << USB_OTG_DIEPCTL_STALL_Pos) /*!< 0x00200000 */
+#define USB_OTG_DIEPCTL_STALL                    USB_OTG_DIEPCTL_STALL_Msk     /*!< STALL handshake                  */
+
+#define USB_OTG_DIEPCTL_TXFNUM_Pos               (22U)                         
+#define USB_OTG_DIEPCTL_TXFNUM_Msk               (0xFUL << USB_OTG_DIEPCTL_TXFNUM_Pos) /*!< 0x03C00000 */
+#define USB_OTG_DIEPCTL_TXFNUM                   USB_OTG_DIEPCTL_TXFNUM_Msk    /*!< TxFIFO number                    */
+#define USB_OTG_DIEPCTL_TXFNUM_0                 (0x1UL << USB_OTG_DIEPCTL_TXFNUM_Pos) /*!< 0x00400000 */
+#define USB_OTG_DIEPCTL_TXFNUM_1                 (0x2UL << USB_OTG_DIEPCTL_TXFNUM_Pos) /*!< 0x00800000 */
+#define USB_OTG_DIEPCTL_TXFNUM_2                 (0x4UL << USB_OTG_DIEPCTL_TXFNUM_Pos) /*!< 0x01000000 */
+#define USB_OTG_DIEPCTL_TXFNUM_3                 (0x8UL << USB_OTG_DIEPCTL_TXFNUM_Pos) /*!< 0x02000000 */
+#define USB_OTG_DIEPCTL_CNAK_Pos                 (26U)                         
+#define USB_OTG_DIEPCTL_CNAK_Msk                 (0x1UL << USB_OTG_DIEPCTL_CNAK_Pos) /*!< 0x04000000 */
+#define USB_OTG_DIEPCTL_CNAK                     USB_OTG_DIEPCTL_CNAK_Msk      /*!< Clear NAK                        */
+#define USB_OTG_DIEPCTL_SNAK_Pos                 (27U)                         
+#define USB_OTG_DIEPCTL_SNAK_Msk                 (0x1UL << USB_OTG_DIEPCTL_SNAK_Pos) /*!< 0x08000000 */
+#define USB_OTG_DIEPCTL_SNAK                     USB_OTG_DIEPCTL_SNAK_Msk      /*!< Set NAK */
+#define USB_OTG_DIEPCTL_SD0PID_SEVNFRM_Pos       (28U)                         
+#define USB_OTG_DIEPCTL_SD0PID_SEVNFRM_Msk       (0x1UL << USB_OTG_DIEPCTL_SD0PID_SEVNFRM_Pos) /*!< 0x10000000 */
+#define USB_OTG_DIEPCTL_SD0PID_SEVNFRM           USB_OTG_DIEPCTL_SD0PID_SEVNFRM_Msk /*!< Set DATA0 PID                    */
+#define USB_OTG_DIEPCTL_SODDFRM_Pos              (29U)                         
+#define USB_OTG_DIEPCTL_SODDFRM_Msk              (0x1UL << USB_OTG_DIEPCTL_SODDFRM_Pos) /*!< 0x20000000 */
+#define USB_OTG_DIEPCTL_SODDFRM                  USB_OTG_DIEPCTL_SODDFRM_Msk   /*!< Set odd frame                    */
+#define USB_OTG_DIEPCTL_EPDIS_Pos                (30U)                         
+#define USB_OTG_DIEPCTL_EPDIS_Msk                (0x1UL << USB_OTG_DIEPCTL_EPDIS_Pos) /*!< 0x40000000 */
+#define USB_OTG_DIEPCTL_EPDIS                    USB_OTG_DIEPCTL_EPDIS_Msk     /*!< Endpoint disable                 */
+#define USB_OTG_DIEPCTL_EPENA_Pos                (31U)                         
+#define USB_OTG_DIEPCTL_EPENA_Msk                (0x1UL << USB_OTG_DIEPCTL_EPENA_Pos) /*!< 0x80000000 */
+#define USB_OTG_DIEPCTL_EPENA                    USB_OTG_DIEPCTL_EPENA_Msk     /*!< Endpoint enable                  */
+
+/********************  Bit definition for USB_OTG_HCCHAR register  ********************/
+#define USB_OTG_HCCHAR_MPSIZ_Pos                 (0U)                          
+#define USB_OTG_HCCHAR_MPSIZ_Msk                 (0x7FFUL << USB_OTG_HCCHAR_MPSIZ_Pos) /*!< 0x000007FF */
+#define USB_OTG_HCCHAR_MPSIZ                     USB_OTG_HCCHAR_MPSIZ_Msk      /*!< Maximum packet size */
+
+#define USB_OTG_HCCHAR_EPNUM_Pos                 (11U)                         
+#define USB_OTG_HCCHAR_EPNUM_Msk                 (0xFUL << USB_OTG_HCCHAR_EPNUM_Pos) /*!< 0x00007800 */
+#define USB_OTG_HCCHAR_EPNUM                     USB_OTG_HCCHAR_EPNUM_Msk      /*!< Endpoint number */
+#define USB_OTG_HCCHAR_EPNUM_0                   (0x1UL << USB_OTG_HCCHAR_EPNUM_Pos) /*!< 0x00000800 */
+#define USB_OTG_HCCHAR_EPNUM_1                   (0x2UL << USB_OTG_HCCHAR_EPNUM_Pos) /*!< 0x00001000 */
+#define USB_OTG_HCCHAR_EPNUM_2                   (0x4UL << USB_OTG_HCCHAR_EPNUM_Pos) /*!< 0x00002000 */
+#define USB_OTG_HCCHAR_EPNUM_3                   (0x8UL << USB_OTG_HCCHAR_EPNUM_Pos) /*!< 0x00004000 */
+#define USB_OTG_HCCHAR_EPDIR_Pos                 (15U)                         
+#define USB_OTG_HCCHAR_EPDIR_Msk                 (0x1UL << USB_OTG_HCCHAR_EPDIR_Pos) /*!< 0x00008000 */
+#define USB_OTG_HCCHAR_EPDIR                     USB_OTG_HCCHAR_EPDIR_Msk      /*!< Endpoint direction */
+#define USB_OTG_HCCHAR_LSDEV_Pos                 (17U)                         
+#define USB_OTG_HCCHAR_LSDEV_Msk                 (0x1UL << USB_OTG_HCCHAR_LSDEV_Pos) /*!< 0x00020000 */
+#define USB_OTG_HCCHAR_LSDEV                     USB_OTG_HCCHAR_LSDEV_Msk      /*!< Low-speed device */
+
+#define USB_OTG_HCCHAR_EPTYP_Pos                 (18U)                         
+#define USB_OTG_HCCHAR_EPTYP_Msk                 (0x3UL << USB_OTG_HCCHAR_EPTYP_Pos) /*!< 0x000C0000 */
+#define USB_OTG_HCCHAR_EPTYP                     USB_OTG_HCCHAR_EPTYP_Msk      /*!< Endpoint type */
+#define USB_OTG_HCCHAR_EPTYP_0                   (0x1UL << USB_OTG_HCCHAR_EPTYP_Pos) /*!< 0x00040000 */
+#define USB_OTG_HCCHAR_EPTYP_1                   (0x2UL << USB_OTG_HCCHAR_EPTYP_Pos) /*!< 0x00080000 */
+
+#define USB_OTG_HCCHAR_MC_Pos                    (20U)                         
+#define USB_OTG_HCCHAR_MC_Msk                    (0x3UL << USB_OTG_HCCHAR_MC_Pos) /*!< 0x00300000 */
+#define USB_OTG_HCCHAR_MC                        USB_OTG_HCCHAR_MC_Msk         /*!< Multi Count (MC) / Error Count (EC) */
+#define USB_OTG_HCCHAR_MC_0                      (0x1UL << USB_OTG_HCCHAR_MC_Pos) /*!< 0x00100000 */
+#define USB_OTG_HCCHAR_MC_1                      (0x2UL << USB_OTG_HCCHAR_MC_Pos) /*!< 0x00200000 */
+
+#define USB_OTG_HCCHAR_DAD_Pos                   (22U)                         
+#define USB_OTG_HCCHAR_DAD_Msk                   (0x7FUL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x1FC00000 */
+#define USB_OTG_HCCHAR_DAD                       USB_OTG_HCCHAR_DAD_Msk        /*!< Device address */
+#define USB_OTG_HCCHAR_DAD_0                     (0x01UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x00400000 */
+#define USB_OTG_HCCHAR_DAD_1                     (0x02UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x00800000 */
+#define USB_OTG_HCCHAR_DAD_2                     (0x04UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x01000000 */
+#define USB_OTG_HCCHAR_DAD_3                     (0x08UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x02000000 */
+#define USB_OTG_HCCHAR_DAD_4                     (0x10UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x04000000 */
+#define USB_OTG_HCCHAR_DAD_5                     (0x20UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x08000000 */
+#define USB_OTG_HCCHAR_DAD_6                     (0x40UL << USB_OTG_HCCHAR_DAD_Pos) /*!< 0x10000000 */
+#define USB_OTG_HCCHAR_ODDFRM_Pos                (29U)                         
+#define USB_OTG_HCCHAR_ODDFRM_Msk                (0x1UL << USB_OTG_HCCHAR_ODDFRM_Pos) /*!< 0x20000000 */
+#define USB_OTG_HCCHAR_ODDFRM                    USB_OTG_HCCHAR_ODDFRM_Msk     /*!< Odd frame */
+#define USB_OTG_HCCHAR_CHDIS_Pos                 (30U)                         
+#define USB_OTG_HCCHAR_CHDIS_Msk                 (0x1UL << USB_OTG_HCCHAR_CHDIS_Pos) /*!< 0x40000000 */
+#define USB_OTG_HCCHAR_CHDIS                     USB_OTG_HCCHAR_CHDIS_Msk      /*!< Channel disable */
+#define USB_OTG_HCCHAR_CHENA_Pos                 (31U)                         
+#define USB_OTG_HCCHAR_CHENA_Msk                 (0x1UL << USB_OTG_HCCHAR_CHENA_Pos) /*!< 0x80000000 */
+#define USB_OTG_HCCHAR_CHENA                     USB_OTG_HCCHAR_CHENA_Msk      /*!< Channel enable */
+
+/********************  Bit definition for USB_OTG_HCSPLT register  ********************/
+
+#define USB_OTG_HCSPLT_PRTADDR_Pos               (0U)                          
+#define USB_OTG_HCSPLT_PRTADDR_Msk               (0x7FUL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x0000007F */
+#define USB_OTG_HCSPLT_PRTADDR                   USB_OTG_HCSPLT_PRTADDR_Msk    /*!< Port address */
+#define USB_OTG_HCSPLT_PRTADDR_0                 (0x01UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000001 */
+#define USB_OTG_HCSPLT_PRTADDR_1                 (0x02UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000002 */
+#define USB_OTG_HCSPLT_PRTADDR_2                 (0x04UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000004 */
+#define USB_OTG_HCSPLT_PRTADDR_3                 (0x08UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000008 */
+#define USB_OTG_HCSPLT_PRTADDR_4                 (0x10UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000010 */
+#define USB_OTG_HCSPLT_PRTADDR_5                 (0x20UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000020 */
+#define USB_OTG_HCSPLT_PRTADDR_6                 (0x40UL << USB_OTG_HCSPLT_PRTADDR_Pos) /*!< 0x00000040 */
+
+#define USB_OTG_HCSPLT_HUBADDR_Pos               (7U)                          
+#define USB_OTG_HCSPLT_HUBADDR_Msk               (0x7FUL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00003F80 */
+#define USB_OTG_HCSPLT_HUBADDR                   USB_OTG_HCSPLT_HUBADDR_Msk    /*!< Hub address */
+#define USB_OTG_HCSPLT_HUBADDR_0                 (0x01UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00000080 */
+#define USB_OTG_HCSPLT_HUBADDR_1                 (0x02UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00000100 */
+#define USB_OTG_HCSPLT_HUBADDR_2                 (0x04UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00000200 */
+#define USB_OTG_HCSPLT_HUBADDR_3                 (0x08UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00000400 */
+#define USB_OTG_HCSPLT_HUBADDR_4                 (0x10UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00000800 */
+#define USB_OTG_HCSPLT_HUBADDR_5                 (0x20UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00001000 */
+#define USB_OTG_HCSPLT_HUBADDR_6                 (0x40UL << USB_OTG_HCSPLT_HUBADDR_Pos) /*!< 0x00002000 */
+
+#define USB_OTG_HCSPLT_XACTPOS_Pos               (14U)                         
+#define USB_OTG_HCSPLT_XACTPOS_Msk               (0x3UL << USB_OTG_HCSPLT_XACTPOS_Pos) /*!< 0x0000C000 */
+#define USB_OTG_HCSPLT_XACTPOS                   USB_OTG_HCSPLT_XACTPOS_Msk    /*!< XACTPOS */
+#define USB_OTG_HCSPLT_XACTPOS_0                 (0x1UL << USB_OTG_HCSPLT_XACTPOS_Pos) /*!< 0x00004000 */
+#define USB_OTG_HCSPLT_XACTPOS_1                 (0x2UL << USB_OTG_HCSPLT_XACTPOS_Pos) /*!< 0x00008000 */
+#define USB_OTG_HCSPLT_COMPLSPLT_Pos             (16U)                         
+#define USB_OTG_HCSPLT_COMPLSPLT_Msk             (0x1UL << USB_OTG_HCSPLT_COMPLSPLT_Pos) /*!< 0x00010000 */
+#define USB_OTG_HCSPLT_COMPLSPLT                 USB_OTG_HCSPLT_COMPLSPLT_Msk  /*!< Do complete split */
+#define USB_OTG_HCSPLT_SPLITEN_Pos               (31U)                         
+#define USB_OTG_HCSPLT_SPLITEN_Msk               (0x1UL << USB_OTG_HCSPLT_SPLITEN_Pos) /*!< 0x80000000 */
+#define USB_OTG_HCSPLT_SPLITEN                   USB_OTG_HCSPLT_SPLITEN_Msk    /*!< Split enable */
+
+/********************  Bit definition for USB_OTG_HCINT register  ********************/
+#define USB_OTG_HCINT_XFRC_Pos                   (0U)                          
+#define USB_OTG_HCINT_XFRC_Msk                   (0x1UL << USB_OTG_HCINT_XFRC_Pos) /*!< 0x00000001 */
+#define USB_OTG_HCINT_XFRC                       USB_OTG_HCINT_XFRC_Msk        /*!< Transfer completed */
+#define USB_OTG_HCINT_CHH_Pos                    (1U)                          
+#define USB_OTG_HCINT_CHH_Msk                    (0x1UL << USB_OTG_HCINT_CHH_Pos) /*!< 0x00000002 */
+#define USB_OTG_HCINT_CHH                        USB_OTG_HCINT_CHH_Msk         /*!< Channel halted */
+#define USB_OTG_HCINT_AHBERR_Pos                 (2U)                          
+#define USB_OTG_HCINT_AHBERR_Msk                 (0x1UL << USB_OTG_HCINT_AHBERR_Pos) /*!< 0x00000004 */
+#define USB_OTG_HCINT_AHBERR                     USB_OTG_HCINT_AHBERR_Msk      /*!< AHB error */
+#define USB_OTG_HCINT_STALL_Pos                  (3U)                          
+#define USB_OTG_HCINT_STALL_Msk                  (0x1UL << USB_OTG_HCINT_STALL_Pos) /*!< 0x00000008 */
+#define USB_OTG_HCINT_STALL                      USB_OTG_HCINT_STALL_Msk       /*!< STALL response received interrupt */
+#define USB_OTG_HCINT_NAK_Pos                    (4U)                          
+#define USB_OTG_HCINT_NAK_Msk                    (0x1UL << USB_OTG_HCINT_NAK_Pos) /*!< 0x00000010 */
+#define USB_OTG_HCINT_NAK                        USB_OTG_HCINT_NAK_Msk         /*!< NAK response received interrupt */
+#define USB_OTG_HCINT_ACK_Pos                    (5U)                          
+#define USB_OTG_HCINT_ACK_Msk                    (0x1UL << USB_OTG_HCINT_ACK_Pos) /*!< 0x00000020 */
+#define USB_OTG_HCINT_ACK                        USB_OTG_HCINT_ACK_Msk         /*!< ACK response received/transmitted interrupt */
+#define USB_OTG_HCINT_NYET_Pos                   (6U)                          
+#define USB_OTG_HCINT_NYET_Msk                   (0x1UL << USB_OTG_HCINT_NYET_Pos) /*!< 0x00000040 */
+#define USB_OTG_HCINT_NYET                       USB_OTG_HCINT_NYET_Msk        /*!< Response received interrupt */
+#define USB_OTG_HCINT_TXERR_Pos                  (7U)                          
+#define USB_OTG_HCINT_TXERR_Msk                  (0x1UL << USB_OTG_HCINT_TXERR_Pos) /*!< 0x00000080 */
+#define USB_OTG_HCINT_TXERR                      USB_OTG_HCINT_TXERR_Msk       /*!< Transaction error */
+#define USB_OTG_HCINT_BBERR_Pos                  (8U)                          
+#define USB_OTG_HCINT_BBERR_Msk                  (0x1UL << USB_OTG_HCINT_BBERR_Pos) /*!< 0x00000100 */
+#define USB_OTG_HCINT_BBERR                      USB_OTG_HCINT_BBERR_Msk       /*!< Babble error */
+#define USB_OTG_HCINT_FRMOR_Pos                  (9U)                          
+#define USB_OTG_HCINT_FRMOR_Msk                  (0x1UL << USB_OTG_HCINT_FRMOR_Pos) /*!< 0x00000200 */
+#define USB_OTG_HCINT_FRMOR                      USB_OTG_HCINT_FRMOR_Msk       /*!< Frame overrun */
+#define USB_OTG_HCINT_DTERR_Pos                  (10U)                         
+#define USB_OTG_HCINT_DTERR_Msk                  (0x1UL << USB_OTG_HCINT_DTERR_Pos) /*!< 0x00000400 */
+#define USB_OTG_HCINT_DTERR                      USB_OTG_HCINT_DTERR_Msk       /*!< Data toggle error */
+
+/********************  Bit definition for USB_OTG_DIEPINT register  ********************/
+#define USB_OTG_DIEPINT_XFRC_Pos                 (0U)                          
+#define USB_OTG_DIEPINT_XFRC_Msk                 (0x1UL << USB_OTG_DIEPINT_XFRC_Pos) /*!< 0x00000001 */
+#define USB_OTG_DIEPINT_XFRC                     USB_OTG_DIEPINT_XFRC_Msk      /*!< Transfer completed interrupt */
+#define USB_OTG_DIEPINT_EPDISD_Pos               (1U)                          
+#define USB_OTG_DIEPINT_EPDISD_Msk               (0x1UL << USB_OTG_DIEPINT_EPDISD_Pos) /*!< 0x00000002 */
+#define USB_OTG_DIEPINT_EPDISD                   USB_OTG_DIEPINT_EPDISD_Msk    /*!< Endpoint disabled interrupt */
+#define USB_OTG_DIEPINT_AHBERR_Pos               (2U)
+#define USB_OTG_DIEPINT_AHBERR_Msk               (0x1UL << USB_OTG_DIEPINT_AHBERR_Pos) /*!< 0x00000004 */
+#define USB_OTG_DIEPINT_AHBERR                   USB_OTG_DIEPINT_AHBERR_Msk   /*!< AHB Error (AHBErr) during an IN transaction */
+#define USB_OTG_DIEPINT_TOC_Pos                  (3U)                          
+#define USB_OTG_DIEPINT_TOC_Msk                  (0x1UL << USB_OTG_DIEPINT_TOC_Pos) /*!< 0x00000008 */
+#define USB_OTG_DIEPINT_TOC                      USB_OTG_DIEPINT_TOC_Msk       /*!< Timeout condition */
+#define USB_OTG_DIEPINT_ITTXFE_Pos               (4U)                          
+#define USB_OTG_DIEPINT_ITTXFE_Msk               (0x1UL << USB_OTG_DIEPINT_ITTXFE_Pos) /*!< 0x00000010 */
+#define USB_OTG_DIEPINT_ITTXFE                   USB_OTG_DIEPINT_ITTXFE_Msk    /*!< IN token received when TxFIFO is empty */
+#define USB_OTG_DIEPINT_INEPNM_Pos               (5U)
+#define USB_OTG_DIEPINT_INEPNM_Msk               (0x1UL << USB_OTG_DIEPINT_INEPNM_Pos) /*!< 0x00000004 */
+#define USB_OTG_DIEPINT_INEPNM                   USB_OTG_DIEPINT_INEPNM_Msk   /*!< IN token received with EP mismatch */
+#define USB_OTG_DIEPINT_INEPNE_Pos               (6U)                          
+#define USB_OTG_DIEPINT_INEPNE_Msk               (0x1UL << USB_OTG_DIEPINT_INEPNE_Pos) /*!< 0x00000040 */
+#define USB_OTG_DIEPINT_INEPNE                   USB_OTG_DIEPINT_INEPNE_Msk    /*!< IN endpoint NAK effective */
+#define USB_OTG_DIEPINT_TXFE_Pos                 (7U)                          
+#define USB_OTG_DIEPINT_TXFE_Msk                 (0x1UL << USB_OTG_DIEPINT_TXFE_Pos) /*!< 0x00000080 */
+#define USB_OTG_DIEPINT_TXFE                     USB_OTG_DIEPINT_TXFE_Msk      /*!< Transmit FIFO empty */
+#define USB_OTG_DIEPINT_TXFIFOUDRN_Pos           (8U)                          
+#define USB_OTG_DIEPINT_TXFIFOUDRN_Msk           (0x1UL << USB_OTG_DIEPINT_TXFIFOUDRN_Pos) /*!< 0x00000100 */
+#define USB_OTG_DIEPINT_TXFIFOUDRN               USB_OTG_DIEPINT_TXFIFOUDRN_Msk /*!< Transmit Fifo Underrun */
+#define USB_OTG_DIEPINT_BNA_Pos                  (9U)                          
+#define USB_OTG_DIEPINT_BNA_Msk                  (0x1UL << USB_OTG_DIEPINT_BNA_Pos) /*!< 0x00000200 */
+#define USB_OTG_DIEPINT_BNA                      USB_OTG_DIEPINT_BNA_Msk       /*!< Buffer not available interrupt */
+#define USB_OTG_DIEPINT_PKTDRPSTS_Pos            (11U)                         
+#define USB_OTG_DIEPINT_PKTDRPSTS_Msk            (0x1UL << USB_OTG_DIEPINT_PKTDRPSTS_Pos) /*!< 0x00000800 */
+#define USB_OTG_DIEPINT_PKTDRPSTS                USB_OTG_DIEPINT_PKTDRPSTS_Msk /*!< Packet dropped status */
+#define USB_OTG_DIEPINT_BERR_Pos                 (12U)                         
+#define USB_OTG_DIEPINT_BERR_Msk                 (0x1UL << USB_OTG_DIEPINT_BERR_Pos) /*!< 0x00001000 */
+#define USB_OTG_DIEPINT_BERR                     USB_OTG_DIEPINT_BERR_Msk      /*!< Babble error interrupt */
+#define USB_OTG_DIEPINT_NAK_Pos                  (13U)                         
+#define USB_OTG_DIEPINT_NAK_Msk                  (0x1UL << USB_OTG_DIEPINT_NAK_Pos) /*!< 0x00002000 */
+#define USB_OTG_DIEPINT_NAK                      USB_OTG_DIEPINT_NAK_Msk       /*!< NAK interrupt */
+
+/********************  Bit definition forUSB_OTG_HCINTMSK register  ********************/
+#define USB_OTG_HCINTMSK_XFRCM_Pos               (0U)                          
+#define USB_OTG_HCINTMSK_XFRCM_Msk               (0x1UL << USB_OTG_HCINTMSK_XFRCM_Pos) /*!< 0x00000001 */
+#define USB_OTG_HCINTMSK_XFRCM                   USB_OTG_HCINTMSK_XFRCM_Msk    /*!< Transfer completed mask */
+#define USB_OTG_HCINTMSK_CHHM_Pos                (1U)                          
+#define USB_OTG_HCINTMSK_CHHM_Msk                (0x1UL << USB_OTG_HCINTMSK_CHHM_Pos) /*!< 0x00000002 */
+#define USB_OTG_HCINTMSK_CHHM                    USB_OTG_HCINTMSK_CHHM_Msk     /*!< Channel halted mask */
+#define USB_OTG_HCINTMSK_AHBERR_Pos              (2U)                          
+#define USB_OTG_HCINTMSK_AHBERR_Msk              (0x1UL << USB_OTG_HCINTMSK_AHBERR_Pos) /*!< 0x00000004 */
+#define USB_OTG_HCINTMSK_AHBERR                  USB_OTG_HCINTMSK_AHBERR_Msk   /*!< AHB error */
+#define USB_OTG_HCINTMSK_STALLM_Pos              (3U)                          
+#define USB_OTG_HCINTMSK_STALLM_Msk              (0x1UL << USB_OTG_HCINTMSK_STALLM_Pos) /*!< 0x00000008 */
+#define USB_OTG_HCINTMSK_STALLM                  USB_OTG_HCINTMSK_STALLM_Msk   /*!< STALL response received interrupt mask */
+#define USB_OTG_HCINTMSK_NAKM_Pos                (4U)                          
+#define USB_OTG_HCINTMSK_NAKM_Msk                (0x1UL << USB_OTG_HCINTMSK_NAKM_Pos) /*!< 0x00000010 */
+#define USB_OTG_HCINTMSK_NAKM                    USB_OTG_HCINTMSK_NAKM_Msk     /*!< NAK response received interrupt mask */
+#define USB_OTG_HCINTMSK_ACKM_Pos                (5U)                          
+#define USB_OTG_HCINTMSK_ACKM_Msk                (0x1UL << USB_OTG_HCINTMSK_ACKM_Pos) /*!< 0x00000020 */
+#define USB_OTG_HCINTMSK_ACKM                    USB_OTG_HCINTMSK_ACKM_Msk     /*!< ACK response received/transmitted interrupt mask */
+#define USB_OTG_HCINTMSK_NYET_Pos                (6U)                          
+#define USB_OTG_HCINTMSK_NYET_Msk                (0x1UL << USB_OTG_HCINTMSK_NYET_Pos) /*!< 0x00000040 */
+#define USB_OTG_HCINTMSK_NYET                    USB_OTG_HCINTMSK_NYET_Msk     /*!< response received interrupt mask */
+#define USB_OTG_HCINTMSK_TXERRM_Pos              (7U)                          
+#define USB_OTG_HCINTMSK_TXERRM_Msk              (0x1UL << USB_OTG_HCINTMSK_TXERRM_Pos) /*!< 0x00000080 */
+#define USB_OTG_HCINTMSK_TXERRM                  USB_OTG_HCINTMSK_TXERRM_Msk   /*!< Transaction error mask */
+#define USB_OTG_HCINTMSK_BBERRM_Pos              (8U)                          
+#define USB_OTG_HCINTMSK_BBERRM_Msk              (0x1UL << USB_OTG_HCINTMSK_BBERRM_Pos) /*!< 0x00000100 */
+#define USB_OTG_HCINTMSK_BBERRM                  USB_OTG_HCINTMSK_BBERRM_Msk   /*!< Babble error mask */
+#define USB_OTG_HCINTMSK_FRMORM_Pos              (9U)                          
+#define USB_OTG_HCINTMSK_FRMORM_Msk              (0x1UL << USB_OTG_HCINTMSK_FRMORM_Pos) /*!< 0x00000200 */
+#define USB_OTG_HCINTMSK_FRMORM                  USB_OTG_HCINTMSK_FRMORM_Msk   /*!< Frame overrun mask */
+#define USB_OTG_HCINTMSK_DTERRM_Pos              (10U)                         
+#define USB_OTG_HCINTMSK_DTERRM_Msk              (0x1UL << USB_OTG_HCINTMSK_DTERRM_Pos) /*!< 0x00000400 */
+#define USB_OTG_HCINTMSK_DTERRM                  USB_OTG_HCINTMSK_DTERRM_Msk   /*!< Data toggle error mask */
+
+/********************  Bit definition for USB_OTG_DIEPTSIZ register  ********************/
+
+#define USB_OTG_DIEPTSIZ_XFRSIZ_Pos              (0U)                          
+#define USB_OTG_DIEPTSIZ_XFRSIZ_Msk              (0x7FFFFUL << USB_OTG_DIEPTSIZ_XFRSIZ_Pos) /*!< 0x0007FFFF */
+#define USB_OTG_DIEPTSIZ_XFRSIZ                  USB_OTG_DIEPTSIZ_XFRSIZ_Msk   /*!< Transfer size */
+#define USB_OTG_DIEPTSIZ_PKTCNT_Pos              (19U)                         
+#define USB_OTG_DIEPTSIZ_PKTCNT_Msk              (0x3FFUL << USB_OTG_DIEPTSIZ_PKTCNT_Pos) /*!< 0x1FF80000 */
+#define USB_OTG_DIEPTSIZ_PKTCNT                  USB_OTG_DIEPTSIZ_PKTCNT_Msk   /*!< Packet count */
+#define USB_OTG_DIEPTSIZ_MULCNT_Pos              (29U)                         
+#define USB_OTG_DIEPTSIZ_MULCNT_Msk              (0x3UL << USB_OTG_DIEPTSIZ_MULCNT_Pos) /*!< 0x60000000 */
+#define USB_OTG_DIEPTSIZ_MULCNT                  USB_OTG_DIEPTSIZ_MULCNT_Msk   /*!< Packet count */
+/********************  Bit definition for USB_OTG_HCTSIZ register  ********************/
+#define USB_OTG_HCTSIZ_XFRSIZ_Pos                (0U)                          
+#define USB_OTG_HCTSIZ_XFRSIZ_Msk                (0x7FFFFUL << USB_OTG_HCTSIZ_XFRSIZ_Pos) /*!< 0x0007FFFF */
+#define USB_OTG_HCTSIZ_XFRSIZ                    USB_OTG_HCTSIZ_XFRSIZ_Msk     /*!< Transfer size */
+#define USB_OTG_HCTSIZ_PKTCNT_Pos                (19U)                         
+#define USB_OTG_HCTSIZ_PKTCNT_Msk                (0x3FFUL << USB_OTG_HCTSIZ_PKTCNT_Pos) /*!< 0x1FF80000 */
+#define USB_OTG_HCTSIZ_PKTCNT                    USB_OTG_HCTSIZ_PKTCNT_Msk     /*!< Packet count */
+#define USB_OTG_HCTSIZ_DOPING_Pos                (31U)                         
+#define USB_OTG_HCTSIZ_DOPING_Msk                (0x1UL << USB_OTG_HCTSIZ_DOPING_Pos) /*!< 0x80000000 */
+#define USB_OTG_HCTSIZ_DOPING                    USB_OTG_HCTSIZ_DOPING_Msk     /*!< Do PING */
+#define USB_OTG_HCTSIZ_DPID_Pos                  (29U)                         
+#define USB_OTG_HCTSIZ_DPID_Msk                  (0x3UL << USB_OTG_HCTSIZ_DPID_Pos) /*!< 0x60000000 */
+#define USB_OTG_HCTSIZ_DPID                      USB_OTG_HCTSIZ_DPID_Msk       /*!< Data PID */
+#define USB_OTG_HCTSIZ_DPID_0                    (0x1UL << USB_OTG_HCTSIZ_DPID_Pos) /*!< 0x20000000 */
+#define USB_OTG_HCTSIZ_DPID_1                    (0x2UL << USB_OTG_HCTSIZ_DPID_Pos) /*!< 0x40000000 */
+
+/********************  Bit definition for USB_OTG_DIEPDMA register  ********************/
+#define USB_OTG_DIEPDMA_DMAADDR_Pos              (0U)                          
+#define USB_OTG_DIEPDMA_DMAADDR_Msk              (0xFFFFFFFFUL << USB_OTG_DIEPDMA_DMAADDR_Pos) /*!< 0xFFFFFFFF */
+#define USB_OTG_DIEPDMA_DMAADDR                  USB_OTG_DIEPDMA_DMAADDR_Msk   /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_HCDMA register  ********************/
+#define USB_OTG_HCDMA_DMAADDR_Pos                (0U)                          
+#define USB_OTG_HCDMA_DMAADDR_Msk                (0xFFFFFFFFUL << USB_OTG_HCDMA_DMAADDR_Pos) /*!< 0xFFFFFFFF */
+#define USB_OTG_HCDMA_DMAADDR                    USB_OTG_HCDMA_DMAADDR_Msk     /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_DTXFSTS register  ********************/
+#define USB_OTG_DTXFSTS_INEPTFSAV_Pos            (0U)                          
+#define USB_OTG_DTXFSTS_INEPTFSAV_Msk            (0xFFFFUL << USB_OTG_DTXFSTS_INEPTFSAV_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_DTXFSTS_INEPTFSAV                USB_OTG_DTXFSTS_INEPTFSAV_Msk /*!< IN endpoint TxFIFO space available */
+
+/********************  Bit definition for USB_OTG_DIEPTXF register  ********************/
+#define USB_OTG_DIEPTXF_INEPTXSA_Pos             (0U)                          
+#define USB_OTG_DIEPTXF_INEPTXSA_Msk             (0xFFFFUL << USB_OTG_DIEPTXF_INEPTXSA_Pos) /*!< 0x0000FFFF */
+#define USB_OTG_DIEPTXF_INEPTXSA                 USB_OTG_DIEPTXF_INEPTXSA_Msk  /*!< IN endpoint FIFOx transmit RAM start address */
+#define USB_OTG_DIEPTXF_INEPTXFD_Pos             (16U)                         
+#define USB_OTG_DIEPTXF_INEPTXFD_Msk             (0xFFFFUL << USB_OTG_DIEPTXF_INEPTXFD_Pos) /*!< 0xFFFF0000 */
+#define USB_OTG_DIEPTXF_INEPTXFD                 USB_OTG_DIEPTXF_INEPTXFD_Msk  /*!< IN endpoint TxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DOEPCTL register  ********************/
+
+#define USB_OTG_DOEPCTL_MPSIZ_Pos                (0U)                          
+#define USB_OTG_DOEPCTL_MPSIZ_Msk                (0x7FFUL << USB_OTG_DOEPCTL_MPSIZ_Pos) /*!< 0x000007FF */
+#define USB_OTG_DOEPCTL_MPSIZ                    USB_OTG_DOEPCTL_MPSIZ_Msk     /*!< Maximum packet size */          /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_USBAEP_Pos               (15U)                         
+#define USB_OTG_DOEPCTL_USBAEP_Msk               (0x1UL << USB_OTG_DOEPCTL_USBAEP_Pos) /*!< 0x00008000 */
+#define USB_OTG_DOEPCTL_USBAEP                   USB_OTG_DOEPCTL_USBAEP_Msk    /*!< USB active endpoint */
+#define USB_OTG_DOEPCTL_NAKSTS_Pos               (17U)                         
+#define USB_OTG_DOEPCTL_NAKSTS_Msk               (0x1UL << USB_OTG_DOEPCTL_NAKSTS_Pos) /*!< 0x00020000 */
+#define USB_OTG_DOEPCTL_NAKSTS                   USB_OTG_DOEPCTL_NAKSTS_Msk    /*!< NAK status */
+#define USB_OTG_DOEPCTL_SD0PID_SEVNFRM_Pos       (28U)                         
+#define USB_OTG_DOEPCTL_SD0PID_SEVNFRM_Msk       (0x1UL << USB_OTG_DOEPCTL_SD0PID_SEVNFRM_Pos) /*!< 0x10000000 */
+#define USB_OTG_DOEPCTL_SD0PID_SEVNFRM           USB_OTG_DOEPCTL_SD0PID_SEVNFRM_Msk /*!< Set DATA0 PID */
+#define USB_OTG_DOEPCTL_SODDFRM_Pos              (29U)                         
+#define USB_OTG_DOEPCTL_SODDFRM_Msk              (0x1UL << USB_OTG_DOEPCTL_SODDFRM_Pos) /*!< 0x20000000 */
+#define USB_OTG_DOEPCTL_SODDFRM                  USB_OTG_DOEPCTL_SODDFRM_Msk   /*!< Set odd frame */
+#define USB_OTG_DOEPCTL_EPTYP_Pos                (18U)                         
+#define USB_OTG_DOEPCTL_EPTYP_Msk                (0x3UL << USB_OTG_DOEPCTL_EPTYP_Pos) /*!< 0x000C0000 */
+#define USB_OTG_DOEPCTL_EPTYP                    USB_OTG_DOEPCTL_EPTYP_Msk     /*!< Endpoint type */
+#define USB_OTG_DOEPCTL_EPTYP_0                  (0x1UL << USB_OTG_DOEPCTL_EPTYP_Pos) /*!< 0x00040000 */
+#define USB_OTG_DOEPCTL_EPTYP_1                  (0x2UL << USB_OTG_DOEPCTL_EPTYP_Pos) /*!< 0x00080000 */
+#define USB_OTG_DOEPCTL_SNPM_Pos                 (20U)                         
+#define USB_OTG_DOEPCTL_SNPM_Msk                 (0x1UL << USB_OTG_DOEPCTL_SNPM_Pos) /*!< 0x00100000 */
+#define USB_OTG_DOEPCTL_SNPM                     USB_OTG_DOEPCTL_SNPM_Msk      /*!< Snoop mode */
+#define USB_OTG_DOEPCTL_STALL_Pos                (21U)                         
+#define USB_OTG_DOEPCTL_STALL_Msk                (0x1UL << USB_OTG_DOEPCTL_STALL_Pos) /*!< 0x00200000 */
+#define USB_OTG_DOEPCTL_STALL                    USB_OTG_DOEPCTL_STALL_Msk     /*!< STALL handshake */
+#define USB_OTG_DOEPCTL_CNAK_Pos                 (26U)                         
+#define USB_OTG_DOEPCTL_CNAK_Msk                 (0x1UL << USB_OTG_DOEPCTL_CNAK_Pos) /*!< 0x04000000 */
+#define USB_OTG_DOEPCTL_CNAK                     USB_OTG_DOEPCTL_CNAK_Msk      /*!< Clear NAK */
+#define USB_OTG_DOEPCTL_SNAK_Pos                 (27U)                         
+#define USB_OTG_DOEPCTL_SNAK_Msk                 (0x1UL << USB_OTG_DOEPCTL_SNAK_Pos) /*!< 0x08000000 */
+#define USB_OTG_DOEPCTL_SNAK                     USB_OTG_DOEPCTL_SNAK_Msk      /*!< Set NAK */
+#define USB_OTG_DOEPCTL_EPDIS_Pos                (30U)                         
+#define USB_OTG_DOEPCTL_EPDIS_Msk                (0x1UL << USB_OTG_DOEPCTL_EPDIS_Pos) /*!< 0x40000000 */
+#define USB_OTG_DOEPCTL_EPDIS                    USB_OTG_DOEPCTL_EPDIS_Msk     /*!< Endpoint disable */
+#define USB_OTG_DOEPCTL_EPENA_Pos                (31U)                         
+#define USB_OTG_DOEPCTL_EPENA_Msk                (0x1UL << USB_OTG_DOEPCTL_EPENA_Pos) /*!< 0x80000000 */
+#define USB_OTG_DOEPCTL_EPENA                    USB_OTG_DOEPCTL_EPENA_Msk     /*!< Endpoint enable */
+
+/********************  Bit definition for USB_OTG_DOEPINT register  ********************/
+#define USB_OTG_DOEPINT_XFRC_Pos                 (0U)                          
+#define USB_OTG_DOEPINT_XFRC_Msk                 (0x1UL << USB_OTG_DOEPINT_XFRC_Pos) /*!< 0x00000001 */
+#define USB_OTG_DOEPINT_XFRC                     USB_OTG_DOEPINT_XFRC_Msk      /*!< Transfer completed interrupt */
+#define USB_OTG_DOEPINT_EPDISD_Pos               (1U)                          
+#define USB_OTG_DOEPINT_EPDISD_Msk               (0x1UL << USB_OTG_DOEPINT_EPDISD_Pos) /*!< 0x00000002 */
+#define USB_OTG_DOEPINT_EPDISD                   USB_OTG_DOEPINT_EPDISD_Msk    /*!< Endpoint disabled interrupt */
+#define USB_OTG_DOEPINT_AHBERR_Pos               (2U)
+#define USB_OTG_DOEPINT_AHBERR_Msk               (0x1UL << USB_OTG_DOEPINT_AHBERR_Pos) /*!< 0x00000004 */
+#define USB_OTG_DOEPINT_AHBERR                   USB_OTG_DOEPINT_AHBERR_Msk   /*!< AHB Error (AHBErr) during an OUT transaction */
+#define USB_OTG_DOEPINT_STUP_Pos                 (3U)                          
+#define USB_OTG_DOEPINT_STUP_Msk                 (0x1UL << USB_OTG_DOEPINT_STUP_Pos) /*!< 0x00000008 */
+#define USB_OTG_DOEPINT_STUP                     USB_OTG_DOEPINT_STUP_Msk      /*!< SETUP phase done */
+#define USB_OTG_DOEPINT_OTEPDIS_Pos              (4U)                          
+#define USB_OTG_DOEPINT_OTEPDIS_Msk              (0x1UL << USB_OTG_DOEPINT_OTEPDIS_Pos) /*!< 0x00000010 */
+#define USB_OTG_DOEPINT_OTEPDIS                  USB_OTG_DOEPINT_OTEPDIS_Msk   /*!< OUT token received when endpoint disabled */
+#define USB_OTG_DOEPINT_OTEPSPR_Pos              (5U)                          
+#define USB_OTG_DOEPINT_OTEPSPR_Msk              (0x1UL << USB_OTG_DOEPINT_OTEPSPR_Pos) /*!< 0x00000020 */
+#define USB_OTG_DOEPINT_OTEPSPR                  USB_OTG_DOEPINT_OTEPSPR_Msk   /*!< Status Phase Received For Control Write */
+#define USB_OTG_DOEPINT_B2BSTUP_Pos              (6U)                          
+#define USB_OTG_DOEPINT_B2BSTUP_Msk              (0x1UL << USB_OTG_DOEPINT_B2BSTUP_Pos) /*!< 0x00000040 */
+#define USB_OTG_DOEPINT_B2BSTUP                  USB_OTG_DOEPINT_B2BSTUP_Msk   /*!< Back-to-back SETUP packets received */
+#define USB_OTG_DOEPINT_OUTPKTERR_Pos            (8U)
+#define USB_OTG_DOEPINT_OUTPKTERR_Msk            (0x1UL << USB_OTG_DOEPINT_OUTPKTERR_Pos) /*!< 0x00000100 */
+#define USB_OTG_DOEPINT_OUTPKTERR                USB_OTG_DOEPINT_OUTPKTERR_Msk   /*!< OUT packet error */
+#define USB_OTG_DOEPINT_NAK_Pos                  (13U)
+#define USB_OTG_DOEPINT_NAK_Msk                  (0x1UL << USB_OTG_DOEPINT_NAK_Pos) /*!< 0x00002000 */
+#define USB_OTG_DOEPINT_NAK                      USB_OTG_DOEPINT_NAK_Msk   /*!< NAK Packet is transmitted by the device */
+#define USB_OTG_DOEPINT_NYET_Pos                 (14U)                         
+#define USB_OTG_DOEPINT_NYET_Msk                 (0x1UL << USB_OTG_DOEPINT_NYET_Pos) /*!< 0x00004000 */
+#define USB_OTG_DOEPINT_NYET                     USB_OTG_DOEPINT_NYET_Msk      /*!< NYET interrupt */
+#define USB_OTG_DOEPINT_STPKTRX_Pos              (15U)
+#define USB_OTG_DOEPINT_STPKTRX_Msk              (0x1UL << USB_OTG_DOEPINT_STPKTRX_Pos) /*!< 0x00008000 */
+#define USB_OTG_DOEPINT_STPKTRX                  USB_OTG_DOEPINT_STPKTRX_Msk   /*!< Setup Packet Received */
+/********************  Bit definition for USB_OTG_DOEPTSIZ register  ********************/
+
+#define USB_OTG_DOEPTSIZ_XFRSIZ_Pos              (0U)                          
+#define USB_OTG_DOEPTSIZ_XFRSIZ_Msk              (0x7FFFFUL << USB_OTG_DOEPTSIZ_XFRSIZ_Pos) /*!< 0x0007FFFF */
+#define USB_OTG_DOEPTSIZ_XFRSIZ                  USB_OTG_DOEPTSIZ_XFRSIZ_Msk   /*!< Transfer size */
+#define USB_OTG_DOEPTSIZ_PKTCNT_Pos              (19U)                         
+#define USB_OTG_DOEPTSIZ_PKTCNT_Msk              (0x3FFUL << USB_OTG_DOEPTSIZ_PKTCNT_Pos) /*!< 0x1FF80000 */
+#define USB_OTG_DOEPTSIZ_PKTCNT                  USB_OTG_DOEPTSIZ_PKTCNT_Msk   /*!< Packet count */
+
+#define USB_OTG_DOEPTSIZ_STUPCNT_Pos             (29U)                         
+#define USB_OTG_DOEPTSIZ_STUPCNT_Msk             (0x3UL << USB_OTG_DOEPTSIZ_STUPCNT_Pos) /*!< 0x60000000 */
+#define USB_OTG_DOEPTSIZ_STUPCNT                 USB_OTG_DOEPTSIZ_STUPCNT_Msk  /*!< SETUP packet count */
+#define USB_OTG_DOEPTSIZ_STUPCNT_0               (0x1UL << USB_OTG_DOEPTSIZ_STUPCNT_Pos) /*!< 0x20000000 */
+#define USB_OTG_DOEPTSIZ_STUPCNT_1               (0x2UL << USB_OTG_DOEPTSIZ_STUPCNT_Pos) /*!< 0x40000000 */
+
+/********************  Bit definition for PCGCCTL register  ********************/
+#define USB_OTG_PCGCCTL_STOPCLK_Pos              (0U)                          
+#define USB_OTG_PCGCCTL_STOPCLK_Msk              (0x1UL << USB_OTG_PCGCCTL_STOPCLK_Pos) /*!< 0x00000001 */
+#define USB_OTG_PCGCCTL_STOPCLK                  USB_OTG_PCGCCTL_STOPCLK_Msk   /*!< SETUP packet count */
+#define USB_OTG_PCGCCTL_GATECLK_Pos              (1U)                          
+#define USB_OTG_PCGCCTL_GATECLK_Msk              (0x1UL << USB_OTG_PCGCCTL_GATECLK_Pos) /*!< 0x00000002 */
+#define USB_OTG_PCGCCTL_GATECLK                  USB_OTG_PCGCCTL_GATECLK_Msk   /*!<Bit 0 */
+#define USB_OTG_PCGCCTL_PHYSUSP_Pos              (4U)                          
+#define USB_OTG_PCGCCTL_PHYSUSP_Msk              (0x1UL << USB_OTG_PCGCCTL_PHYSUSP_Pos) /*!< 0x00000010 */
+#define USB_OTG_PCGCCTL_PHYSUSP                  USB_OTG_PCGCCTL_PHYSUSP_Msk   /*!<Bit 1 */
+
+/* Legacy define */
+/********************  Bit definition for OTG register  ********************/
+#define USB_OTG_CHNUM_Pos                        (0U)                          
+#define USB_OTG_CHNUM_Msk                        (0xFUL << USB_OTG_CHNUM_Pos)   /*!< 0x0000000F */
+#define USB_OTG_CHNUM                            USB_OTG_CHNUM_Msk             /*!< Channel number */
+#define USB_OTG_CHNUM_0                          (0x1UL << USB_OTG_CHNUM_Pos)   /*!< 0x00000001 */
+#define USB_OTG_CHNUM_1                          (0x2UL << USB_OTG_CHNUM_Pos)   /*!< 0x00000002 */
+#define USB_OTG_CHNUM_2                          (0x4UL << USB_OTG_CHNUM_Pos)   /*!< 0x00000004 */
+#define USB_OTG_CHNUM_3                          (0x8UL << USB_OTG_CHNUM_Pos)   /*!< 0x00000008 */
+#define USB_OTG_BCNT_Pos                         (4U)                          
+#define USB_OTG_BCNT_Msk                         (0x7FFUL << USB_OTG_BCNT_Pos)  /*!< 0x00007FF0 */
+#define USB_OTG_BCNT                             USB_OTG_BCNT_Msk              /*!< Byte count */
+
+#define USB_OTG_DPID_Pos                         (15U)                         
+#define USB_OTG_DPID_Msk                         (0x3UL << USB_OTG_DPID_Pos)    /*!< 0x00018000 */
+#define USB_OTG_DPID                             USB_OTG_DPID_Msk              /*!< Data PID */
+#define USB_OTG_DPID_0                           (0x1UL << USB_OTG_DPID_Pos)    /*!< 0x00008000 */
+#define USB_OTG_DPID_1                           (0x2UL << USB_OTG_DPID_Pos)    /*!< 0x00010000 */
+
+#define USB_OTG_PKTSTS_Pos                       (17U)                         
+#define USB_OTG_PKTSTS_Msk                       (0xFUL << USB_OTG_PKTSTS_Pos)  /*!< 0x001E0000 */
+#define USB_OTG_PKTSTS                           USB_OTG_PKTSTS_Msk            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                         (0x1UL << USB_OTG_PKTSTS_Pos)  /*!< 0x00020000 */
+#define USB_OTG_PKTSTS_1                         (0x2UL << USB_OTG_PKTSTS_Pos)  /*!< 0x00040000 */
+#define USB_OTG_PKTSTS_2                         (0x4UL << USB_OTG_PKTSTS_Pos)  /*!< 0x00080000 */
+#define USB_OTG_PKTSTS_3                         (0x8UL << USB_OTG_PKTSTS_Pos)  /*!< 0x00100000 */
+
+#define USB_OTG_EPNUM_Pos                        (0U)                          
+#define USB_OTG_EPNUM_Msk                        (0xFUL << USB_OTG_EPNUM_Pos)   /*!< 0x0000000F */
+#define USB_OTG_EPNUM                            USB_OTG_EPNUM_Msk             /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                          (0x1UL << USB_OTG_EPNUM_Pos)   /*!< 0x00000001 */
+#define USB_OTG_EPNUM_1                          (0x2UL << USB_OTG_EPNUM_Pos)   /*!< 0x00000002 */
+#define USB_OTG_EPNUM_2                          (0x4UL << USB_OTG_EPNUM_Pos)   /*!< 0x00000004 */
+#define USB_OTG_EPNUM_3                          (0x8UL << USB_OTG_EPNUM_Pos)   /*!< 0x00000008 */
+
+#define USB_OTG_FRMNUM_Pos                       (21U)                         
+#define USB_OTG_FRMNUM_Msk                       (0xFUL << USB_OTG_FRMNUM_Pos)  /*!< 0x01E00000 */
+#define USB_OTG_FRMNUM                           USB_OTG_FRMNUM_Msk            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                         (0x1UL << USB_OTG_FRMNUM_Pos)  /*!< 0x00200000 */
+#define USB_OTG_FRMNUM_1                         (0x2UL << USB_OTG_FRMNUM_Pos)  /*!< 0x00400000 */
+#define USB_OTG_FRMNUM_2                         (0x4UL << USB_OTG_FRMNUM_Pos)  /*!< 0x00800000 */
+#define USB_OTG_FRMNUM_3                         (0x8UL << USB_OTG_FRMNUM_Pos)  /*!< 0x01000000 */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_STREAM_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Stream0) || \
+                                              ((INSTANCE) == DMA1_Stream1) || \
+                                              ((INSTANCE) == DMA1_Stream2) || \
+                                              ((INSTANCE) == DMA1_Stream3) || \
+                                              ((INSTANCE) == DMA1_Stream4) || \
+                                              ((INSTANCE) == DMA1_Stream5) || \
+                                              ((INSTANCE) == DMA1_Stream6) || \
+                                              ((INSTANCE) == DMA1_Stream7) || \
+                                              ((INSTANCE) == DMA2_Stream0) || \
+                                              ((INSTANCE) == DMA2_Stream1) || \
+                                              ((INSTANCE) == DMA2_Stream2) || \
+                                              ((INSTANCE) == DMA2_Stream3) || \
+                                              ((INSTANCE) == DMA2_Stream4) || \
+                                              ((INSTANCE) == DMA2_Stream5) || \
+                                              ((INSTANCE) == DMA2_Stream6) || \
+                                              ((INSTANCE) == DMA2_Stream7))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOD) || \
+                                        ((INSTANCE) == GPIOE) || \
+                                        ((INSTANCE) == GPIOH))
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1) || \
+                                       ((INSTANCE) == I2C2) || \
+                                       ((INSTANCE) == I2C3))
+
+/******************************* SMBUS Instances ******************************/
+#define IS_SMBUS_ALL_INSTANCE         IS_I2C_ALL_INSTANCE
+
+/******************************** I2S Instances *******************************/
+
+#define IS_I2S_ALL_INSTANCE(INSTANCE)  (((INSTANCE) == SPI2) || \
+                                       ((INSTANCE) == SPI3))
+
+/*************************** I2S Extended Instances ***************************/
+#define IS_I2S_EXT_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2S2ext)|| \
+                                           ((INSTANCE) == I2S3ext))
+/* Legacy Defines */
+#define IS_I2S_ALL_INSTANCE_EXT    IS_I2S_EXT_ALL_INSTANCE
+
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
+                                       ((INSTANCE) == SPI2) || \
+                                       ((INSTANCE) == SPI3) || \
+                                       ((INSTANCE) == SPI4))
+
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                   ((INSTANCE) == TIM2)   || \
+                                   ((INSTANCE) == TIM3)   || \
+                                   ((INSTANCE) == TIM4)   || \
+                                   ((INSTANCE) == TIM5)   || \
+                                   ((INSTANCE) == TIM9)   || \
+                                   ((INSTANCE) == TIM10)  || \
+                                   ((INSTANCE) == TIM11))
+
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                         ((INSTANCE) == TIM2)  || \
+                                         ((INSTANCE) == TIM3)  || \
+                                         ((INSTANCE) == TIM4)  || \
+                                         ((INSTANCE) == TIM5)  || \
+                                         ((INSTANCE) == TIM9)  || \
+                                         ((INSTANCE) == TIM10) || \
+                                         ((INSTANCE) == TIM11))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                       ((INSTANCE) == TIM2) || \
+                                       ((INSTANCE) == TIM3) || \
+                                       ((INSTANCE) == TIM4) || \
+                                       ((INSTANCE) == TIM5) || \
+                                       ((INSTANCE) == TIM9))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1) || \
+                                         ((INSTANCE) == TIM2) || \
+                                         ((INSTANCE) == TIM3) || \
+                                         ((INSTANCE) == TIM4) || \
+                                         ((INSTANCE) == TIM5))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                       ((INSTANCE) == TIM2) || \
+                                       ((INSTANCE) == TIM3) || \
+                                       ((INSTANCE) == TIM4) || \
+                                       ((INSTANCE) == TIM5))
+
+/******************** TIM Instances : Advanced-control timers *****************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1) || \
+                                         ((INSTANCE) == TIM2) || \
+                                         ((INSTANCE) == TIM3) || \
+                                         ((INSTANCE) == TIM4) || \
+                                         ((INSTANCE) == TIM5))
+
+/****************** TIM Instances : DMA requests generation (UDE) *************/
+#define IS_TIM_DMA_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                       ((INSTANCE) == TIM2) || \
+                                       ((INSTANCE) == TIM3) || \
+                                       ((INSTANCE) == TIM4) || \
+                                       ((INSTANCE) == TIM5))
+
+/************ TIM Instances : DMA requests generation (CCxDE) *****************/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                          ((INSTANCE) == TIM2) || \
+                                          ((INSTANCE) == TIM3) || \
+                                          ((INSTANCE) == TIM4) || \
+                                          ((INSTANCE) == TIM5))
+
+/************ TIM Instances : DMA requests generation (COMDE) *****************/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                          ((INSTANCE) == TIM2) || \
+                                          ((INSTANCE) == TIM3) || \
+                                          ((INSTANCE) == TIM4) || \
+                                          ((INSTANCE) == TIM5)) 
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                             ((INSTANCE) == TIM2) || \
+                                             ((INSTANCE) == TIM3) || \
+                                             ((INSTANCE) == TIM4) || \
+                                             ((INSTANCE) == TIM5))
+
+/****** TIM Instances : master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                          ((INSTANCE) == TIM2) || \
+                                          ((INSTANCE) == TIM3) || \
+                                          ((INSTANCE) == TIM4) || \
+                                          ((INSTANCE) == TIM5))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                         ((INSTANCE) == TIM2) || \
+                                         ((INSTANCE) == TIM3) || \
+                                         ((INSTANCE) == TIM4) || \
+                                         ((INSTANCE) == TIM5) || \
+                                         ((INSTANCE) == TIM9))
+/********************** TIM Instances : 32 bit Counter ************************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
+                                              ((INSTANCE) == TIM5))
+
+/***************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                        ((INSTANCE) == TIM2) || \
+                                        ((INSTANCE) == TIM3) || \
+                                        ((INSTANCE) == TIM4) || \
+                                        ((INSTANCE) == TIM5))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)  || \
+                                         ((INSTANCE) == TIM5)  || \
+                                         ((INSTANCE) == TIM11))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+    ((((INSTANCE) == TIM1) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((INSTANCE) == TIM2) &&                   \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((INSTANCE) == TIM3) &&                   \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((INSTANCE) == TIM4) &&                   \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((INSTANCE) == TIM5) &&                   \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((INSTANCE) == TIM9) &&                   \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((INSTANCE) == TIM10) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((INSTANCE) == TIM11) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1))))
+
+/************ TIM Instances : complementary output(s) available ***************/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+   ((((INSTANCE) == TIM1) &&                    \
+     (((CHANNEL) == TIM_CHANNEL_1) ||           \
+      ((CHANNEL) == TIM_CHANNEL_2) ||           \
+      ((CHANNEL) == TIM_CHANNEL_3))))
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM4) || \
+                                                        ((INSTANCE) == TIM5))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                  ((INSTANCE) == TIM2)   || \
+                                                  ((INSTANCE) == TIM3)   || \
+                                                  ((INSTANCE) == TIM4)   || \
+                                                  ((INSTANCE) == TIM5)   || \
+                                                  ((INSTANCE) == TIM9)   || \
+                                                  ((INSTANCE) == TIM10)  || \
+                                                  ((INSTANCE) == TIM11))
+
+
+/****************** TIM Instances : supporting commutation event generation ***/
+
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM2) || \
+                                                       ((INSTANCE) == TIM3) || \
+                                                       ((INSTANCE) == TIM4) || \
+                                                       ((INSTANCE) == TIM5))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM4) || \
+                                                        ((INSTANCE) == TIM5) || \
+                                                        ((INSTANCE) == TIM9))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)|| \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM4) || \
+                                                        ((INSTANCE) == TIM5))
+
+/****** TIM Instances : supporting external clock mode 1 for TIX inputs ******/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM4) || \
+                                                        ((INSTANCE) == TIM5) || \
+                                                        ((INSTANCE) == TIM9))
+
+/********** TIM Instances : supporting internal trigger inputs(ITRX) *********/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM4) || \
+                                                        ((INSTANCE) == TIM5) || \
+                                                        ((INSTANCE) == TIM9))
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                      ((INSTANCE) == TIM2) || \
+                                                      ((INSTANCE) == TIM3) || \
+                                                      ((INSTANCE) == TIM4) || \
+                                                      ((INSTANCE) == TIM5) || \
+                                                      ((INSTANCE) == TIM9))
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                          ((INSTANCE) == TIM2) || \
+                                                          ((INSTANCE) == TIM3) || \
+                                                          ((INSTANCE) == TIM4) || \
+                                                          ((INSTANCE) == TIM5))
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                     ((INSTANCE) == USART2) || \
+                                     ((INSTANCE) == USART6))
+
+/******************** UART Instances : Half-Duplex mode **********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                               ((INSTANCE) == USART2) || \
+                                               ((INSTANCE) == USART6))
+
+/* Legacy defines */
+#define IS_UART_INSTANCE          IS_UART_HALFDUPLEX_INSTANCE
+
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == USART2) || \
+                                           ((INSTANCE) == USART6))
+/******************** UART Instances : LIN mode **********************/
+#define IS_UART_LIN_INSTANCE          IS_UART_HALFDUPLEX_INSTANCE
+
+/********************* UART Instances : Smart card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                         ((INSTANCE) == USART2) || \
+                                         ((INSTANCE) == USART6))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                    ((INSTANCE) == USART2) || \
+                                    ((INSTANCE) == USART6))     
+
+/*********************** PCD Instances ****************************************/
+#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS))
+
+/*********************** HCD Instances ****************************************/
+#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS))
+
+/****************************** SDIO Instances ********************************/
+#define IS_SDIO_ALL_INSTANCE(INSTANCE) ((INSTANCE) == SDIO)
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+/****************************** USB Exported Constants ************************/
+#define USB_OTG_FS_HOST_MAX_CHANNEL_NBR                8U
+#define USB_OTG_FS_MAX_IN_ENDPOINTS                    4U    /* Including EP0 */
+#define USB_OTG_FS_MAX_OUT_ENDPOINTS                   4U    /* Including EP0 */
+#define USB_OTG_FS_TOTAL_FIFO_SIZE                     1280U /* in Bytes */
+
+/*
+ * @brief Specific devices reset values definitions
+ */
+#define RCC_PLLCFGR_RST_VALUE              0x24003010U
+#define RCC_PLLI2SCFGR_RST_VALUE           0x20003000U
+
+#define RCC_MAX_FREQUENCY            84000000U         /*!< Max frequency of family in Hz*/
+#define RCC_MAX_FREQUENCY_SCALE3     60000000U         /*!< Maximum frequency for system clock at power scale3, in Hz */
+#define RCC_MAX_FREQUENCY_SCALE2    RCC_MAX_FREQUENCY  /*!< Maximum frequency for system clock at power scale2, in Hz */
+#define RCC_PLLVCO_OUTPUT_MIN       192000000U       /*!< Frequency min for PLLVCO output, in Hz */
+#define RCC_PLLVCO_INPUT_MIN           950000U       /*!< Frequency min for PLLVCO input, in Hz  */
+#define RCC_PLLVCO_INPUT_MAX          2100000U       /*!< Frequency max for PLLVCO input, in Hz  */
+#define RCC_PLLVCO_OUTPUT_MAX       432000000U       /*!< Frequency max for PLLVCO output, in Hz */
+
+#define RCC_PLLN_MIN_VALUE                192U
+#define RCC_PLLN_MAX_VALUE                432U
+
+#define FLASH_SCALE2_LATENCY1_FREQ    30000000U      /*!< HCLK frequency to set FLASH latency 1 in power scale 2  */
+#define FLASH_SCALE2_LATENCY2_FREQ    60000000U      /*!< HCLK frequency to set FLASH latency 2 in power scale 2  */
+
+#define FLASH_SCALE3_LATENCY1_FREQ    30000000U      /*!< HCLK frequency to set FLASH latency 1 in power scale 3  */
+#define FLASH_SCALE3_LATENCY2_FREQ    60000000U      /*!< HCLK frequency to set FLASH latency 2 in power scale 3  */
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F401xC_H */

--- a/unit_testing/fakes/fake_stm32xxxx_hal.cpp
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.cpp
@@ -8,9 +8,64 @@ using namespace std::chrono;
 ** PUBLIC OBJECTS
 ***************************************************************************************************/
 
-RCC_TypeDef RCC_obj;
+TIM_TypeDef TIM2_obj;
+TIM_TypeDef TIM3_obj;
 TIM_TypeDef TIM4_obj;
 TIM_TypeDef TIM5_obj;
+RTC_TypeDef RTC_obj;
+WWDG_TypeDef WWDG_obj;
+IWDG_TypeDef IWDG_obj;
+SPI_TypeDef I2S2ext_obj;
+SPI_TypeDef SPI2_obj;
+SPI_TypeDef SPI3_obj;
+SPI_TypeDef I2S3ext_obj;
+USART_TypeDef USART2_obj;
+I2C_TypeDef I2C1_obj;
+I2C_TypeDef I2C2_obj;
+I2C_TypeDef I2C3_obj;
+PWR_TypeDef PWR_obj;
+TIM_TypeDef TIM1_obj;
+USART_TypeDef USART1_obj;
+USART_TypeDef USART6_obj;
+ADC_TypeDef ADC1_obj;
+ADC_Common_TypeDef ADC1_COMMON_obj;
+//SDIO_TypeDef SDIO_obj;
+SPI_TypeDef SPI1_obj;
+SPI_TypeDef SPI4_obj;
+SYSCFG_TypeDef SYSCFG_obj;
+EXTI_TypeDef EXTI_obj;
+TIM_TypeDef TIM9_obj;
+TIM_TypeDef TIM10_obj;
+TIM_TypeDef TIM11_obj;
+GPIO_TypeDef GPIOA_obj;
+GPIO_TypeDef GPIOB_obj;
+GPIO_TypeDef GPIOC_obj;
+GPIO_TypeDef GPIOD_obj;
+GPIO_TypeDef GPIOE_obj;
+GPIO_TypeDef GPIOH_obj;
+CRC_TypeDef CRC_obj;
+RCC_TypeDef RCC_obj;
+FLASH_TypeDef FLASH_obj;
+DMA_TypeDef DMA1_obj;
+DMA_Stream_TypeDef DMA1_Stream0_obj;
+DMA_Stream_TypeDef DMA1_Stream1_obj;
+DMA_Stream_TypeDef DMA1_Stream2_obj;
+DMA_Stream_TypeDef DMA1_Stream3_obj;
+DMA_Stream_TypeDef DMA1_Stream4_obj;
+DMA_Stream_TypeDef DMA1_Stream5_obj;
+DMA_Stream_TypeDef DMA1_Stream6_obj;
+DMA_Stream_TypeDef DMA1_Stream7_obj;
+DMA_TypeDef DMA2_obj;
+DMA_Stream_TypeDef DMA2_Stream0_obj;
+DMA_Stream_TypeDef DMA2_Stream1_obj;
+DMA_Stream_TypeDef DMA2_Stream2_obj;
+DMA_Stream_TypeDef DMA2_Stream3_obj;
+DMA_Stream_TypeDef DMA2_Stream4_obj;
+DMA_Stream_TypeDef DMA2_Stream5_obj;
+DMA_Stream_TypeDef DMA2_Stream6_obj;
+DMA_Stream_TypeDef DMA2_Stream7_obj;
+DBGMCU_TypeDef DBGMCU_obj;
+USB_OTG_GlobalTypeDef USB_OTG_FS_obj;
 
 /***************************************************************************************************
 ** PRIVATE MEMBERS
@@ -46,6 +101,22 @@ HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim) {
 HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim)
 {
     /* Do nothing */
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel) {
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel) {
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel) {
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel) {
     return HAL_OK;
 }
 

--- a/unit_testing/fakes/fake_stm32xxxx_hal.h
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.h
@@ -20,7 +20,6 @@
 #include "stm32f4xx_hal_gpio.h"
 #include "stm32f4xx_hal_rcc.h"
 #include "stm32f4xx_hal_tim.h"
-#include "stm32f4xx_hal_wwdg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +45,11 @@ typedef struct ADC_HandleTypeDef
     uint32_t* dma_address;
     uint32_t  dma_length;
 } ADC_HandleTypeDef;
+
+typedef uint32_t CRC_HandleTypeDef;
 typedef uint32_t SPI_HandleTypeDef;
+typedef uint32_t WWDG_HandleTypeDef;
+
 /***************************************************************************************************
 ** PUBLIC OBJECTS
 ***************************************************************************************************/
@@ -57,9 +60,13 @@ typedef uint32_t SPI_HandleTypeDef;
 ***************************************************************************************************/
 /* ADC */
 HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+
 /* SPI */
 HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+
+/* Watchdog */
+HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg);
 
 /* HAL */
 void forceTick(uint32_t next_val);

--- a/unit_testing/fakes/fake_stm32xxxx_hal.h
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.h
@@ -12,6 +12,16 @@
 
 #include <stdint.h>
 
+/* Using the fake "device file" means that the normal headers can be included, dramatically 
+** reducing the amount of duplication this file requires */
+#include "fake_stm32f401xc.h"
+#define STM32F401xC
+#include "stm32f4xx_hal_dma.h"
+#include "stm32f4xx_hal_gpio.h"
+#include "stm32f4xx_hal_rcc.h"
+#include "stm32f4xx_hal_tim.h"
+#include "stm32f4xx_hal_wwdg.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,58 +30,7 @@ extern "C" {
 ** DEFINES
 ***************************************************************************************************/
 
-/* GPIO module */
-#define GPIOA (uint32_t*)(0)
-#define GPIOB (uint32_t*)(0)
-#define GPIOC (uint32_t*)(0)
-#define GPIOD (uint32_t*)(0)
-#define GPIOE (uint32_t*)(0)
-#define GPIOH (uint32_t*)(0)
 
-#define GPIO_PIN_0   0x0001
-#define GPIO_PIN_1   0x0002
-#define GPIO_PIN_2   0x0004
-#define GPIO_PIN_3   0x0008
-#define GPIO_PIN_4   0x0010
-#define GPIO_PIN_5   0x0020
-#define GPIO_PIN_6   0x0040
-#define GPIO_PIN_7   0x0080
-#define GPIO_PIN_8   0x0100
-#define GPIO_PIN_9   0x0200
-#define GPIO_PIN_10  0x0400
-#define GPIO_PIN_11  0x0800
-#define GPIO_PIN_12  0x1000
-#define GPIO_PIN_13  0x2000
-#define GPIO_PIN_14  0x4000
-#define GPIO_PIN_15  0x8000
-#define GPIO_PIN_All 0xFFFF
-
-/* Watchdog module */
-#define RCC_FLAG_HSIRDY                  ((uint8_t)0x21)
-#define RCC_FLAG_HSERDY                  ((uint8_t)0x31)
-#define RCC_FLAG_PLLRDY                  ((uint8_t)0x39)
-#define RCC_FLAG_PLLI2SRDY               ((uint8_t)0x3B)
-#define RCC_FLAG_LSERDY                  ((uint8_t)0x41)
-#define RCC_FLAG_LSIRDY                  ((uint8_t)0x61)
-#define RCC_FLAG_BORRST                  ((uint8_t)0x79)
-#define RCC_FLAG_PINRST                  ((uint8_t)0x7A)
-#define RCC_FLAG_PORRST                  ((uint8_t)0x7B)
-#define RCC_FLAG_SFTRST                  ((uint8_t)0x7C)
-#define RCC_FLAG_IWDGRST                 ((uint8_t)0x7D)
-#define RCC_FLAG_WWDGRST                 ((uint8_t)0x7E)
-#define RCC_FLAG_LPWRRST                 ((uint8_t)0x7F)
-
-#define __HAL_RCC_WWDG_CLK_DISABLE()  0
-#define __HAL_RCC_CLEAR_RESET_FLAGS() 0
-#define __HAL_RCC_GET_FLAG(x)         0
-
-#define RCC  (&RCC_obj)
-#define TIM4 (&TIM4_obj)
-#define TIM5 (&TIM5_obj)
-
-#define __NOP()  0
-
-#define __HAL_TIM_GET_COUNTER(x) ((TIM_HandleTypeDef*)x)->CNT;
 
 /***************************************************************************************************
 ** PUBLIC TYPEDEFS
@@ -87,57 +46,17 @@ typedef struct ADC_HandleTypeDef
     uint32_t* dma_address;
     uint32_t  dma_length;
 } ADC_HandleTypeDef;
-
-typedef struct {
-    uint32_t CSR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-} RCC_TypeDef;
-
-typedef struct {
-    uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-    uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-    uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-    uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-} TIM_TypeDef;
-
-typedef struct {
-    uint32_t CNT;
-} TIM_HandleTypeDef;
-
-typedef uint32_t CRC_HandleTypeDef;
-typedef uint32_t WWDG_HandleTypeDef;
 typedef uint32_t SPI_HandleTypeDef;
-typedef uint32_t GPIO_TypeDef;
-
-typedef enum
-{
-  HAL_OK       = 0x00,
-  HAL_ERROR    = 0x01,
-  HAL_BUSY     = 0x02,
-  HAL_TIMEOUT  = 0x03
-} HAL_StatusTypeDef;
-
 /***************************************************************************************************
 ** PUBLIC OBJECTS
 ***************************************************************************************************/
 
-extern RCC_TypeDef RCC_obj;
-extern TIM_TypeDef TIM4_obj;
-extern TIM_TypeDef TIM5_obj;
 
 /***************************************************************************************************
 ** PUBLIC FUNCTIONS
 ***************************************************************************************************/
-
 /* ADC */
 HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
-
-/* Watchdog */
-HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg);
-
-/* TIM */
-HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim);
-HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim);
-
 /* SPI */
 HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);


### PR DESCRIPTION
* Updated Fake HAL to use the same headers as the HAL where possible. Reduces duplication and also makes future expansion easier - function headers no longer need to be copied into a new file.