### PR TITLE
Status definition command

### DIFF
--- a/STM32/Util/Inc/CAProtocol.h
+++ b/STM32/Util/Inc/CAProtocol.h
@@ -11,6 +11,10 @@
 #include <stdbool.h>
 #include "HAL_otp.h"
 
+/***************************************************************************************************
+** STRUCTURES
+***************************************************************************************************/
+
 typedef struct
 {
     int port;
@@ -30,6 +34,9 @@ typedef struct
     // system info request using "Status". These should be overwritten with additional 
     // board specific status codes.
     void (*printStatus)();
+    // system info request using "StatusDef". These should be overwritten with additional 
+    // board specific status codes.
+    void (*printStatusDef)();
     void (*jumpToBootLoader)();
 
     // Calibration request.
@@ -50,6 +57,10 @@ typedef struct
 
     struct CAProtocolData *data; // Private data for CAProtocol.
 } CAProtocolCtx;
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
 
 void inputCAProtocol(CAProtocolCtx* ctx);
 void initCAProtocol(CAProtocolCtx* ctx, ReaderFn fn);

--- a/STM32/Util/Inc/CAProtocolStm.h
+++ b/STM32/Util/Inc/CAProtocolStm.h
@@ -2,10 +2,15 @@
 #include "CAProtocol.h"
 #include <stdbool.h>
 
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
+
 void HALundefined(const char *input);
 void HALJumpToBootloader();
 void CAPrintHeader();
 void CAPrintStatus(bool printStart);
+void CAPrintStatusDef(bool printStart);
 void CAotpRead();
 
 // analyse reason for boot and in case of SW reset jump to DFU SW update.

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -77,6 +77,12 @@ typedef struct {
     uint8_t minor;
 } pcbVersion;
 
