### PR TITLE
STM32H7: OTP procedure update

### DIFF
--- a/STM32/FLASH_readwrite/Src/HAL_H7_otp.c
+++ b/STM32/FLASH_readwrite/Src/HAL_H7_otp.c
@@ -40,7 +40,7 @@ int removeOTP(FLASH_OBProgramInitTypeDef *OB, const BoardInfo *boardInfo)
     if (HAL_FLASH_Unlock() != HAL_OK)
         return OTP_WRITE_FAIL;
 
-    // Unlock Flash OPT registry that allows removal of write protection of FLASH section
+    // Unlock Flash options bytes register that allows removal of write protection of FLASH section
     if (HAL_FLASH_OB_Unlock() != HAL_OK)
         return OTP_WRITE_FAIL;
 
@@ -107,7 +107,7 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     if (HAL_FLASH_Unlock() != HAL_OK)
         return OTP_WRITE_FAIL;
 
-    // Unlock Flash OPT registry that allows removal of write protection of FLASH section
+    // Unlock Flash options bytes register that allows removal of write protection of FLASH section
     if (HAL_FLASH_OB_Unlock() != HAL_OK)
         return OTP_WRITE_FAIL;
 

--- a/STM32/FLASH_readwrite/Src/HAL_H7_otp.c
+++ b/STM32/FLASH_readwrite/Src/HAL_H7_otp.c
@@ -20,46 +20,44 @@
 // to OTP memory. This part of the memory is therefore not allowed to write to during
 // normal FLASH storing.
 #define FLASH_OTP_BASE		0x08080000
-#define OTP_FLASH_SECTOR	0x04
-
-uint32_t OTP_CLEAR_ADDRESS = 0xFFFFFFFF;
-
+#define OB_WRP_SECTOR       OB_WRP_SECTOR_4
 #define FLASH_WORD_SIZE		32 // 32 bytes
 
-// This method can change the write-protection of a sector of BANK 1.
-// The documentation for this may be found in reference manual RM0433
-// section 4.5.1 and 4.9.16.
-static HAL_StatusTypeDef changeWriteProtectedSector(bool enable)
-{
-	if (!enable && ((FLASH->OPTCR & 0x01) == 0U))
-	{
-		// Remove write protection of 'OTP' sector
-		FLASH->WPSN_PRG1 |= (1UL << OTP_FLASH_SECTOR);
-
-		if (((FLASH->WPSN_PRG1 >> 4) & 0x01) != 0x01)
-			return HAL_ERROR;
-
-	}
-	else if (enable && ((FLASH->OPTCR & 0x01) == 0U))
-	{
-		// Enable write protection of 'OTP' sector
-		FLASH->WPSN_PRG1 &= ~(1UL << OTP_FLASH_SECTOR);
-
-		if (((FLASH->WPSN_PRG1 >> 4) & 0x01) != 0U)
-			return HAL_ERROR;
-	}
-	return HAL_OK;
-}
 
 // Check whether OTP data is already programmed on board.
-static int isOTPAvailable()
+static int isOTPAvailable(FLASH_OBProgramInitTypeDef *OB)
 {
-    volatile uint32_t* p = (uint32_t*) FLASH_OTP_BASE;
-    if (*p == OTP_CLEAR_ADDRESS)
+    if (OB->WRPSector & OB_WRP_SECTOR)
     	return 0;
 
-    // all OTP sectors is free
+    // OTP sector is write-protected
     return 1;
+}
+
+// Remove existing OTP data 
+int removeOTP(FLASH_OBProgramInitTypeDef *OB, const BoardInfo *boardInfo)
+{
+    if (HAL_FLASH_Unlock() != HAL_OK)
+        return OTP_WRITE_FAIL;
+
+    // Unlock Flash OPT registry that allows removal of write protection of FLASH section
+    if (HAL_FLASH_OB_Unlock() != HAL_OK)
+    	return OTP_WRITE_FAIL;
+
+    // Disable write-protection for OB_WRP_SECTOR in FLASH_BANK_1
+    OB->OptionType = OPTIONBYTE_WRP;
+	OB->WRPState = OB_WRPSTATE_DISABLE;
+	OB->Banks = FLASH_BANK_1;
+    OB->WRPSector = OB_WRP_SECTOR;
+
+    // Write and update new settings to the FLASH memory option bytes
+    HAL_FLASHEx_OBProgram(OB);
+    HAL_FLASH_OB_Launch();
+
+    if (eraseSectors(FLASH_OTP_BASE, sizeof(boardInfo->data)/sizeof(uint32_t)) != 0)
+    		return OTP_WRITE_FAIL;
+
+    return OTP_SUCCESS;
 }
 
 // Read the current content of the OTP data.
