### PR TITLE
Saltleak patch unit test support

### DIFF
--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -10,7 +10,9 @@
 #include "fake_stm32xxxx_hal.h"
 #include "pcbversion.h"
 #include "serialStatus_tests.h"
+#ifdef HAL_CRC_MODULE_ENABLED
 #include "uptime.h"
+#endif
 #include "FLASH_readwrite.h"
 
 using namespace std;
@@ -217,6 +219,7 @@ void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char
 ** checks the data is stored in flash memory correctly.
 */
 void uptimeTest(SerialStatusTest& sst, uintptr_t flashAddr) {
+#ifdef HAL_CRC_MODULE_ENABLED
     // Initialise board
     sst.boundInit();
 
@@ -257,4 +260,5 @@ void uptimeTest(SerialStatusTest& sst, uintptr_t flashAddr) {
     } uptime_test = {0};
     (void)readFromFlash((uint32_t)flashAddr, (uint8_t*)&uptime_test, sizeof(uptime_test));
     EXPECT_EQ(uptime_test.total_uptime_channel.count, 1440);
+#endif
 }

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -296,6 +296,7 @@ void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char
     EXPECT_FLUSH_USB(::testing::ElementsAreArray(pass_string));
 }
 
+#ifdef HAL_CRC_MODULE_ENABLED
 /*!
 ** @brief Tests that the uptime counting functionality works correctly
 **
@@ -307,7 +308,6 @@ void serialPrintoutTest(SerialStatusTest& sst, const char* boardName, const char
 ** checks the data is stored in flash memory correctly.
 */
 void uptimeTest(SerialStatusTest& sst, uintptr_t flashAddr) {
-#ifdef HAL_CRC_MODULE_ENABLED
     // Initialise board
     sst.boundInit();
 
@@ -348,5 +348,5 @@ void uptimeTest(SerialStatusTest& sst, uintptr_t flashAddr) {
     } uptime_test = {0};
     (void)readFromFlash((uint32_t)flashAddr, (uint8_t*)&uptime_test, sizeof(uptime_test));
     EXPECT_EQ(uptime_test.total_uptime_channel.count, 1440);
-#endif
 }
+#endif

--- a/unit_testing/fakes/fake_stm32xxxx_hal.cpp
+++ b/unit_testing/fakes/fake_stm32xxxx_hal.cpp
@@ -158,7 +158,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
     return HAL_OK;
 }
 
-HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim) {
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(const TIM_HandleTypeDef *htim) {
     return htim->State;
 }
 


### PR DESCRIPTION
### Primary

* Made it so including uptime specific code in the unit tests hinges on having the CRC module enabled
  * Note: this might be a short term fix, since it is possible to have the CRC module enabled but still _NOT_ want uptime
* Fixed a bug where the "const" was missed in a function definition, leading to an apparent "missing function"