+typedef struct
+{
+    char* buf;
+    int len;
+} bufferStructure;
+
 /***************************************************************************************************
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
@@ -90,8 +96,8 @@ const char* systemInfo();
 const char* statusInfo(bool printStart);
 
 /* Generic info about system status definition.
- * @return info about system in null terminated string. */
-const char* statusDefInfo(bool printStart);
+ * @return buffer structure. */
+bufferStructure statusDefInfo(bool printStart);
 
 // Description: Get Boardinfo. If input values are NULL these are ignored.
 // @param bdt:  Boardtype used in the SW running

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -8,6 +8,10 @@
 extern "C" {
 #endif
 
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
+
 /* General Board Status register definitions */
 #define BS_ERROR_Pos                        31U
 #define BS_ERROR_Msk                        (1UL << BS_ERROR_Pos)
@@ -37,6 +41,10 @@ extern "C" {
 #define BS_SYSTEM_ERRORS_Msk                (BS_OVER_TEMPERATURE_Msk | BS_UNDER_VOLTAGE_Msk | \
                                              BS_OVER_VOLTAGE_Msk | BS_OVER_CURRENT_Msk | \
                                              BS_VERSION_ERROR_Msk | BS_USB_ERROR_Msk)
+
+/***************************************************************************************************
+** STRUCTURES
+***************************************************************************************************/
 
 // NOTE!! Do not change order or values since this list must match ALL OTP programmers.
 typedef enum {
@@ -69,6 +77,10 @@ typedef struct {
     uint8_t minor;
 } pcbVersion;
 
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
+
 /* Generic info about PCB and git build system/data.
  * @return info about system in null terminated string. */
 const char* systemInfo();
@@ -76,6 +88,10 @@ const char* systemInfo();
 /* Generic info about system status.
  * @return info about system in null terminated string. */
 const char* statusInfo(bool printStart);
+
+/* Generic info about system status definition.
+ * @return info about system in null terminated string. */
+const char* statusDefInfo(bool printStart);
 
 // Description: Get Boardinfo. If input values are NULL these are ignored.
 // @param bdt:  Boardtype used in the SW running

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -77,12 +77,6 @@ typedef struct {
     uint8_t minor;
 } pcbVersion;
 
-typedef struct
-{
-    char* buf;
-    int len;
-} bufferStructure;
-
 /***************************************************************************************************
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
@@ -97,7 +91,7 @@ const char* statusInfo(bool printStart);
 
 /* Generic info about system status definition.
  * @return buffer structure. */
-bufferStructure statusDefInfo(bool printStart);
+const char* statusDefInfo(bool printStart);
 
 // Description: Get Boardinfo. If input values are NULL these are ignored.
 // @param bdt:  Boardtype used in the SW running

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -40,7 +40,7 @@ static int CAgetMsg(CAProtocolCtx* ctx);
 static int getArgs(const char * input, char delim, char ** args, int max_len);
 
 /***************************************************************************************************
-** FUNCTION DEFINITIONS
+** PRIVATE FUNCTION DEFINITIONS
 ***************************************************************************************************/
 
 static void calibration(CAProtocolCtx* ctx, const char* input)
@@ -228,6 +228,10 @@ static int getArgs(const char * input, char delim, char ** argv, int max_len)
     return count;
 }
 
+/***************************************************************************************************
+** PUBLIC FUNCTION DEFINITIONS
+***************************************************************************************************/
+
 void inputCAProtocol(CAProtocolCtx* ctx)
 {
     int msgLen = CAgetMsg(ctx);
@@ -249,6 +253,13 @@ void inputCAProtocol(CAProtocolCtx* ctx)
         if (ctx->printStatus)
             ctx->printStatus(); // Print board specific part of status message
         CAPrintStatus(false); // Print end of status message
+    }
+    else if(strncmp(input, "StatusDef", 9) == 0)
+    {
+        CAPrintStatusDef(true); // Print start of status definition message
+        if (ctx->printStatusDef)
+            ctx->printStatusDef(); // Print board specific part of statusdefinition message
+        CAPrintStatusDef(false); // Print end of status definition message
     }
     else if(strncmp(input, "DFU", 3) == 0)
     {

--- a/STM32/Util/Src/CAProtocol.c
+++ b/STM32/Util/Src/CAProtocol.c
@@ -247,19 +247,19 @@ void inputCAProtocol(CAProtocolCtx* ctx)
         if (ctx->printHeader)
             ctx->printHeader();
     }
-    else if(strncmp(input, "Status", 6) == 0)
-    {
-        CAPrintStatus(true); // Print start of status message
-        if (ctx->printStatus)
-            ctx->printStatus(); // Print board specific part of status message
-        CAPrintStatus(false); // Print end of status message
-    }
     else if(strncmp(input, "StatusDef", 9) == 0)
     {
         CAPrintStatusDef(true); // Print start of status definition message
         if (ctx->printStatusDef)
             ctx->printStatusDef(); // Print board specific part of statusdefinition message
         CAPrintStatusDef(false); // Print end of status definition message
+    }
+    else if(strncmp(input, "Status", 6) == 0)
+    {
+        CAPrintStatus(true); // Print start of status message
+        if (ctx->printStatus)
+            ctx->printStatus(); // Print board specific part of status message
+        CAPrintStatus(false); // Print end of status message
     }
     else if(strncmp(input, "DFU", 3) == 0)
     {

--- a/STM32/Util/Src/CAProtocolStm.c
+++ b/STM32/Util/Src/CAProtocolStm.c
@@ -46,13 +46,14 @@ void CAPrintHeader()
 
 void CAPrintStatus(bool printStart)
 {
-    USBnprintf(statusInfo(printStart));
+    const char* buf = statusInfo(printStart);
+    writeUSB(buf, strlen(buf));
 }
 
 void CAPrintStatusDef(bool printStart)
 {
-    bufferStructure bufStruct = statusDefInfo(printStart);
-    writeUSB(bufStruct.buf, bufStruct.len);
+    const char* buf = statusDefInfo(printStart);
+    writeUSB(buf, strlen(buf));
 }
 
 void CAotpRead()

--- a/STM32/Util/Src/CAProtocolStm.c
+++ b/STM32/Util/Src/CAProtocolStm.c
@@ -19,6 +19,10 @@
 #define RCC_FLAG_IWDGRST RCC_FLAG_IWDG1RST
 #endif
 
+/***************************************************************************************************
+** PUBLIC FUNCTION DEFINITIONS
+***************************************************************************************************/
+
 void HALundefined(const char *input)
 {
     if(strcmp(input, "\0"))
@@ -43,6 +47,11 @@ void CAPrintHeader()
 void CAPrintStatus(bool printStart)
 {
     USBnprintf(statusInfo(printStart));
+}
+
+void CAPrintStatusDef(bool printStart)
+{
+    USBnprintf(statusDefInfo(printStart));
 }
 
 void CAotpRead()

--- a/STM32/Util/Src/CAProtocolStm.c
+++ b/STM32/Util/Src/CAProtocolStm.c
@@ -51,7 +51,8 @@ void CAPrintStatus(bool printStart)
 
 void CAPrintStatusDef(bool printStart)
 {
-    USBnprintf(statusDefInfo(printStart));
+    bufferStructure bufStruct = statusDefInfo(printStart);
+    writeUSB(bufStruct.buf, bufStruct.len);
 }
 
 void CAotpRead()

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -161,11 +161,11 @@ const char* statusInfo(bool printStart)
     // Print end of message and return
     if (!printStart)
     {
-        len += snprintf(&buf[len], sizeof(buf) - len, "End of board status. \r\n");
+        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status. \r\n");
         return buf;
     }
 
-    len += snprintf(&buf[len], sizeof(buf) - len, "Start of board status:\r\n");
+    len += snprintf(&buf[len], sizeof(buf) - len, "\r\nStart of board status:\r\n");
     if (!(BS.boardStatus & BS_ERROR_Msk))
     {
         len += snprintf(&buf[len], sizeof(buf) - len, "The board is operating normally.\r\n");
@@ -221,16 +221,15 @@ const char* statusInfo(bool printStart)
     return buf;
 }
 
-bufferStructure statusDefInfo(bool printStart)
+const char* statusDefInfo(bool printStart)
 {
     int len = 0;
 
     // Print end of message and return
     if (!printStart)
     {
-        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status definition. \r\n");
-        bufferStructure bufStruct = {buf, len};
-        return bufStruct;
+        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status definition.\r\n");
+        return buf;
     }
 
     len += snprintf(&buf[len], sizeof(buf) - len, "\r\nStart of board status definition:\r\n");
@@ -245,8 +244,7 @@ bufferStructure statusDefInfo(bool printStart)
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",USB error\r\n", BS_USB_ERROR_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n", BS_FLASH_ONGOING_Msk);
     
-    bufferStructure bufStruct = {buf, len};
-    return bufStruct;
+    return buf;
 }
 
 int getBoardInfo(BoardType *bdt, SubBoardType *sbdt)

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -221,6 +221,31 @@ const char* statusInfo(bool printStart)
     return buf;
 }
 
+const char* statusDefInfo(bool printStart)
+{
+    int len = 0;
+
+    // Print end of message and return
+    if (!printStart)
+    {
+        len += snprintf(&buf[len], sizeof(buf) - len, "End of board status definition. \r\n");
+        return buf;
+    }
+
+    len += snprintf(&buf[len], sizeof(buf) - len, "Start of board status definition:\r\n");
+
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Error\r\n", BS_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over temperature\r\n", BS_OVER_TEMPERATURE_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Under voltage\r\n", BS_UNDER_VOLTAGE_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over voltage\r\n", BS_OVER_VOLTAGE_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over current\r\n", BS_OVER_CURRENT_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Version error\r\n", BS_VERSION_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",USB error\r\n", BS_USB_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n", BS_USB_ERROR_Msk);
+
+    return buf;
+}
+
 int getBoardInfo(BoardType *bdt, SubBoardType *sbdt)
 {
     BoardInfo info = { 0 };

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -234,6 +234,7 @@ const char* statusDefInfo(bool printStart)
 
     len += snprintf(&buf[len], sizeof(buf) - len, "Start of board status definition:\r\n");
 
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",System errors\r\n", BS_SYSTEM_ERRORS_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Error\r\n", BS_ERROR_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over temperature\r\n", BS_OVER_TEMPERATURE_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Under voltage\r\n", BS_UNDER_VOLTAGE_Msk);
@@ -241,7 +242,7 @@ const char* statusDefInfo(bool printStart)
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over current\r\n", BS_OVER_CURRENT_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Version error\r\n", BS_VERSION_ERROR_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",USB error\r\n", BS_USB_ERROR_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n", BS_USB_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n", BS_FLASH_ONGOING_Msk);
 
     return buf;
 }

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -35,7 +35,7 @@ static struct BS
     pcbVersion pcb_version;
 } BS = {0};
 
