### PR TITLE
boardErrorStatus and over voltage fix

### DIFF
--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -1,9 +1,15 @@
+/*!
+ * @file    systemInfo.h
+ * @brief   Header file of systemInfo.c
+ * @date    25/03/2025
+ * @author  Timothé D
+ */
+
 #ifndef SYSTEM_INFO_H
 #define SYSTEM_INFO_H
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,64 +20,66 @@ extern "C" {
 ***************************************************************************************************/
 
 /* General Board Status register definitions */
-#define BS_ERROR_Pos                        31U
-#define BS_ERROR_Msk                        (1UL << BS_ERROR_Pos)
 
-#define BS_OVER_TEMPERATURE_Pos             30U
-#define BS_OVER_TEMPERATURE_Msk             (1UL << BS_OVER_TEMPERATURE_Pos)
+#define BS_ERROR_Pos 31U
+#define BS_ERROR_Msk (1UL << BS_ERROR_Pos)
 
-#define BS_UNDER_VOLTAGE_Pos                29U
-#define BS_UNDER_VOLTAGE_Msk                (1UL << BS_UNDER_VOLTAGE_Pos)
+#define BS_OVER_TEMPERATURE_Pos 30U
+#define BS_OVER_TEMPERATURE_Msk (1UL << BS_OVER_TEMPERATURE_Pos)
 
-#define BS_OVER_VOLTAGE_Pos                 28U
-#define BS_OVER_VOLTAGE_Msk                 (1UL << BS_OVER_VOLTAGE_Pos)
+#define BS_UNDER_VOLTAGE_Pos 29U
+#define BS_UNDER_VOLTAGE_Msk (1UL << BS_UNDER_VOLTAGE_Pos)
 
-#define BS_OVER_CURRENT_Pos                 27U
-#define BS_OVER_CURRENT_Msk                 (1UL << BS_OVER_CURRENT_Pos)
+#define BS_OVER_VOLTAGE_Pos 28U
+#define BS_OVER_VOLTAGE_Msk (1UL << BS_OVER_VOLTAGE_Pos)
 
-#define BS_VERSION_ERROR_Pos                26U
-#define BS_VERSION_ERROR_Msk                (1UL << BS_VERSION_ERROR_Pos)
+#define BS_OVER_CURRENT_Pos 27U
+#define BS_OVER_CURRENT_Msk (1UL << BS_OVER_CURRENT_Pos)
 
-#define BS_USB_ERROR_Pos                    25U
-#define BS_USB_ERROR_Msk                    (1UL << BS_USB_ERROR_Pos)
+#define BS_VERSION_ERROR_Pos 26U
+#define BS_VERSION_ERROR_Msk (1UL << BS_VERSION_ERROR_Pos)
 
-#define BS_FLASH_ONGOING_Pos                24U
-#define BS_FLASH_ONGOING_Msk                (1UL << BS_FLASH_ONGOING_Pos)
+#define BS_USB_ERROR_Pos 25U
+#define BS_USB_ERROR_Msk (1UL << BS_USB_ERROR_Pos)
+
+#define BS_FLASH_ONGOING_Pos 24U
+#define BS_FLASH_ONGOING_Msk (1UL << BS_FLASH_ONGOING_Pos)
 
 /* Used for defining which bits are errors, and which are statuses */
-#define BS_SYSTEM_ERRORS_Msk                (BS_OVER_TEMPERATURE_Msk | BS_UNDER_VOLTAGE_Msk | \
-                                             BS_OVER_VOLTAGE_Msk | BS_OVER_CURRENT_Msk | \
-                                             BS_VERSION_ERROR_Msk | BS_USB_ERROR_Msk)
+#define BS_SYSTEM_ERRORS_Msk                                                                      \
+    (BS_OVER_TEMPERATURE_Msk | BS_UNDER_VOLTAGE_Msk | BS_OVER_VOLTAGE_Msk | BS_OVER_CURRENT_Msk | \
+     BS_VERSION_ERROR_Msk | BS_USB_ERROR_Msk)
 
 /***************************************************************************************************
 ** STRUCTURES
 ***************************************************************************************************/
 
 // NOTE!! Do not change order or values since this list must match ALL OTP programmers.
+
 typedef enum {
-    AC_Board          = 1,
-    DC_Board          = 2,
-    Temperature       = 3,
-    Current           = 4,
-    GasFlow           = 5,
-    HumidityChip      = 6,
-    Pressure          = 7,
-    SaltFlowBoard     = 8,
-    SaltLeak          = 9,
+    AC_Board           = 1,
+    DC_Board           = 2,
+    Temperature        = 3,
+    Current            = 4,
+    GasFlow            = 5,
+    HumidityChip       = 6,
+    Pressure           = 7,
+    SaltFlowBoard      = 8,
+    SaltLeak           = 9,
     HotValveController = 10,
-	ZrO2Oxygen 		= 11,
-	AMBcurrent 		= 12,
-	Geiger 			= 13,
-	AirCondition 	= 14,
-	LightController = 15,
-    LiquidLevel     = 16,
-    ER              = 17,
-    ERHC            = 18,
-    VFD             = 19,
-    Tachometer      = 20,
-    ACTenChannel    = 21
+    ZrO2Oxygen         = 11,
+    AMBcurrent         = 12,
+    Geiger             = 13,
+    AirCondition       = 14,
+    LightController    = 15,
+    LiquidLevel        = 16,
+    ER                 = 17,
+    ERHC               = 18,
+    VFD                = 19,
+    Tachometer         = 20,
+    ACTenChannel       = 21
 } BoardType;
