### PR TITLE
CA snprintf macro

### DIFF
--- a/STM32/USBprint/Inc/USBprint.h
+++ b/STM32/USBprint/Inc/USBprint.h
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 /**
  * @brief Adds a formatted string at the end of a buffer

--- a/STM32/USBprint/Inc/USBprint.h
+++ b/STM32/USBprint/Inc/USBprint.h
@@ -13,6 +13,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/**
+ * @brief Adds a formatted string at the end of a buffer
+ * @param b Buffer
+ * @param l Length already written (is updated)
+ * @param ... Formatted string
+ */
+#define CA_SNPRINTF(b, l, ...) l += snprintf(&b[l], sizeof(b) - l, __VA_ARGS__)
+
 // Wrap vsnprintf(char *str, size_t size, const char *format, va_list ap)
 // and send data to USB port. The n indicates that buffer overflow is handled.
 // String/n is max 256 bytes.

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -50,8 +50,6 @@ extern "C" {
     (BS_OVER_TEMPERATURE_Msk | BS_UNDER_VOLTAGE_Msk | BS_OVER_VOLTAGE_Msk | BS_OVER_CURRENT_Msk | \
      BS_VERSION_ERROR_Msk | BS_USB_ERROR_Msk)
 
-#define CA_SNPRINTF(b, l, ...) l += snprintf(&b[l], sizeof(b) - l, __VA_ARGS__)
-
 /***************************************************************************************************
 ** STRUCTURES
 ***************************************************************************************************/

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -50,6 +50,8 @@ extern "C" {
     (BS_OVER_TEMPERATURE_Msk | BS_UNDER_VOLTAGE_Msk | BS_OVER_VOLTAGE_Msk | BS_OVER_CURRENT_Msk | \
      BS_VERSION_ERROR_Msk | BS_USB_ERROR_Msk)
 
+#define CA_SNPRINTF(b, l, ...) l += snprintf(&b[l], sizeof(b) - l, __VA_ARGS__)
+
 /***************************************************************************************************
 ** STRUCTURES
 ***************************************************************************************************/


### PR DESCRIPTION
Addition of CA_SNPRINTF() macro as suggested.
I didn't force the use of buf, len names because I would create errors when compiling the unit tests, as buf is already defined as a static variable in systeminfo.c.