### PR TITLE
ADCmin and strchr

### DIFF
--- a/STM32/ADCMonitor/Inc/ADCMonitor.h
+++ b/STM32/ADCMonitor/Inc/ADCMonitor.h
@@ -41,7 +41,8 @@ int16_t cmaAvarage(int16_t *pData, uint16_t channel, int16_t cma, int k);
 double ADCMean(const int16_t *pData, uint16_t channel);
 double ADCAbsMean(const int16_t *pData, uint16_t channel);
 double ADCrms(const int16_t *pData, uint16_t channel);
-uint16_t ADCmax(const int16_t *pData, uint16_t channel);
+int16_t ADCmax(const int16_t *pData, uint16_t channel);
+int16_t ADCmin(const int16_t *pData, uint16_t channel);
 
 // @Description Compute fast mean using bit shift (NOTE: Can only be used if array length is multiple of 2)
 // @Param pData Pointer to buffer from callback function

--- a/STM32/ADCMonitor/Src/ADCmonitor.c
+++ b/STM32/ADCMonitor/Src/ADCmonitor.c
@@ -188,7 +188,7 @@ void ADCSetOffset(int16_t* pData, int16_t offset, uint16_t channel)
 
     for (uint32_t sampleId = 0; sampleId < ADCMonitorData.noOfSamples; sampleId++)
     {
-        // No need to addjust for overflow since ADC is 12 bits.
+        // No need to adjust for overflow since ADC is 12 bits.
         pData[sampleId*ADCMonitorData.noOfChannels + channel] += offset;
     }
 }

--- a/STM32/ADCMonitor/Src/ADCmonitor.c
+++ b/STM32/ADCMonitor/Src/ADCmonitor.c
@@ -139,7 +139,7 @@ double ADCAbsMean(const int16_t *pData, uint16_t channel)
     return ( ((double) sum) / ((double) ADCMonitorData.noOfSamples) );
 }
 
-uint16_t ADCmax(const int16_t *pData, uint16_t channel)
+int16_t ADCmax(const int16_t *pData, uint16_t channel)
 {
     if (ADCMonitorData.activeBuffer == NotAvailable ||
         pData == NULL ||
@@ -148,14 +148,33 @@ uint16_t ADCmax(const int16_t *pData, uint16_t channel)
         return 0;
     }
 
-    uint16_t max = 0;
-    for (uint32_t sampleId = 0; sampleId < ADCMonitorData.noOfSamples; sampleId++)
+    int16_t max = pData[channel];
+    for (uint32_t sampleId = 1; sampleId < ADCMonitorData.noOfSamples; sampleId++)
     {
         int16_t sample = pData[sampleId*ADCMonitorData.noOfChannels + channel];
         if (max < sample)
             max = sample;
     }
     return max;
+}
+
+int16_t ADCmin(const int16_t *pData, uint16_t channel)
+{
+    if (ADCMonitorData.activeBuffer == NotAvailable ||
+        pData == NULL ||
+        channel >= ADCMonitorData.noOfChannels)
+    {
+        return 0;
+    }
+
+    int16_t min = pData[channel];
+    for (uint32_t sampleId = 1; sampleId < ADCMonitorData.noOfSamples; sampleId++)
+    {
+        int16_t sample = pData[sampleId*ADCMonitorData.noOfChannels + channel];
+        if (min > sample)
+            min = sample;
+    }
+    return min;
 }
 
 void ADCSetOffset(int16_t* pData, int16_t offset, uint16_t channel)

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <strings.h>
 #include <stdlib.h>
 #include <inttypes.h>
 
@@ -46,7 +45,7 @@ static int getArgs(const char * input, char delim, char ** args, int max_len);
 
 static void calibration(CAProtocolCtx* ctx, const char* input)
 {
-    char* idx = index((char*)input, ' ');
+    char* idx = strchr((char*)input, ' ');
     CACalibration cal[MAX_NO_CALIBRATION];
     int noOfCalibrations = 0;
 
@@ -76,7 +75,7 @@ static void calibration(CAProtocolCtx* ctx, const char* input)
             cal[noOfCalibrations] = (CACalibration) { port, alpha, beta, threshold };
             noOfCalibrations++;
         }
-        idx = index(idx, ' '); // get the next space.
+        idx = strchr(idx, ' '); // get the next space.
     }
 
     if (noOfCalibrations != 0)
