### PR TITLE
Update bsSetField / bsSetError functions

### DIFF
--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -132,6 +133,12 @@ void bsSetField(uint32_t field);
 // Description: set a board status field.
 // @param field: a 1 bit shifted to the field index to be cleared.
 void bsClearField(uint32_t field);
+
+// Description: Update a board status field
+void bsUpdateField(uint32_t field, bool set);
+
+// Description: Update a board status error field
+void bsUpdateError(uint32_t field, bool set, uint32_t error_bits);
 
 // Description: Get the board status registry.
 // Return a uint32_t containing the board status.

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -326,6 +326,40 @@ void bsClearError(uint32_t field) {
 void bsSetError(uint32_t field) { BS.boardStatus |= (BS_ERROR_Msk | field); }
 void bsSetField(uint32_t field){ BS.boardStatus |= field; }
 void bsClearField(uint32_t field){ BS.boardStatus &= ~field; }
+
+/*!
+** @brief Update a field using a bool to determine whether set or clear
+**
+** @param[in] field      Field to set/clear
+** @param[in] set        Whether to Set or Clear the field
+*/
+void bsUpdateField(uint32_t field, bool set) {
+    if(set) {
+        bsSetField(field);
+    }
+    else {
+        bsClearField(field);
+    }
+}
+
+/*!
+** @brief Update an error field using a bool to determine whether set or clear
+**
+** @param[in] field      Field to set/clear
+** @param[in] set        Whether to Set or Clear the field
+** @param[in] error_bits A collection of all error bits. Used to determine if the master error bit
+**                       should be set or not
+*/
+void bsUpdateError(uint32_t field, bool set, uint32_t error_bits) {
+    if(set) {
+        bsSetError(field);
+    }
+    else {
+        bsClearField(field);
+        bsClearError(error_bits);
+    }
+}
+
 uint32_t bsGetStatus(){ return BS.boardStatus; }
 uint32_t bsGetField(uint32_t field){ return BS.boardStatus & field; }
 void setBoardTemp(float temp){ BS.temp = temp; }


### PR DESCRIPTION
* New API for bsSet/ClearField/Error
* Should change code from this:
```
    void (*setter)(uint32_t) = getPumpState() ? bsSetField : bsClearField;
    setter(LIQUID_LEVEL_PUMP_STATUS_Msk);

OR

    getPumpState() ? bsSetField(LIQUID_LEVEL_PUMP_STATUS_Msk) : bsClearField(LIQUID_LEVEL_PUMP_STATUS_Msk);
```
to this:
```
    bsUpdateField(LIQUID_LEVEL_PUMP_STATUS_Msk, getPumpState());
``` 
* Note also that bsUpdateError combines the behaviour of bsSetError and bsClearError, when previously they behaved differently
* No change to the previous implementation so as not to force far reaching updates on other pieces of code