### PR TITLE
ERHC Unit tests

### DIFF
--- a/STM32/Crc/Inc/crc.h
+++ b/STM32/Crc/Inc/crc.h
@@ -11,6 +11,10 @@
 #ifndef CRC_H_
 #define CRC_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /***************************************************************************************************
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
@@ -19,5 +23,9 @@ void initCrc4(uint8_t init, uint8_t poly);
 void initCrc8(uint8_t init, uint8_t poly);
 uint8_t crc8Calculate(uint8_t *data, size_t len);
 uint8_t crc4Calculate(uint8_t *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CRC_H_ */

--- a/STM32/SPI/Src/DAC7811.c
+++ b/STM32/SPI/Src/DAC7811.c
@@ -51,7 +51,7 @@ HAL_StatusTypeDef transmitData(DAC7811Device *dev, uint8_t* txBuf)
 
 HAL_StatusTypeDef loadAndUpdate(DAC7811Device *dev, uint16_t data)
 {
-	DAC7811Cmd cmd = { .ctrlbits = LoadUpdate, .dataMsb = (uint8_t) ((data >> 8) & 0x0f), .dataLsb = (data & 0xFF)};
+	DAC7811Cmd cmd = { .dataLsb = (uint8_t)(data & 0xFFU), .dataMsb = (uint8_t) ((data >> 8) & 0x0f), .ctrlbits = LoadUpdate};
 
 	if (transmitData(dev, cmd.data) != HAL_OK)
 		return HAL_ERROR;
@@ -60,7 +60,7 @@ HAL_StatusTypeDef loadAndUpdate(DAC7811Device *dev, uint16_t data)
 
 HAL_StatusTypeDef readOutputValue(DAC7811Device *dev)
 {
-	DAC7811Cmd rxData = { .ctrlbits = ReadBack, .dataMsb = 0, .dataLsb = 0 };
+	DAC7811Cmd rxData = { .dataLsb = 0 , .dataMsb = 0, .ctrlbits = ReadBack};
 
 	if (receiveData(dev, rxData.data) != HAL_OK)
 		return HAL_ERROR;
@@ -72,7 +72,7 @@ HAL_StatusTypeDef readOutputValue(DAC7811Device *dev)
 
 HAL_StatusTypeDef resetMidScale(DAC7811Device *dev)
 {
-	DAC7811Cmd cmd = { .ctrlbits = ResetMidScale, .dataMsb = 0, .dataLsb = 0 };
+	DAC7811Cmd cmd = { .dataLsb = 0, .dataMsb = 0, .ctrlbits = ResetMidScale};
 
 	if (transmitData(dev, cmd.data) != HAL_OK)
 		return HAL_ERROR;
@@ -81,7 +81,7 @@ HAL_StatusTypeDef resetMidScale(DAC7811Device *dev)
 
 HAL_StatusTypeDef disableDaisyChain(DAC7811Device *dev)
 {
-	DAC7811Cmd cmd = { .ctrlbits = DisableDC, .dataMsb = 0, .dataLsb = 0 };
+	DAC7811Cmd cmd = { .dataLsb = 0, .dataMsb = 0, .ctrlbits = DisableDC, };
 
 	if (transmitData(dev, cmd.data) != HAL_OK)
 		return HAL_ERROR;

--- a/unit_testing/fakes/fake_FLASH_readwrite.cpp
+++ b/unit_testing/fakes/fake_FLASH_readwrite.cpp
@@ -110,11 +110,15 @@ int readFromFlashCRC(CRC_HandleTypeDef *hcrc, uint32_t flash_address, uint8_t *d
 
     (void) readFromFlash(flash_address, buf, size + 1);
 
-    /* Real behaviour overwrites data even if CRC is not valid */
-    memcpy(data, buf, size);
+    /* Real behaviour does not overwrite data even if CRC is not valid */
     initCrc8(0x00, 0x07);
     uint8_t crc = crc8Calculate(buf, size);
 
-    return crc == buf[size] ? 0 : 1;
+    if(crc != buf[size]) {
+        return -1; // CRC mismatch
+    }
+
+    memcpy(data, buf, size);
+    return 0;
 }
 #endif

--- a/unit_testing/fakes/fake_FLASH_readwrite.cpp
+++ b/unit_testing/fakes/fake_FLASH_readwrite.cpp
@@ -110,7 +110,7 @@ int readFromFlashCRC(CRC_HandleTypeDef *hcrc, uint32_t flash_address, uint8_t *d
 
     (void) readFromFlash(flash_address, buf, size + 1);
 
-    /* Real behaviour does not overwrite data even if CRC is not valid */
+    /* Real behaviour does not overwrite data if CRC is not valid */
     initCrc8(0x00, 0x07);
     uint8_t crc = crc8Calculate(buf, size);
 


### PR DESCRIPTION
* Fixes from unit tests for ERHC:
  * crc.h needs extern "C" guards
  * fake_FlashReadCrc behaviour didn't match actual library code
  * DAC7811 struct definitions weren't c++ compatible