@@ -67,7 +65,13 @@ static int isOTPAvailable()
 // Return 0 on success else OTP_EMPTY and boardInfo will be unchanged.
 int HAL_otpRead(BoardInfo *boardInfo)
 {
-    if (!isOTPAvailable())
+    static FLASH_OBProgramInitTypeDef OB;
+
+    /* Fetch all OB type configuration (we need WRP sectors)
+	 * This step is to check if write protection is already set
+	 */
+	HAL_FLASHEx_OBGetConfig(&OB);
+    if (!isOTPAvailable(&OB))
         return OTP_EMPTY; // Nothing has been written to OTP area.
 
     // Valid section found. Copy data to pointer since user should NOT get direct access to OTP area.
@@ -82,16 +86,22 @@ int HAL_otpRead(BoardInfo *boardInfo)
 // Return 0 on success else OTP_WRITE_FAIL if all OTP sections is written.
 const int HAL_otpWrite(const BoardInfo *boardInfo)
 {
+    static FLASH_OBProgramInitTypeDef OB;
+
+    /* Fetch all OB type configuration (we need WRP sectors)
+	 * This step is to check if write protection is already set
+	 */
+	HAL_FLASHEx_OBGetConfig(&OB);
+
     // Check the version of the Board info
     if (boardInfo->otpVersion > OTP_VERSION || boardInfo->otpVersion == 0) {
         return OTP_WRITE_FAIL;
     }
 
     // If sector has already been written to erase first.
-    if (isOTPAvailable())
+    if (isOTPAvailable(&OB))
     {
-    	if (eraseSectors(FLASH_OTP_BASE, sizeof(boardInfo->data)/sizeof(uint32_t)) != 0)
-    		return OTP_WRITE_FAIL;
+    	removeOTP(&OB, boardInfo);
     }
 
     if (HAL_FLASH_Unlock() != HAL_OK)
@@ -101,25 +111,26 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     if (HAL_FLASH_OB_Unlock() != HAL_OK)
     	return OTP_WRITE_FAIL;
 
-    // Remove write protection of 'OTP' sector
-    if (changeWriteProtectedSector(false) != HAL_OK)
-    	return OTP_WRITE_FAIL;
-
     // Write board info to sector using word size.
     uint32_t otpStartAddress = FLASH_OTP_BASE;
     for (int i=0; i<sizeof(boardInfo->data)/sizeof(uint32_t); i++)
     {
         if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, otpStartAddress, (uint32_t) &boardInfo->data[i]) != HAL_OK)
         {
-        	HAL_FLASH_OB_Lock();
-            HAL_FLASH_Lock();
             return OTP_WRITE_FAIL;
         }
         otpStartAddress += FLASH_WORD_SIZE;
     }
 
-    if (changeWriteProtectedSector(true) != HAL_OK)
-    	return OTP_WRITE_FAIL;
+    // Enable write-protection for OB_WRP_SECTOR in FLASH_BANK_1
+    OB.OptionType = OPTIONBYTE_WRP;
+	OB.WRPState = OB_WRPSTATE_ENABLE;
+	OB.Banks = FLASH_BANK_1;
+    OB.WRPSector = OB_WRP_SECTOR;
+
+    // Write and update new settings to the FLASH memory option bytes
+    HAL_FLASHEx_OBProgram(&OB);
+    HAL_FLASH_OB_Launch();
 
     if (HAL_FLASH_OB_Lock() != HAL_OK)
     	return OTP_WRITE_FAIL;

--- a/STM32/FLASH_readwrite/Src/HAL_H7_otp.c
+++ b/STM32/FLASH_readwrite/Src/HAL_H7_otp.c
@@ -28,7 +28,7 @@
 static int isOTPAvailable(FLASH_OBProgramInitTypeDef *OB)
 {
     if (OB->WRPSector & OB_WRP_SECTOR)
-    	return 0;
+        return 0;
 
     // OTP sector is write-protected
     return 1;
@@ -42,12 +42,12 @@ int removeOTP(FLASH_OBProgramInitTypeDef *OB, const BoardInfo *boardInfo)
 
     // Unlock Flash OPT registry that allows removal of write protection of FLASH section
     if (HAL_FLASH_OB_Unlock() != HAL_OK)
-    	return OTP_WRITE_FAIL;
+        return OTP_WRITE_FAIL;
 
     // Disable write-protection for OB_WRP_SECTOR in FLASH_BANK_1
     OB->OptionType = OPTIONBYTE_WRP;
-	OB->WRPState = OB_WRPSTATE_DISABLE;
-	OB->Banks = FLASH_BANK_1;
+    OB->WRPState = OB_WRPSTATE_DISABLE;
+    OB->Banks = FLASH_BANK_1;
     OB->WRPSector = OB_WRP_SECTOR;
 
     // Write and update new settings to the FLASH memory option bytes
@@ -55,7 +55,7 @@ int removeOTP(FLASH_OBProgramInitTypeDef *OB, const BoardInfo *boardInfo)
     HAL_FLASH_OB_Launch();
 
     if (eraseSectors(FLASH_OTP_BASE, sizeof(boardInfo->data)/sizeof(uint32_t)) != 0)
-    		return OTP_WRITE_FAIL;
+            return OTP_WRITE_FAIL;
 
     return OTP_SUCCESS;
 }
