### PR TITLE
systeminfo: add ACTenChannel board 

### DIFF
--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -59,7 +59,8 @@ typedef enum {
     ER              = 17,
     ERHC            = 18,
     VFD             = 19,
-    Tachometer      = 20
+    Tachometer      = 20,
+    ACTenChannel    = 21
 } BoardType;
 typedef uint8_t SubBoardType; // SubBoardType needed for some boards.
 

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -301,7 +301,7 @@ void inputCAProtocol(CAProtocolCtx* ctx)
     {
         if (ctx->allOn) ctx->allOn(false, -1);
     }
-    else if (input[0] == 'p' && strnlen(input, 13) <= 13) // 13 since that is length of pX on YY ZZZ%
+    else if (input[0] == 'p' && strnlen(input, 14) <= 14) // 14 since that is length of pXX on YY ZZZ%
     {
         char cmd[13];
         int port;

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -104,6 +104,7 @@ static const char* productType(uint8_t id)
     case ERHC             :  return "ERHC";            	 break;
     case VFD              :  return "VFD";            	 break;
     case Tachometer       :  return "Tachometer";     	 break;
+    case ACTenChannel     :  return "ACTenChannel";    	 break;
     }
     return "NA";
 }


### PR DESCRIPTION
 - Add `ACTenChannel` to valid board types
 - Allow for p10 command (previous implementation was limited to single digit ports)
 - Used in this [PR](https://github.com/copenhagenatomics/CA_Embedded/pull/178)