### PR TITLE
Fixed minor version check bug

### DIFF
--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -80,7 +80,7 @@ static const char* mcuType()
     return mcu;
 }
 
-static char* productType(uint8_t id)
+static const char* productType(uint8_t id)
 {
     switch(id)
     {
@@ -197,7 +197,7 @@ const char* statusInfo(bool printStart)
 
     if (BS.boardStatus & BS_VERSION_ERROR_Msk)
     {
-        BoardType bt = {0};
+        BoardType bt = (BoardType)0;
         pcbVersion pv = {0};
         (void) getBoardInfo(&bt, NULL);
         (void) getPcbVersion(&pv);
@@ -228,14 +228,14 @@ int getBoardInfo(BoardType *bdt, SubBoardType *sbdt)
 
     if (info.otpVersion == OTP_VERSION_1)
     {
-        if (bdt)  { *bdt  = info.v1.boardType; }
+        if (bdt)  { *bdt  = (BoardType)info.v1.boardType; }
         if (sbdt) { *sbdt = 0; } // Sub board type is not included in version 1
         return 0;
     }
 
     if (info.otpVersion == OTP_VERSION_2)
     {
-        if (bdt)  { *bdt  = info.v2.boardType; }
+        if (bdt)  { *bdt  = (BoardType)info.v2.boardType; }
         if (sbdt) { *sbdt = info.v2.subBoardType; }
         return 0;
     }
@@ -327,7 +327,10 @@ int boardSetup(BoardType type, pcbVersion breaking_version) {
     }
 
     pcbVersion ver;
-    if (getPcbVersion(&ver) || ver.major < breaking_version.major || ver.minor < breaking_version.minor) {
+    if (getPcbVersion(&ver) || ver.major < breaking_version.major) {
+        bsSetError(BS_VERSION_ERROR_Msk);
+    }
+    else if(ver.major == breaking_version.major && ver.minor < breaking_version.minor) {
         bsSetError(BS_VERSION_ERROR_Msk);
     }
 

--- a/unit_testing/Util/CMakeLists.txt
+++ b/unit_testing/Util/CMakeLists.txt
@@ -39,9 +39,16 @@ enable_testing()
 
 include(GoogleTest)
 
-# ADCMonitor tests
+# CAProtocol tests
 add_executable(caprotocol_test caprotocol_tests.cpp ${UT_STUBS}/stub_CAProtocolStm.cpp)
 target_include_directories(caprotocol_test PRIVATE ${UT_FAKES} ${UT_STUBS} ${INC_LIB})
 target_link_libraries(caprotocol_test GTest::gtest_main gmock_main)
 target_compile_definitions(caprotocol_test PUBLIC UNIT_TESTING)
 gtest_discover_tests(caprotocol_test)
+
+# Systeminfo tests
+add_executable(systeminfo_test systeminfo_tests.cpp ${UT_FAKES}/fake_HAL_otp.cpp)
+target_include_directories(systeminfo_test PRIVATE ${UT_FAKES} ${UT_STUBS} ${INC_LIB})
+target_link_libraries(systeminfo_test GTest::gtest_main gmock_main)
+target_compile_definitions(systeminfo_test PUBLIC UNIT_TESTING)
+gtest_discover_tests(systeminfo_test)

--- a/unit_testing/Util/systeminfo_tests.cpp
+++ b/unit_testing/Util/systeminfo_tests.cpp
@@ -1,0 +1,71 @@
+/*!
+** @file   systeminfo_tests.cpp
+** @author Luke W
+** @date   05/11/2024
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+/* Fakes */
+
+/* Real supporting units */
+
+/* UUT */
+#include "systeminfo.c"
+
+/***************************************************************************************************
+** TEST FIXTURES
+***************************************************************************************************/
+
+class TestSystemInfo: public ::testing::Test
+{
+    public: 
+        /*******************************************************************************************
+        ** PUBLIC METHODS
+        *******************************************************************************************/
+        TestSystemInfo() {}
+
+    private:
+        /*******************************************************************************************
+        ** PRIVATE METHODS
+        *******************************************************************************************/
+};
+
+/***************************************************************************************************
+** TESTS
+***************************************************************************************************/
+
+TEST_F(TestSystemInfo, testBoardVersion) {
+    /* Setup fake board info with correct version number */
+    BoardInfo bi = {
+        .v2 = {
+            .otpVersion = OTP_VERSION_2,
+            .boardType = AC_Board,
+            .pcbVersion = {1, 1},
+        }
+    };
+    HAL_otpWrite(&bi);
+
+    /* Different test cases smaller, equal and larger for both major/minor */
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 0}));
+    /* Error flag is retained between tests, so make sure to clear it */
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 1}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 2}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 0}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 1}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ(-1, boardSetup(AC_Board, {1, 2}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 0}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 1}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 2}));
+    bsClearField(0xFFFFFFFF);
+    EXPECT_EQ(-1, boardSetup(DC_Board, {1, 1}));
+}


### PR DESCRIPTION
* Version check would previously fail if the breaking version minor was higher than the actual version minor (regardless of the value of major)
* Added unit test to catch the error