@@ -68,9 +68,9 @@ int HAL_otpRead(BoardInfo *boardInfo)
     static FLASH_OBProgramInitTypeDef OB;
 
     /* Fetch all OB type configuration (we need WRP sectors)
-	 * This step is to check if write protection is already set
-	 */
-	HAL_FLASHEx_OBGetConfig(&OB);
+     * This step is to check if write protection is already set
+     */
+    HAL_FLASHEx_OBGetConfig(&OB);
     if (!isOTPAvailable(&OB))
         return OTP_EMPTY; // Nothing has been written to OTP area.
 
@@ -89,9 +89,9 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     static FLASH_OBProgramInitTypeDef OB;
 
     /* Fetch all OB type configuration (we need WRP sectors)
-	 * This step is to check if write protection is already set
-	 */
-	HAL_FLASHEx_OBGetConfig(&OB);
+     * This step is to check if write protection is already set
+     */
+    HAL_FLASHEx_OBGetConfig(&OB);
 
     // Check the version of the Board info
     if (boardInfo->otpVersion > OTP_VERSION || boardInfo->otpVersion == 0) {
@@ -101,7 +101,7 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     // If sector has already been written to erase first.
     if (isOTPAvailable(&OB))
     {
-    	removeOTP(&OB, boardInfo);
+        removeOTP(&OB, boardInfo);
     }
 
     if (HAL_FLASH_Unlock() != HAL_OK)
@@ -109,7 +109,7 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
 
     // Unlock Flash OPT registry that allows removal of write protection of FLASH section
     if (HAL_FLASH_OB_Unlock() != HAL_OK)
-    	return OTP_WRITE_FAIL;
+        return OTP_WRITE_FAIL;
 
     // Write board info to sector using word size.
     uint32_t otpStartAddress = FLASH_OTP_BASE;
@@ -124,8 +124,8 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
 
     // Enable write-protection for OB_WRP_SECTOR in FLASH_BANK_1
     OB.OptionType = OPTIONBYTE_WRP;
-	OB.WRPState = OB_WRPSTATE_ENABLE;
-	OB.Banks = FLASH_BANK_1;
+    OB.WRPState = OB_WRPSTATE_ENABLE;
+    OB.Banks = FLASH_BANK_1;
     OB.WRPSector = OB_WRP_SECTOR;
 
     // Write and update new settings to the FLASH memory option bytes
@@ -133,7 +133,7 @@ const int HAL_otpWrite(const BoardInfo *boardInfo)
     HAL_FLASH_OB_Launch();
 
     if (HAL_FLASH_OB_Lock() != HAL_OK)
-    	return OTP_WRITE_FAIL;
+        return OTP_WRITE_FAIL;
 
     HAL_FLASH_Lock();
     return OTP_SUCCESS;

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -71,6 +71,7 @@ static const char* mcuType()
     {
     case 0x423: len += snprintf(&mcu[len], sizeof(mcu) -len, "STM32F401xB/C");        break;
     case 0x433: len += snprintf(&mcu[len], sizeof(mcu) -len, "STM32F401xD/E");        break;
+    case 0x450: len += snprintf(&mcu[len], sizeof(mcu) -len, "STM32H753IIT6");        break;
     default:    len += snprintf(&mcu[len], sizeof(mcu) -len, "Unknown 0x%3X", idCode); break;
     }
 

--- a/unit_testing/Util/caprotocol_tests.cpp
+++ b/unit_testing/Util/caprotocol_tests.cpp
@@ -13,7 +13,6 @@
 #include <queue>
 
 /* Fakes */
-#include "fake_stm32xxxx_hal.h"
 
 /* Real supporting units */
 


### PR DESCRIPTION
- Changed the method of accessing and updating option bytes to enable enable/disable of write-protection of memory area
- The memory area reserved for OTP info is unchanged and is in bank 1 section 4
- The memory in a write-protected area is unchanged after full chip erase tested with STM32CubeProgrammer 
- Added MCU idCode to systemInfo.c

The code has been tested by adding the otpWrite functionality directly to the CurrentController code, but a new project (or update to the existing OTP project) is needed to comply to ensure OTP data can only be written once.