### PR TITLE
Prevented interruption of loading circular buffer

### DIFF
--- a/unit_testing/USBprint/Inc/stm32f4xx_hal_conf.h
+++ b/unit_testing/USBprint/Inc/stm32f4xx_hal_conf.h
@@ -87,7 +87,7 @@
 /* #define HAL_RCC_MODULE_ENABLED */
 /* #define HAL_FLASH_MODULE_ENABLED */
 /* #define HAL_PWR_MODULE_ENABLED */
-/* #define HAL_CORTEX_MODULE_ENABLED */
+#define HAL_CORTEX_MODULE_ENABLED
 
 /* ########################## HSE/HSI Values adaptation ##################### */
 /**

--- a/unit_testing/fakes/fake_stm32xxxx_hal.cpp
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.cpp
@@ -316,3 +316,11 @@ void HAL_NVIC_SystemReset(void)
 {
 
 }
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn) {}
+
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn) {}
+
+#endif


### PR DESCRIPTION
Turns this:

![image](https://github.com/user-attachments/assets/ccd2e667-5724-4ec6-806a-678ed8d68e1a)

Note: second packet broken up into "End ", "of board ", "st", "atus." with the last element coming after a temperature line

into this:

![image](https://github.com/user-attachments/assets/edc481c4-703b-465b-9968-7e3a7e56dee1)

See comment in code for rational