-// Print buffer for systemInfo & statusInfo
+// Print buffer for systemInfo, statusInfo and statusDefInfo
 static char buf[600] = { 0 };
 
 // F4xx UID
@@ -221,18 +221,19 @@ const char* statusInfo(bool printStart)
     return buf;
 }
 
-const char* statusDefInfo(bool printStart)
+bufferStructure statusDefInfo(bool printStart)
 {
     int len = 0;
 
     // Print end of message and return
     if (!printStart)
     {
-        len += snprintf(&buf[len], sizeof(buf) - len, "End of board status definition. \r\n");
-        return buf;
+        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status definition. \r\n");
+        bufferStructure bufStruct = {buf, len};
+        return bufStruct;
     }
 
-    len += snprintf(&buf[len], sizeof(buf) - len, "Start of board status definition:\r\n");
+    len += snprintf(&buf[len], sizeof(buf) - len, "\r\nStart of board status definition:\r\n");
 
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",System errors\r\n", BS_SYSTEM_ERRORS_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Error\r\n", BS_ERROR_Msk);
@@ -243,8 +244,9 @@ const char* statusDefInfo(bool printStart)
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Version error\r\n", BS_VERSION_ERROR_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",USB error\r\n", BS_USB_ERROR_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n", BS_FLASH_ONGOING_Msk);
-
-    return buf;
+    
+    bufferStructure bufStruct = {buf, len};
+    return bufStruct;
 }
 
 int getBoardInfo(BoardType *bdt, SubBoardType *sbdt)

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -111,6 +111,35 @@ void statusPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) 
 }
 
 /*!
+** @brief Tests that the status definition printout matches the correct format
+**
+** @param[in] sst         Test data object
+** @param[in] pass_string The board specific part of the status definition printout
+**
+** Initialises the board then sends the 'StatusDef' command. Checks the response matches the protocol 
+** template and the supplied board specific string.
+*/
+void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) {
+    sst.boundInit();
+    /* Note: usb RX buffer is flushed during the first loop, so a single loop must be done before
+    ** printing anything */
+    sst.testFixture->_loopFunction(sst.testFixture->bootMsg);
+    sst.testFixture->writeBoardMessage("StatusDef\n");
+
+    vector<const char*> bsd_pre = {"\r", 
+        "Boot Unit Test\r", 
+        "Start of board status definition:\r"};
+    vector<const char*> bsd_post = {"\r", 
+        "End of board status definition. \r"
+    };
+
+    bsd_pre.insert(bsd_pre.end(), pass_string.begin(), pass_string.end());
+    bsd_pre.insert(bsd_pre.end(), bsd_post.begin(), bsd_post.end());
+
+    EXPECT_FLUSH_USB(::testing::ElementsAreArray(bs_pre));
+}
+
+/*!
 ** @brief Tests that the serial printout matches the correct format
 **
 ** @param[in] sst         Test data object

--- a/unit_testing/Util/serialStatus_tests.h
+++ b/unit_testing/Util/serialStatus_tests.h
@@ -41,6 +41,7 @@ class SerialStatusTest {
 void goldenPathTest(SerialStatusTest& sst, const char* pass_string, int firstPrintTick=100);
 void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick=100);
 void statusPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
+void statusDefPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
 void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char* cal_string=nullptr);
 
 #endif /* SERIAL_STATUS_TESTS_H_ */

--- a/unit_testing/stubs/stub_CAProtocolStm.cpp
+++ b/unit_testing/stubs/stub_CAProtocolStm.cpp
@@ -26,6 +26,11 @@ void CAPrintStatus(bool printStart)
 
 }
 
+void CAPrintStatusDef(bool printStart)
+{
+
+}
+
 void CAotpRead()
 {
 


### PR DESCRIPTION
When sending `StatusDef` on Serial, it will print a list of the status bits with their respective bit mask as well as their name.

In a more or less distant future, this command is intended to be sent by LoopControl when a board is detected or rebooted, so it can get information about all status bits.

The first line called System errors makes it possible to distinguish between error and status.

This new feature has been tested on VFD V1.1:

![image](https://github.com/user-attachments/assets/25c04b04-37e6-4ac1-b507-b0a35f49299b)