-typedef uint8_t SubBoardType; // SubBoardType needed for some boards.
+typedef uint8_t SubBoardType;  // SubBoardType needed for some boards.
 
 typedef struct {
     uint8_t major;
@@ -82,94 +90,34 @@ typedef struct {
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
-/* Generic info about PCB and git build system/data.
- * @return info about system in null terminated string. */
 const char* systemInfo();
-
-/* Generic info about system status.
- * @return info about system in null terminated string. */
 const char* statusInfo(bool printStart);
-
-/* Generic info about system status definition.
- * @return buffer structure. */
 const char* statusDefInfo(bool printStart);
-
-// Description: Get Boardinfo. If input values are NULL these are ignored.
-// @param bdt:  Boardtype used in the SW running
-// @param sbdt: SubBoardtype used in the SW running, if 0xFF value is ignore in compare
-// Return 0 if data is valid, else negative value.
 int getBoardInfo(BoardType* bdt, SubBoardType* sbdt);
+int getPcbVersion(pcbVersion* ver);
 
-// Description: get the PCB version of the board.
-// @param ver: Pointer to struct pcbVersion
-// Return 0 if data is valid, else negative value.
-int getPcbVersion(pcbVersion * ver);
-
-// Description: set a board status field.
-// @param field: a 1 bit shifted to the field index to be set in addition to
-// the error bit also being set.
-// @param range: the bits in the range parameter is reset prior to setting the
-// bits in the field parameter.
 void bsSetErrorRange(uint32_t field, uint32_t range);
-
-// Description: set a board status field.
-// @param field: a 1 bit shifted to the field index to be set.
-// @param range: the bits in the range parameter is reset prior to setting the
-// bits in the field parameter.
 void bsSetFieldRange(uint32_t field, uint32_t range);
-
-// Description: Set a board status field, and the error bit
-// @param field: a 1 bit shifted to the field index. Can be OR'd together
 void bsSetError(uint32_t field);
-
-// Description: Clear the error bit, if none of the bits in "field" are set
-// @param field: a 1 bit shifted to the field index. Can be OR'd together
 void bsClearError(uint32_t field);
-
-// Description: Set a board status field.
-// @param field: a 1 bit shifted to the field index to be set. Can be OR'd together
 void bsSetField(uint32_t field);
-
-// Description: set a board status field.
-// @param field: a 1 bit shifted to the field index to be cleared.
 void bsClearField(uint32_t field);
-
-// Description: Update a board status field
 void bsUpdateField(uint32_t field, bool set);
-
-// Description: Update a board status error field
 void bsUpdateError(uint32_t field, bool set, uint32_t error_bits);
-
-// Description: Get the board status registry.
-// Return a uint32_t containing the board status.
 uint32_t bsGetStatus();
-
-// Description: get a board status field.
-// @param field: a 1 bit shifted to the field index.
 uint32_t bsGetField(uint32_t field);
 
 void setBoardTemp(float temp);
 void setBoardVoltage(float voltage);
 void setBoardCurrent(float current);
 void setBoardUsbError(uint32_t err);
-
-/*!
-** @brief Sets the board type, the firmware is expecting to be used with
-*/
 void setFirmwareBoardType(BoardType type);
-
-/*!
-** @brief Sets the board version, the firmware is expecting to be used with
-*/
 void setFirmwareBoardVersion(pcbVersion version);
 
-/*!
-** @brief Sets the board type and version the firmware was compiled for
-*/
 int boardSetup(BoardType type, pcbVersion breaking_version, uint32_t boardErrorsMsk);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // SYSTEM_INFO_H
+#endif  // SYSTEM_INFO_H

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -166,7 +166,7 @@ void setFirmwareBoardVersion(pcbVersion version);
 /*!
 ** @brief Sets the board type and version the firmware was compiled for
 */
-int boardSetup(BoardType type, pcbVersion breaking_version);
+int boardSetup(BoardType type, pcbVersion breaking_version, uint32_t boardErrorsMsk);
 
 #ifdef __cplusplus
 }

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -1,31 +1,64 @@
-/*
- * Generic functions used the the STM system
+/*!
+ * @file    systemInfo.h
+ * @brief   Generic functions used for the STM system
+ * @date    25/03/2025
+ * @author  Timothé D
  */
 
-#include <stdio.h>
 #include <inttypes.h>
+#include <stdio.h>
 
 #include "HAL_otp.h"
 #include "systemInfo.h"
 
 #ifndef UNIT_TESTING
-    #if defined(STM32F401xC)
-    #include "stm32f4xx_hal.h"
-    #elif defined(STM32H753xx)
-    #include "stm32h7xx_hal.h"
-    #endif
-    #include "githash.h"
+#if defined(STM32F401xC)
+#include "stm32f4xx_hal.h"
+#elif defined(STM32H753xx)
+#include "stm32h7xx_hal.h"
+#endif
+#include "githash.h"
 #else
 
 #endif
 
+/***************************************************************************************************
+** DEFINES
+***************************************************************************************************/
 
-// Struct containing the board status sw registry
-// as well as some of the general values.
-// A board should update the values in this struct using the
-// functions defined below for updating the board status.
-static struct BS
-{
+// F4xx UID
+#ifndef UNIT_TESTING
+#define ID1 *((unsigned long*)(UID_BASE))
+#define ID2 *((unsigned long*)(UID_BASE + 4U))
+#define ID3 *((unsigned long*)(UID_BASE + 8U))
+#else
+#define ID1 (unsigned long)0U
+#define ID2 (unsigned long)0U
+#define ID3 (unsigned long)0U
+
+#define GIT_VERSION "0"
+#define GIT_DATE    "0"
+#define GIT_SHA     "0"
+#endif
+
+/***************************************************************************************************
+** PRIVATE FUNCTION DECLARATIONS
+***************************************************************************************************/
+
+static const char* mcuType();
+static const char* productType(uint8_t id);
+
+/***************************************************************************************************
+** PRIVATE OBJECTS
+***************************************************************************************************/
+
+/*
+Struct containing the board status sw registry
+as well as some of the general values.
+A board should update the values in this struct using the
+functions defined below for updating the board status.
+*/
+static struct BS {
     uint32_t boardErrorsMsk;
     uint32_t boardStatus;
     float temp;
@@ -37,277 +70,372 @@ static struct BS
 } BS = {0};
 
 // Print buffer for systemInfo, statusInfo and statusDefInfo
-static char buf[600] = { 0 };
+static char buf[600] = {0};
 
-// F4xx UID
-#ifndef UNIT_TESTING
-    #define ID1 *((unsigned long *) (UID_BASE))
-    #define ID2 *((unsigned long *) (UID_BASE + 4U))
-    #define ID3 *((unsigned long *) (UID_BASE + 8U))
-#else
-    #define ID1 (unsigned long) 0U
-    #define ID2 (unsigned long) 0U
-    #define ID3 (unsigned long) 0U
+/***************************************************************************************************
+** PRIVATE FUNCTION DEFINITIONS
+***************************************************************************************************/
 
-    #define GIT_VERSION "0"
-    #define GIT_DATE    "0"
-    #define GIT_SHA     "0"
-#endif
-
-static const char* mcuType()
-{
-    static char mcu[50] = { 0 }; // static to prevent allocate on stack.
-    int len = 0;
+/*!
+ * @brief   Gives MCU type
+ * @return  MCU type as a string
+ */
+static const char* mcuType() {
+    static char mcu[50] = {0};  // static to prevent allocate on stack.
+    int len             = 0;
 
 #ifndef UNIT_TESTING
     const DBGMCU_TypeDef* mcuType = DBGMCU;
-    const uint16_t idCode = 0x00000FFF & mcuType->IDCODE;
-    const uint16_t revCode = 0xFFFF & (mcuType->IDCODE >> 16);
+    const uint16_t idCode         = 0x00000FFF & mcuType->IDCODE;
+    const uint16_t revCode        = 0xFFFF & (mcuType->IDCODE >> 16);
 #else
-    const uint16_t idCode = 0;
+    const uint16_t idCode  = 0;
     const uint16_t revCode = 0;
 #endif
 
-    switch(idCode)
-    {
-    case 0x423: len += snprintf(&mcu[len], sizeof(mcu) -len, "STM32F401xB/C");        break;
-    case 0x433: len += snprintf(&mcu[len], sizeof(mcu) -len, "STM32F401xD/E");        break;
-    case 0x450: len += snprintf(&mcu[len], sizeof(mcu) -len, "STM32H753IIT6");        break;
-    default:    len += snprintf(&mcu[len], sizeof(mcu) -len, "Unknown 0x%3X", idCode); break;
+    switch (idCode) {
+        case 0x423:
+            len += snprintf(&mcu[len], sizeof(mcu) - len, "STM32F401xB/C");
+            break;
+        case 0x433:
+            len += snprintf(&mcu[len], sizeof(mcu) - len, "STM32F401xD/E");
+            break;
+        case 0x450:
+            len += snprintf(&mcu[len], sizeof(mcu) - len, "STM32H753IIT6");
+            break;
+        default:
+            len += snprintf(&mcu[len], sizeof(mcu) - len, "Unknown 0x%3X", idCode);
+            break;
     }
 
-    len += snprintf(&mcu[len], sizeof(mcu) -len, " Rev %x", revCode);
+    len += snprintf(&mcu[len], sizeof(mcu) - len, " Rev %x", revCode);
 
     return mcu;
 }
 
-static const char* productType(uint8_t id)
-{
-    switch(id)
-    {
-    case AC_Board         :  return "AC Board";          break;
-    case DC_Board         :  return "DC Board";          break;
-    case Temperature      :  return "Temperature";       break;
-    case Current          :  return "Current";           break;
-    case GasFlow          :  return "GasFlow";           break;
-    case HumidityChip     :  return "HumidityChip";      break;
-    case Pressure         :  return "Pressure";          break;
-    case SaltFlowBoard    :  return "Salt Flow Board";   break;
-    case SaltLeak         :  return "SaltLeak";          break;
-    case HotValveController: return "HotValveController"; break;
-    case ZrO2Oxygen		  :  return "ZrO2Oxygen"; 		 break;
-    case AMBcurrent		  :  return "AMBcurrent"; 		 break;
-    case Geiger           :  return "Geiger"; 			 break;
-    case AirCondition     :  return "AirCondition"; 	 break;
-    case LightController  :  return "LightController"; 	 break;
-    case LiquidLevel      :  return "LiquidLevel";   	 break;
-    case ER               :  return "ER";            	 break;
-    case ERHC             :  return "ERHC";            	 break;
-    case VFD              :  return "VFD";            	 break;
-    case Tachometer       :  return "Tachometer";     	 break;
-    case ACTenChannel     :  return "ACTenChannel";    	 break;
+/*!
+ * @brief   Gives product type
+ * @return  Board type as a string
+ */
+static const char* productType(uint8_t id) {
+    switch (id) {
+        case AC_Board:
+            return "AC Board";
+            break;
+        case DC_Board:
+            return "DC Board";
+            break;
+        case Temperature:
+            return "Temperature";
+            break;
+        case Current:
+            return "Current";
+            break;
+        case GasFlow:
+            return "GasFlow";
+            break;
+        case HumidityChip:
+            return "HumidityChip";
+            break;
+        case Pressure:
+            return "Pressure";
+            break;
+        case SaltFlowBoard:
+            return "Salt Flow Board";
+            break;
+        case SaltLeak:
+            return "SaltLeak";
+            break;
+        case HotValveController:
+            return "HotValveController";
+            break;
+        case ZrO2Oxygen:
+            return "ZrO2Oxygen";
+            break;
+        case AMBcurrent:
+            return "AMBcurrent";
+            break;
+        case Geiger:
+            return "Geiger";
+            break;
+        case AirCondition:
+            return "AirCondition";
+            break;
+        case LightController:
+            return "LightController";
+            break;
+        case LiquidLevel:
+            return "LiquidLevel";
+            break;
+        case ER:
+            return "ER";
+            break;
+        case ERHC:
+            return "ERHC";
+            break;
+        case VFD:
+            return "VFD";
+            break;
+        case Tachometer:
+            return "Tachometer";
+            break;
+        case ACTenChannel:
+            return "ACTenChannel";
+            break;
     }
     return "NA";
 }
 
-const char* systemInfo()
-{
-    BoardInfo info = { 0 };
+/***************************************************************************************************
+** PUBLIC FUNCTION DEFINITIONS
+***************************************************************************************************/
 
-    if (HAL_otpRead(&info) != OTP_SUCCESS)
-    {
-        info.otpVersion = 0; // Invalid OTP version
+/*!
+ * @brief   Generic info about PCB and git build system/data
+ * @return  Info about system in null terminated string
+ */
+const char* systemInfo() {
+    BoardInfo info = {0};
+
+    if (HAL_otpRead(&info) != OTP_SUCCESS) {
+        info.otpVersion = 0;  // Invalid OTP version
     }
 
     int len = 0;
-    len  = snprintf(&buf[len], sizeof(buf) - len, "Serial Number: %lX%lX%lX\r\n", ID1, ID2, ID3);
-    switch(info.otpVersion)
-    {
-    case OTP_VERSION_1:
-        len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType(info.v1.boardType));
-        break;
-    case OTP_VERSION_2:
-        len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n", productType(info.v2.boardType));
-        len += snprintf(&buf[len], sizeof(buf) - len, "Sub Product Type: %u\r\n", info.v2.subBoardType);
-        break;
-    default:
-        len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: NA\r\n");
-        break;
+    len     = snprintf(&buf[len], sizeof(buf) - len, "Serial Number: %lX%lX%lX\r\n", ID1, ID2, ID3);
+    switch (info.otpVersion) {
+        case OTP_VERSION_1:
+            len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n",
+                            productType(info.v1.boardType));
+            break;
+        case OTP_VERSION_2:
+            len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: %s\r\n",
+                            productType(info.v2.boardType));
+            len += snprintf(&buf[len], sizeof(buf) - len, "Sub Product Type: %u\r\n",
+                            info.v2.subBoardType);
+            break;
+        default:
+            len += snprintf(&buf[len], sizeof(buf) - len, "Product Type: NA\r\n");
+            break;
     }
     len += snprintf(&buf[len], sizeof(buf) - len, "MCU Family: %s\r\n", mcuType());
     len += snprintf(&buf[len], sizeof(buf) - len, "Software Version: %s\r\n", GIT_VERSION);
     len += snprintf(&buf[len], sizeof(buf) - len, "Compile Date: %s\r\n", GIT_DATE);
     len += snprintf(&buf[len], sizeof(buf) - len, "Git SHA: %s\r\n", GIT_SHA);
-    switch(info.otpVersion)
-    {
-    case OTP_VERSION_1:
-        len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d", info.v1.pcbVersion.major, info.v1.pcbVersion.minor);
-        break;
-    case OTP_VERSION_2:
-        len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d", info.v2.pcbVersion.major, info.v2.pcbVersion.minor);
-        break;
-    default:
-        len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: NA");
-        break;
+    switch (info.otpVersion) {
+        case OTP_VERSION_1:
+            len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d",
+                            info.v1.pcbVersion.major, info.v1.pcbVersion.minor);
+            break;
+        case OTP_VERSION_2:
+            len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: %d.%d",
+                            info.v2.pcbVersion.major, info.v2.pcbVersion.minor);
+            break;
+        default:
+            len += snprintf(&buf[len], sizeof(buf) - len, "PCB Version: NA");
+            break;
     }
     len += snprintf(&buf[len], sizeof(buf) - len, "\r\n");
 
     return buf;
 }
 
-const char* statusInfo(bool printStart)
-{
+/*!
+ * @brief   Generic info about system status
+ * @param   printStart Select beginning or end of print
+ * @return  Info about system in null terminated string
+ */
+const char* statusInfo(bool printStart) {
     int len = 0;
 
     // Print end of message and return
-    if (!printStart)
-    {
+    if (!printStart) {
         len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status. \r\n");
         return buf;
     }
 
     len += snprintf(&buf[len], sizeof(buf) - len, "\r\nStart of board status:\r\n");
-    if (!(BS.boardStatus & BS_ERROR_Msk))
-    {
+    if (!(BS.boardStatus & BS_ERROR_Msk)) {
         len += snprintf(&buf[len], sizeof(buf) - len, "The board is operating normally.\r\n");
         return buf;
-    } 
-    
-    if (BS.boardStatus & BS_OVER_TEMPERATURE_Msk)
-    {
-        len += snprintf(&buf[len], sizeof(buf) - len, 
+    }
+
+    if (BS.boardStatus & BS_OVER_TEMPERATURE_Msk) {
+        len += snprintf(&buf[len], sizeof(buf) - len,
                         "Over temperature. The board temperature is %.2fC.\r\n", BS.temp);
     }
 
-    if (BS.boardStatus & BS_UNDER_VOLTAGE_Msk)
-    {
-        len += snprintf(&buf[len], sizeof(buf) - len, 
-                        "Under voltage. The board operates at too low voltage of %.2fV. Check power supply.\r\n", BS.voltage);
+    if (BS.boardStatus & BS_UNDER_VOLTAGE_Msk) {
+        len += snprintf(&buf[len], sizeof(buf) - len,
+                        "Under voltage. The board operates at too low voltage of %.2fV. Check "
+                        "power supply.\r\n",
+                        BS.voltage);
     }
 
-    if (BS.boardStatus & BS_OVER_VOLTAGE_Msk)
-    {
-        len += snprintf(&buf[len], sizeof(buf) - len, 
-                        "Over voltage. The board operates at too high voltage of %.2fV. Check power supply.\r\n", BS.voltage);
+    if (BS.boardStatus & BS_OVER_VOLTAGE_Msk) {
+        len += snprintf(&buf[len], sizeof(buf) - len,
+                        "Over voltage. The board operates at too high voltage of %.2fV. Check "
+                        "power supply.\r\n",
+                        BS.voltage);
     }
 
-    if (BS.boardStatus & BS_OVER_CURRENT_Msk)
-    {
-        len += snprintf(&buf[len], sizeof(buf) - len, 
-                        "Over current. One of the ports has reached a current out of its measurement range at %.2fA.\r\n", BS.current);
+    if (BS.boardStatus & BS_OVER_CURRENT_Msk) {
+        len += snprintf(&buf[len], sizeof(buf) - len,
+                        "Over current. One of the ports has reached a current out of its "
+                        "measurement range at %.2fA.\r\n",
+                        BS.current);
     }
 
-    if (BS.boardStatus & BS_VERSION_ERROR_Msk)
-    {
-        BoardType bt = (BoardType)0;
+    if (BS.boardStatus & BS_VERSION_ERROR_Msk) {
+        BoardType bt  = (BoardType)0;
         pcbVersion pv = {0};
-        (void) getBoardInfo(&bt, NULL);
-        (void) getPcbVersion(&pv);
-        len += snprintf(&buf[len], sizeof(buf) - len, 
-            "Error: Incorrect Version.\r\n"
-            "   Board is: %d.\r\n"
-            "   Board should be: %d.\r\n"
-            "   PCB Version is: %d.%d.\r\n"
-            "   PCB Version should be > %d.%d.\r\n", 
-            (int)bt, (int)BS.boardType, pv.major, pv.minor, BS.pcb_version.major, BS.pcb_version.minor);
+        (void)getBoardInfo(&bt, NULL);
+        (void)getPcbVersion(&pv);
+        len += snprintf(&buf[len], sizeof(buf) - len,
+                        "Error: Incorrect Version.\r\n"
+                        "   Board is: %d.\r\n"
+                        "   Board should be: %d.\r\n"
+                        "   PCB Version is: %d.%d.\r\n"
+                        "   PCB Version should be > %d.%d.\r\n",
+                        (int)bt, (int)BS.boardType, pv.major, pv.minor, BS.pcb_version.major,
+                        BS.pcb_version.minor);
     }
 
-    if (BS.usb)
-    {
-        len += snprintf(&buf[len], sizeof(buf) - len, 
-                        "USB. USB communication error 0x%08" PRIx32 " occurred most recently.\r\n", BS.usb);
+    if (BS.usb) {
+        len += snprintf(&buf[len], sizeof(buf) - len,
+                        "USB. USB communication error 0x%08" PRIx32 " occurred most recently.\r\n",
+                        BS.usb);
         BS.usb = 0U;
     }
 
     return buf;
 }
 
-const char* statusDefInfo(bool printStart)
-{
+/*!
+ * @brief   Generic info about system status definition
+ * @param   printStart Select beginning or end of print
+ * @return  Info about system status definition in null terminated string
+ */
+const char* statusDefInfo(bool printStart) {
     int len = 0;
 
     // Print end of message and return
-    if (!printStart)
-    {
+    if (!printStart) {
         len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status definition.\r\n");
         return buf;
     }
 
     len += snprintf(&buf[len], sizeof(buf) - len, "\r\nStart of board status definition:\r\n");
 
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",System errors\r\n", (uint32_t) BS.boardErrorsMsk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Error\r\n", (uint32_t) BS_ERROR_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over temperature\r\n", (uint32_t) BS_OVER_TEMPERATURE_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Under voltage\r\n", (uint32_t) BS_UNDER_VOLTAGE_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over voltage\r\n", (uint32_t) BS_OVER_VOLTAGE_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over current\r\n", (uint32_t) BS_OVER_CURRENT_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Version error\r\n", (uint32_t) BS_VERSION_ERROR_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",USB error\r\n", (uint32_t) BS_USB_ERROR_Msk);
-    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n", (uint32_t) BS_FLASH_ONGOING_Msk);
-    
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",System errors\r\n",
+                    (uint32_t)BS.boardErrorsMsk);
+    len +=
+        snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Error\r\n", (uint32_t)BS_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over temperature\r\n",
+                    (uint32_t)BS_OVER_TEMPERATURE_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Under voltage\r\n",
+                    (uint32_t)BS_UNDER_VOLTAGE_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over voltage\r\n",
+                    (uint32_t)BS_OVER_VOLTAGE_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Over current\r\n",
+                    (uint32_t)BS_OVER_CURRENT_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Version error\r\n",
+                    (uint32_t)BS_VERSION_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",USB error\r\n",
+                    (uint32_t)BS_USB_ERROR_Msk);
+    len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",Flash ongoing\r\n",
+                    (uint32_t)BS_FLASH_ONGOING_Msk);
+
     return buf;
 }
 
-int getBoardInfo(BoardType *bdt, SubBoardType *sbdt)
-{
-    BoardInfo info = { 0 };
-    if (HAL_otpRead(&info) != OTP_SUCCESS)
+/*!
+ * @brief   Gets Boardinfo. If input values are NULL these are ignored
+ * @param   bdt Boardtype used in the SW running
+ * @param   sbdt SubBoardtype used in the SW running, if 0xFF value is ignore in compare
+ * @return  0 if data is valid, else negative value
+ */
+int getBoardInfo(BoardType* bdt, SubBoardType* sbdt) {
+    BoardInfo info = {0};
+    if (HAL_otpRead(&info) != OTP_SUCCESS) {
         return -1;
+    }
 
-    if (info.otpVersion == OTP_VERSION_1)
-    {
-        if (bdt)  { *bdt  = (BoardType)info.v1.boardType; }
-        if (sbdt) { *sbdt = 0; } // Sub board type is not included in version 1
+    if (info.otpVersion == OTP_VERSION_1) {
+        if (bdt) {
+            *bdt = (BoardType)info.v1.boardType;
+        }
+        if (sbdt) {
+            *sbdt = 0;
+        }  // Sub board type is not included in version 1
         return 0;
     }
 
-    if (info.otpVersion == OTP_VERSION_2)
-    {
-        if (bdt)  { *bdt  = (BoardType)info.v2.boardType; }
-        if (sbdt) { *sbdt = info.v2.subBoardType; }
+    if (info.otpVersion == OTP_VERSION_2) {
+        if (bdt) {
+            *bdt = (BoardType)info.v2.boardType;
+        }
+        if (sbdt) {
+            *sbdt = info.v2.subBoardType;
+        }
         return 0;
     }
 
-    return -1; // New OTP version. i.e. this SW is to old.
+    return -1;  // New OTP version. i.e. this SW is to old.
 }
 
-int getPcbVersion(pcbVersion* ver)
-{
-    BoardInfo info = { 0 };
-    if (ver == 0 || HAL_otpRead(&info) != OTP_SUCCESS)
+/*!
+ * @brief   Gets the PCB version of the board
+ * @param   ver Pointer to struct pcbVersion
+ * @return  0 if data is valid, else negative value
+ */
+int getPcbVersion(pcbVersion* ver) {
+    BoardInfo info = {0};
+    if (ver == 0 || HAL_otpRead(&info) != OTP_SUCCESS) {
         return -1;
+    }
 
-    if (info.otpVersion == OTP_VERSION_1)
-    {
+    if (info.otpVersion == OTP_VERSION_1) {
         ver->major = info.v1.pcbVersion.major;
         ver->minor = info.v1.pcbVersion.minor;
         return 0;
     }
 
-    if (info.otpVersion == OTP_VERSION_2)
-    {
+    if (info.otpVersion == OTP_VERSION_2) {
         ver->major = info.v2.pcbVersion.major;
         ver->minor = info.v2.pcbVersion.minor;
         return 0;
     }
 
-    return -1; // New OTP version. i.e. this SW is to old.
+    return -1;  // New OTP version. i.e. this SW is to old.
 }
 
-// Functions updating board status
-void bsSetErrorRange(uint32_t field, uint32_t range)
-{
-    // For ranges of bits where only a subset of them are being set,
-    // then setting a new subset will result in the union of the two subset.
-    // Since, for a range it is assumed that the bits in the range
-    // are related i.e. each combination meaning a unique state, then
-    // we need to reset previous state before setting the new state.
+/*!
+ * @brief   Sets a board status error range
+ * @param   field A 1 bit shifted to the field index to be set in addition to the error bit also
+ * being set
+ * @param   range The bits in the range parameter are reset prior to setting the bits in the field
+ * parameter
+ */
+void bsSetErrorRange(uint32_t field, uint32_t range) {
+    /*
+    For ranges of bits where only a subset of them are being set,
+    then setting a new subset will result in the union of the two subset.
+    Since, for a range it is assumed that the bits in the range
+    are related i.e. each combination meaning a unique state, then
+    we need to reset previous state before setting the new state.
+    */
     BS.boardStatus &= ~range;
     BS.boardStatus |= (BS_ERROR_Msk | field);
 }
 
-void bsSetFieldRange(uint32_t field, uint32_t range)
-{
+/*!
+ * @brief   Sets a board status field
+ * @param   field A 1 bit shifted to the field index to be set
+ * @param   range The bits in the range parameter are reset prior to setting the bits in the field
+ * parameter
+ */
+void bsSetFieldRange(uint32_t field, uint32_t range) {
     // Reset bits before setting the new value of the range for the same
     // reason as described in the bsSetErrorRange function.
     BS.boardStatus &= ~range;
@@ -315,27 +443,40 @@ void bsSetFieldRange(uint32_t field, uint32_t range)
 }
 
 /*!
-** @brief Clears the error bit, if none of the bits in the field are set
-*/
-void bsClearError(uint32_t field) {     
-    if (!(BS.boardStatus & field))
-    {
-        bsClearField(BS_ERROR_Msk);
-    } 
-}
-
+ * @brief   Sets a board status field, and the error bit
+ * @param   field A 1 bit shifted to the field index to be set. Can be OR'd together
+ */
 void bsSetError(uint32_t field) { BS.boardStatus |= (BS_ERROR_Msk | field); }
-void bsSetField(uint32_t field){ BS.boardStatus |= field; }
-void bsClearField(uint32_t field){ BS.boardStatus &= ~field; }
 
 /*!
-** @brief Update a field using a bool to determine whether set or clear
-**
-** @param[in] field      Field to set/clear
-** @param[in] set        Whether to Set or Clear the field
-*/
+ * @brief   Clears the error bit, if none of the bits in "field" are set
+ * @param   field A 1 bit shifted to the field index to be set. Can be OR'd together
+ */
+void bsClearError(uint32_t field) {
+    if (!(BS.boardStatus & field)) {
+        bsClearField(BS_ERROR_Msk);
+    }
+}
+
+/*!
+ * @brief   Sets a board status field
+ * @param   field A 1 bit shifted to the field index to be set. Can be OR'd together
+ */
+void bsSetField(uint32_t field) { BS.boardStatus |= field; }
+
+/*!
+ * @brief   Clears a board status field
+ * @param   field A 1 bit shifted to the field index to be cleared
+ */
+void bsClearField(uint32_t field) { BS.boardStatus &= ~field; }
+
+/*!
+ * @brief   Updates a field using a bool to determine whether set or clear
+ * @param   field Field to set/clear
+ * @param   set Whether to Set or Clear the field
+ */
 void bsUpdateField(uint32_t field, bool set) {
-    if(set) {
+    if (set) {
         bsSetField(field);
     }
     else {
@@ -344,15 +485,14 @@ void bsUpdateField(uint32_t field, bool set) {
 }
 
 /*!
-** @brief Update an error field using a bool to determine whether set or clear
-**
-** @param[in] field      Field to set/clear
-** @param[in] set        Whether to Set or Clear the field
-** @param[in] error_bits A collection of all error bits. Used to determine if the master error bit
-**                       should be set or not
-*/
+ * @brief   Updates an error field using a bool to determine whether set or clear
+ * @param   field Field to set/clear
+ * @param   set Whether to Set or Clear the field
+ * @param   error_bits A collection of all error bits. Used to determine if the master error bit
+ * should be set or not
+ */
 void bsUpdateError(uint32_t field, bool set, uint32_t error_bits) {
-    if(set) {
+    if (set) {
         bsSetError(field);
     }
     else {
@@ -361,25 +501,64 @@ void bsUpdateError(uint32_t field, bool set, uint32_t error_bits) {
     }
 }
 
-uint32_t bsGetStatus(){ return BS.boardStatus; }
-uint32_t bsGetField(uint32_t field){ return BS.boardStatus & field; }
-void setBoardTemp(float temp){ BS.temp = temp; }
-void setBoardVoltage(float voltage){ BS.voltage = voltage; }
-void setBoardCurrent(float current){ BS.current = current; }
-void setBoardUsbError(uint32_t err) {BS.usb = err; }
-void setFirmwareBoardType(BoardType type){ BS.boardType = type; }
-void setFirmwareBoardVersion(pcbVersion version){ BS.pcb_version = version; }
+/*!
+ * @brief   Gets the board status registry
+ * @return  uint32_t containing the board status
+ */
+uint32_t bsGetStatus() { return BS.boardStatus; }
 
 /*!
-** @brief Sets the board type and version the firmware was compiled for
-**
-** If the board type/version does not match the value programmed in the OTP, this function sets the 
-** board status version error flag, and returns -1
-**
-** @param[in] type              Type of board, e.g. AC, DC, Current ...
-** @param[in] breaking_version  Oldest version of PCB this firmware can run on
-** @param[in] boardErrorsMsk    Board error mask (with board specific bits)
-*/
+ * @brief   Gets a board status field
+ * @param   field A 1 bit shifted to the field index
+ * @return  uint32_t containing the board status field
+ */
+uint32_t bsGetField(uint32_t field) { return BS.boardStatus & field; }
+
+/*!
+ * @brief   Sets temperature
+ * @param   temp Temperature in degC
+ */
+void setBoardTemp(float temp) { BS.temp = temp; }
+
+/*!
+ * @brief   Sets voltage
+ * @param   voltage Voltage in V
+ */
+void setBoardVoltage(float voltage) { BS.voltage = voltage; }
+
+/*!
+ * @brief   Sets current
+ * @param   current Current in A
+ */
+void setBoardCurrent(float current) { BS.current = current; }
+
+/*!
+ * @brief   Sets USB error
+ * @param   err USB error
+ */
+void setBoardUsbError(uint32_t err) { BS.usb = err; }
+
+/*!
+ * @brief   Sets the board type, the firmware is expecting to be used with
+ * @param   type Board type
+ */
+void setFirmwareBoardType(BoardType type) { BS.boardType = type; }
+
+/*!
+ * @brief   Sets the board version, the firmware is expecting to be used with
+ * @param   version Board version
+ */
+void setFirmwareBoardVersion(pcbVersion version) { BS.pcb_version = version; }
+
+/*!
+ * @brief   Sets the board type and version the firmware was compiled for
+ * @note    If the board type/version does not match the value programmed in the OTP, this function
+ * sets the board status version error flag
+ * @param   type Type of board, e.g. AC, DC, Current ...
+ * @param   breaking_version Oldest version of PCB this firmware can run on
+ * @param   boardErrorsMsk Board error mask (with board specific bits)
+ * @return  0 if OK, -1 if version error
+ */
 int boardSetup(BoardType type, pcbVersion breaking_version, uint32_t boardErrorsMsk) {
     setFirmwareBoardType(type);
     setFirmwareBoardVersion(breaking_version);
@@ -393,7 +572,7 @@ int boardSetup(BoardType type, pcbVersion breaking_version, uint32_t boardErrors
     if (getPcbVersion(&ver) || ver.major < breaking_version.major) {
         bsSetError(BS_VERSION_ERROR_Msk);
     }
-    else if(ver.major == breaking_version.major && ver.minor < breaking_version.minor) {
+    else if (ver.major == breaking_version.major && ver.minor < breaking_version.minor) {
         bsSetError(BS_VERSION_ERROR_Msk);
     }
 

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -378,6 +378,7 @@ void setFirmwareBoardVersion(pcbVersion version){ BS.pcb_version = version; }
 **
 ** @param[in] type              Type of board, e.g. AC, DC, Current ...
 ** @param[in] breaking_version  Oldest version of PCB this firmware can run on
+** @param[in] boardErrorsMsk    Board error mask (with board specific bits)
 */
 int boardSetup(BoardType type, pcbVersion breaking_version, uint32_t boardErrorsMsk) {
     setFirmwareBoardType(type);

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -121,67 +121,47 @@ static const char* productType(uint8_t id) {
     switch (id) {
         case AC_Board:
             return "AC Board";
-            break;
         case DC_Board:
             return "DC Board";
-            break;
         case Temperature:
             return "Temperature";
-            break;
         case Current:
             return "Current";
-            break;
         case GasFlow:
             return "GasFlow";
-            break;
         case HumidityChip:
             return "HumidityChip";
-            break;
         case Pressure:
             return "Pressure";
-            break;
         case SaltFlowBoard:
             return "Salt Flow Board";
-            break;
         case SaltLeak:
             return "SaltLeak";
             break;
         case HotValveController:
             return "HotValveController";
-            break;
         case ZrO2Oxygen:
             return "ZrO2Oxygen";
-            break;
         case AMBcurrent:
             return "AMBcurrent";
-            break;
         case Geiger:
             return "Geiger";
-            break;
         case AirCondition:
             return "AirCondition";
-            break;
         case LightController:
             return "LightController";
-            break;
         case LiquidLevel:
             return "LiquidLevel";
-            break;
         case ER:
             return "ER";
-            break;
         case ERHC:
             return "ERHC";
-            break;
         case VFD:
             return "VFD";
-            break;
         case Tachometer:
             return "Tachometer";
-            break;
         case ACTenChannel:
             return "ACTenChannel";
-            break;
     }
     return "NA";
 }

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -119,34 +119,37 @@ void statusPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) 
 ** Initialises the board then sends the 'StatusDef' command. Checks the response matches the protocol 
 ** template and the supplied board specific string.
 */
-void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) {
+void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> boardErrorsString, vector<const char*> boardStatusDefString) {
     sst.boundInit();
     /* Note: usb RX buffer is flushed during the first loop, so a single loop must be done before
     ** printing anything */
     sst.testFixture->_loopFunction(sst.testFixture->bootMsg);
     sst.testFixture->writeBoardMessage("StatusDef\n");
 
-    vector<const char*> bsd_pre = {"\r",
+    vector<const char*> bsdPre1 = {"\r",
         "Boot Unit Test\r",
         "Start of board status definition:\r",
-        "0x7e000000,System errors\r",
-        "0x80000000,Error\r",
-        "0x40000000,Over temperature\r",
-        "0x20000000,Under voltage\r",
-        "0x10000000,Over voltage\r",
-        "0x08000000,Over current\r",
-        "0x04000000,Version error\r",
-        "0x02000000,USB error\r",
-        "0x01000000,Flash ongoing\r",
-        };
-    vector<const char*> bsd_post = {"\r",
+    };
+    vector<const char*> bsdPre2 = {
+            "0x80000000,Error\r",
+            "0x40000000,Over temperature\r",
+            "0x20000000,Under voltage\r",
+            "0x10000000,Over voltage\r",
+            "0x08000000,Over current\r",
+            "0x04000000,Version error\r",
+            "0x02000000,USB error\r",
+            "0x01000000,Flash ongoing\r",
+    };
+    vector<const char*> bsdPost = {"\r",
         "End of board status definition.\r"
     };
 
-    bsd_pre.insert(bsd_pre.end(), pass_string.begin(), pass_string.end());
-    bsd_pre.insert(bsd_pre.end(), bsd_post.begin(), bsd_post.end());
+    bsdPre1.insert(bsdPre1.end(), boardErrorsString.begin(), boardErrorsString.end());
+    bsdPre1.insert(bsdPre1.end(), bsdPre2.begin(), bsdPre2.end());
+    bsdPre1.insert(bsdPre1.end(), boardStatusDefString.begin(), boardStatusDefString.end());
+    bsdPre1.insert(bsdPre1.end(), bsdPost.begin(), bsdPost.end());
 
-    EXPECT_FLUSH_USB(::testing::ElementsAreArray(bsd_pre));
+    EXPECT_FLUSH_USB(::testing::ElementsAreArray(bsdPre1));
 }
 
 /*!

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -119,7 +119,7 @@ void statusPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) 
 ** Initialises the board then sends the 'StatusDef' command. Checks the response matches the protocol 
 ** template and the supplied board specific string.
 */
-void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> boardErrorsString, vector<const char*> boardStatusDefString) {
+void statusDefPrintoutTest(SerialStatusTest& sst, const char* boardErrorsString, vector<const char*> boardStatusDefString) {
     sst.boundInit();
     /* Note: usb RX buffer is flushed during the first loop, so a single loop must be done before
     ** printing anything */
@@ -144,7 +144,7 @@ void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> boardError
         "End of board status definition.\r"
     };
 
-    bsdPre1.insert(bsdPre1.end(), boardErrorsString.begin(), boardErrorsString.end());
+    bsdPre1.push_back(boardErrorsString);
     bsdPre1.insert(bsdPre1.end(), bsdPre2.begin(), bsdPre2.end());
     bsdPre1.insert(bsdPre1.end(), boardStatusDefString.begin(), boardStatusDefString.end());
     bsdPre1.insert(bsdPre1.end(), bsdPost.begin(), bsdPost.end());

--- a/unit_testing/Util/serialStatus_tests.h
+++ b/unit_testing/Util/serialStatus_tests.h
@@ -41,7 +41,7 @@ class SerialStatusTest {
 void goldenPathTest(SerialStatusTest& sst, const char* pass_string, int firstPrintTick=100);
 void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick=100);
 void statusPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
-void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> boardErrorsString, vector<const char*> boardStatusDefString);
+void statusDefPrintoutTest(SerialStatusTest& sst, std::vector<const char*> boardErrorsString, std::vector<const char*> boardStatusDefString);
 void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char* cal_string=nullptr);
 
 #endif /* SERIAL_STATUS_TESTS_H_ */

--- a/unit_testing/Util/serialStatus_tests.h
+++ b/unit_testing/Util/serialStatus_tests.h
@@ -41,7 +41,7 @@ class SerialStatusTest {
 void goldenPathTest(SerialStatusTest& sst, const char* pass_string, int firstPrintTick=100);
 void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick=100);
 void statusPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
-void statusDefPrintoutTest(SerialStatusTest& sst, std::vector<const char*> boardErrorsString, std::vector<const char*> boardStatusDefString);
+void statusDefPrintoutTest(SerialStatusTest& sst, const char* boardErrorsString, std::vector<const char*> boardStatusDefString);
 void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char* cal_string=nullptr);
 
 #endif /* SERIAL_STATUS_TESTS_H_ */

--- a/unit_testing/Util/serialStatus_tests.h
+++ b/unit_testing/Util/serialStatus_tests.h
@@ -41,7 +41,7 @@ class SerialStatusTest {
 void goldenPathTest(SerialStatusTest& sst, const char* pass_string, int firstPrintTick=100);
 void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick=100);
 void statusPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
-void statusDefPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
+void statusDefPrintoutTest(SerialStatusTest& sst, vector<const char*> boardErrorsString, vector<const char*> boardStatusDefString);
 void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char* cal_string=nullptr);
 
 #endif /* SERIAL_STATUS_TESTS_H_ */

--- a/unit_testing/Util/systeminfo_tests.cpp
+++ b/unit_testing/Util/systeminfo_tests.cpp
@@ -51,11 +51,11 @@ TEST_F(TestSystemInfo, testBoardVersion) {
     EXPECT_EQ( 0, boardSetup(AC_Board, {0, 0}, 0));
     /* Error flag is retained between tests, so make sure to clear it */
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 1}, 0));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 1}, 0x233));
     bsClearField(0xFFFFFFFF);
     EXPECT_EQ( 0, boardSetup(AC_Board, {0, 2}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 0}, 0));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 0}, 0x233));
     bsClearField(0xFFFFFFFF);
     EXPECT_EQ( 0, boardSetup(AC_Board, {1, 1}, 0));
     bsClearField(0xFFFFFFFF);
@@ -68,4 +68,24 @@ TEST_F(TestSystemInfo, testBoardVersion) {
     EXPECT_EQ(-1, boardSetup(AC_Board, {2, 2}, 0));
     bsClearField(0xFFFFFFFF);
     EXPECT_EQ(-1, boardSetup(DC_Board, {1, 1}, 0));
+}
+
+TEST_F(TestSystemInfo, testBoardErrorMask) {
+    /* Setup fake board info with correct version number */
+    BoardInfo bi = {
+        .v2 = {
+            .otpVersion = OTP_VERSION_2,
+            .boardType = AC_Board,
+            .pcbVersion = {1, 1},
+        }
+    };
+    HAL_otpWrite(&bi);
+
+    uint32_t BS_ERROR_1_Msk = 1UL << 4U;
+    uint32_t BS_ERROR_2_Msk = 1UL << 2U;
+    uint32_t BOARD_ERRORS_Msk = (BS_SYSTEM_ERRORS_Msk | BS_ERROR_1_Msk | BS_ERROR_2_Msk);
+
+    boardSetup(AC_Board, {0, 0}, BOARD_ERRORS_Msk);
+
+    EXPECT_EQ(BS.boardErrorsMsk, BOARD_ERRORS_Msk);
 }

--- a/unit_testing/Util/systeminfo_tests.cpp
+++ b/unit_testing/Util/systeminfo_tests.cpp
@@ -48,24 +48,24 @@ TEST_F(TestSystemInfo, testBoardVersion) {
     HAL_otpWrite(&bi);
 
     /* Different test cases smaller, equal and larger for both major/minor */
-    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 0}));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 0}, 0));
     /* Error flag is retained between tests, so make sure to clear it */
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 1}));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 1}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 2}));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {0, 2}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 0}));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 0}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 1}));
+    EXPECT_EQ( 0, boardSetup(AC_Board, {1, 1}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ(-1, boardSetup(AC_Board, {1, 2}));
+    EXPECT_EQ(-1, boardSetup(AC_Board, {1, 2}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 0}));
+    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 0}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 1}));
+    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 1}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 2}));
+    EXPECT_EQ(-1, boardSetup(AC_Board, {2, 2}, 0));
     bsClearField(0xFFFFFFFF);
-    EXPECT_EQ(-1, boardSetup(DC_Board, {1, 1}));
+    EXPECT_EQ(-1, boardSetup(DC_Board, {1, 1}, 0));
 }


### PR DESCRIPTION
**Fixing issue [77](https://github.com/copenhagenatomics/CA_Embedded_Libraries/issues/77):**
- The over voltage general status message doesn't refer to a specific port anymore, because the ports are project specific 

**Fixing issue [78](https://github.com/copenhagenatomics/CA_Embedded_Libraries/issues/78):**
- The user can now include his own error bits in the system errors mask (that contains all the error bits), so the line _System errors_ displays all error bits
- Unit test update
Before: (look at system error line)
![image](https://github.com/user-attachments/assets/07cea495-4b6c-4dfb-b305-85110c3bdcb7)
After:
![image](https://github.com/user-attachments/assets/02f56fb5-33a5-49ee-8ef5-b505c799fc5f)

**Formatting (clang + typos + ...)**
- done in last commit so you can remove its modification to review more easily