@@ -89,7 +88,7 @@ static void calibration(CAProtocolCtx* ctx, const char* input)
 
 static void logging(CAProtocolCtx* ctx, const char *input)
 {
-    char* idx = index((char*)input, ' ');
+    char* idx = strchr((char*)input, ' ');
     int port;
 
     if (!idx) {

--- a/unit_testing/ADCMonitor/adcmonitor_tests.cpp
+++ b/unit_testing/ADCMonitor/adcmonitor_tests.cpp
@@ -118,7 +118,7 @@ TEST_F(ADCMonitorTest, testADCAbsMean)
 TEST_F(ADCMonitorTest, testADCmax)
 {
     const int noOfSamples = 1000;
-    const int noOfChannels = 3;
+    const int noOfChannels = 5;
     int16_t pData[noOfSamples*noOfChannels*2] = {0};
 
     for (int i = 0; i<noOfSamples; i++)
@@ -128,16 +128,54 @@ TEST_F(ADCMonitorTest, testADCmax)
     }
 
     const int AMPLITUDE = 2047; 
-    const int OFFSET = 2047;
-    generateSine(pData, noOfChannels, noOfSamples, 2, OFFSET, AMPLITUDE, 1000);
+    const int OFFSET_1 = 2047;
+    const int OFFSET_2 = 0;
+    const int OFFSET_3 = -2047;
+
+    generateSine(pData, noOfChannels, noOfSamples, 2, OFFSET_1, AMPLITUDE, 1000);
+    generateSine(pData, noOfChannels, noOfSamples, 3, OFFSET_2, AMPLITUDE, 1000);
+    generateSine(pData, noOfChannels, noOfSamples, 4, OFFSET_3, AMPLITUDE, 1000);
 
     ADC_HandleTypeDef dummy = { { noOfChannels } };
     ADCMonitorInit(&dummy, pData, noOfSamples*noOfChannels*2);
     HAL_ADC_ConvHalfCpltCallback(&dummy); 
 
     EXPECT_EQ(ADCmax(pData,0), noOfSamples-1);
-    EXPECT_EQ(ADCmax(pData,1), (noOfSamples-1)*2); 
-    EXPECT_EQ(ADCmax(pData,2), 3993);    
+    EXPECT_EQ(ADCmax(pData,1), (noOfSamples-1)*2);
+    EXPECT_EQ(ADCmax(pData,2), 3993);
+    EXPECT_EQ(ADCmax(pData,3), 1946);
+    EXPECT_EQ(ADCmax(pData,4), -100);
+}
+
+TEST_F(ADCMonitorTest, testADCmin)
+{
+    const int noOfSamples = 1000;
+    const int noOfChannels = 5;
+    int16_t pData[noOfSamples*noOfChannels*2] = {0};
+
+    for (int i = 0; i<noOfSamples; i++)
+    {
+        pData[noOfChannels*i] = i*1 + 12;
+        pData[noOfChannels*i+1] = -i*2;
+    }
+
+    const int AMPLITUDE = 2047;
+    const int OFFSET_1 = 2047;
+    const int OFFSET_2 = 0;
+    const int OFFSET_3 = -2047;
+    generateSine(pData, noOfChannels, noOfSamples, 2, OFFSET_1, AMPLITUDE, 1000);
+    generateSine(pData, noOfChannels, noOfSamples, 3, OFFSET_2, AMPLITUDE, 1000);
+    generateSine(pData, noOfChannels, noOfSamples, 4, OFFSET_3, AMPLITUDE, 1000);
+
+    ADC_HandleTypeDef dummy = { { noOfChannels } };
+    ADCMonitorInit(&dummy, pData, noOfSamples*noOfChannels*2);
+    HAL_ADC_ConvHalfCpltCallback(&dummy);
+
+    EXPECT_EQ(ADCmin(pData,0), 12);
+    EXPECT_EQ(ADCmin(pData,1), (1-noOfSamples)*2);
+    EXPECT_EQ(ADCmin(pData,2), 100);
+    EXPECT_EQ(ADCmin(pData,3), -1946);
+    EXPECT_EQ(ADCmin(pData,4), -3993);
 }
 
 TEST_F(ADCMonitorTest, testADCSetOffset)


### PR DESCRIPTION
- **Addition of `ADCmin()`:** computes the minimum of the selected ADC buffer. Can be a negative value if `ADCSetOffset()` has been applied.
- **Modification of `ADCmax()`:** outputs an int16 instead of uint16 to make sure a negative value can be the output (after `ADCSetOffset()`has been used). These modifications shouldn't be a problem as the ADC is 12 bits and the buffer is 16 bits.

_**Note:**_
- `index()` legacy function from `strings.h` replaced by `strchr()` from `string.h` [link](https://pubs.opengroup.org/onlinepubs/009695399/functions/index.html)

**Tested on LowVoltageVFD, Current and Temperature boards that already had the flash update**