### PR TITLE
Dev/analog input support

### DIFF
--- a/STM32/I2C/Inc/MCP4531.h
+++ b/STM32/I2C/Inc/MCP4531.h
@@ -1,12 +1,12 @@
 /*!
- * @file    mcp4x.h
- * @brief   See mcp4x.c for details
+ * @file    MCP4531.h
+ * @brief   See MCP4531.c for details
  * @date    28/07/2025
  * @authors Luke Walker
  */
 
-#ifndef MCP4651_H
-#define MCP4651_H
+#ifndef MCP4531_H_
+#define MCP4531_H_
 
 #include <stdint.h>
 
@@ -22,14 +22,14 @@ typedef struct {
     uint8_t num_bits; /* Number of bits of the device (7/8) */
     uint16_t max_value; /* Maximum value of the device wiper (corresponds to number of bits) */
     uint8_t device_num; /* Sub-circuit on device - 0 or 1. Use 0 for single circuit devices */
-} mcp4x_handle_t;
+} mcp4531_handle_t;
 
 /***************************************************************************************************
 ** PUBLIC FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
-int mcp4x_init(mcp4x_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_address, uint8_t num_bits, uint8_t device_num);
-int mcp4x_setWiperPos(mcp4x_handle_t* handle, uint16_t wiper_position);
-int mcp4x_getWiperPos(mcp4x_handle_t* handle, uint16_t* wiper_position);
+int mcp4531_init(mcp4531_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_address, uint8_t num_bits, uint8_t device_num);
+int mcp4531_setWiperPos(mcp4531_handle_t* handle, uint16_t wiper_position);
+int mcp4531_getWiperPos(mcp4531_handle_t* handle, uint16_t* wiper_position);
 
-#endif // MCP4651_H
+#endif // MCP4531_H_

--- a/STM32/I2C/Src/MCP4531.c
+++ b/STM32/I2C/Src/MCP4531.c
@@ -1,8 +1,11 @@
 /*!
- * @file    mcp4xxx.c
+ * @file    MCP4531.c
  * @brief   Driver file for MCP4x family of digital potentiometers/rheostats
  * @date    28/07/2025
  * @authors Luke Walker
+ * 
+ * Full set of Part numbers: MCP4531, MCP4532, MCP4541, MCP4542, MCP4551, MCP4552, MCP4561, MCP4562
+ *                           MCP4631, MCP4632, MCP4641, MCP4642, MCP4651, MCP4652, MCP4661, MCP4662
  * 
  * Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/22096b.pdf
  */
@@ -11,7 +14,7 @@
 
 #include "stm32f4xx_hal.h"
 
-#include "mcp4x.h"
+#include "MCP4531.h"
 
 /***************************************************************************************************
 ** DEFINES
@@ -39,7 +42,7 @@
 ** @param device_num Which device to initialise (valid for dual devices, always 0 for single devices)
 ** @return 0 on success, -1 on failure
 */
-int mcp4x_init(mcp4x_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_address, uint8_t num_bits, uint8_t device_num) {
+int mcp4531_init(mcp4531_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_address, uint8_t num_bits, uint8_t device_num) {
     if (!handle || !hi2c || num_bits > 8 || num_bits < 7 || device_num > 1) {
         return -1;
     }
@@ -64,8 +67,8 @@ int mcp4x_init(mcp4x_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_addr
         return -3; // I2C communication error
     }
 
-    /* Note: STATUS is fixed at 1F7h acc. datasheet for volatile devices. TODO: will this work for 
-    ** non-volatile devices too? */
+    /* Note: STATUS is fixed at 1F7h acc. datasheet for volatile devices. It is unclear from the 
+    ** datasheet if this is also the expected return value for non-volatile devices */
     return (data[0] == 0x01) && (data[1] == 0xF1) ? 0 : -4;
 }
 
@@ -74,9 +77,9 @@ int mcp4x_init(mcp4x_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_addr
  *
  * @param handle Pointer to the initialized MCP4x handle
  * @param wiper_position Position to set the wiper (0 to max_value)
- * @return HAL status code
+ * @return Error code
  */
-int mcp4x_setWiperPos(mcp4x_handle_t* handle, uint16_t wiper_position) {
+int mcp4531_setWiperPos(mcp4531_handle_t* handle, uint16_t wiper_position) {
     if (!handle || wiper_position > handle->max_value) {
         return -1;
     }
@@ -99,9 +102,9 @@ int mcp4x_setWiperPos(mcp4x_handle_t* handle, uint16_t wiper_position) {
  *
  * @param handle Pointer to the initialized MCP4x handle
  * @param wiper_position Pointer to store the wiper position
- * @return HAL status code
+ * @return Error code
  */
-int mcp4x_getWiperPos(mcp4x_handle_t* handle, uint16_t* wiper_position) {
+int mcp4531_getWiperPos(mcp4531_handle_t* handle, uint16_t* wiper_position) {
     if (!handle || !wiper_position) {
         return -1;
     }

--- a/STM32/I2C/Src/MCP4531.c
+++ b/STM32/I2C/Src/MCP4531.c
@@ -68,7 +68,8 @@ int mcp4531_init(mcp4531_handle_t* handle, I2C_HandleTypeDef* hi2c, uint8_t i2c_
     }
 
     /* Note: STATUS is fixed at 1F7h acc. datasheet for volatile devices. It is unclear from the 
-    ** datasheet if this is also the expected return value for non-volatile devices */
+    ** datasheet if this is also the expected return value for non-volatile devices. In all 
+    ** prototypes the actual return value was 0x1F1. The reason for this is not known. */
     return (data[0] == 0x01) && (data[1] == 0xF1) ? 0 : -4;
 }
 

--- a/STM32/Util/Inc/systemInfo.h
+++ b/STM32/Util/Inc/systemInfo.h
@@ -85,7 +85,8 @@ typedef enum {
     SaltLeakCal        = 23,
     PressureCal        = 24,
     ERUHC              = 25,
-    FanController      = 26
+    FanController      = 26,
+    AnalogInput        = 27,
 } BoardType;
 typedef uint8_t SubBoardType;  // SubBoardType needed for some boards.
 

--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -171,6 +171,8 @@ static const char* productType(uint8_t id) {
             return "ERUHC";
         case FanController:
             return "FanController";
+        case AnalogInput:
+            return "AnalogInput";
     }
     return "NA";
 }

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -121,11 +121,11 @@ void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick) {
     sst.testFixture->goToTick(firstPrintTick);
 
     /* Check the printout is correct */
-    vector<string>* ss = hostUSBread();
+    vector<string> ss = hostUSBread();
 
     /* Get the final element of the most recent message, strip any whitespace, parse as an integer
     ** and check the error bit */
-    string final = ss->back();
+    string final = ss.back();
     uint32_t status = parseFinalHex(final);
     EXPECT_TRUE(status & BS_VERSION_ERROR_Msk);
 }
@@ -162,11 +162,11 @@ void incorrectBoardVersionTest(SerialStatusTest& sst, int firstPrintTick) {
     sst.testFixture->goToTick(firstPrintTick);
 
     /* Check the printout is correct */
-    vector<string>* ss = hostUSBread();
+    vector<string> ss = hostUSBread();
 
     /* Get the final element of the most recent message, strip any whitespace, parse as an integer
     ** and check the error bit */
-    string final = ss->back();
+    string final = ss.back();
     uint32_t status = parseFinalHex(final);
     EXPECT_TRUE(status & BS_VERSION_ERROR_Msk);
 }
@@ -185,8 +185,7 @@ void statusPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) 
     /* Note: usb RX buffer is flushed during the first loop, so a single loop must be done before
     ** printing anything */
     sst.testFixture->_loopFunction(sst.testFixture->bootMsg);
-    vector<string>* ss = hostUSBread(true);
-    delete ss;
+    (void) hostUSBread(true);
 
     sst.testFixture->writeBoardMessage("Status\n");
 

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -5,6 +5,11 @@
 */
 
 #include <vector>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <algorithm>
+#include <cctype>
 
 #include "fake_USBprint.h"
 #include "fake_stm32xxxx_hal.h"
@@ -16,6 +21,46 @@
 using namespace std;
 using ::testing::Contains;
 using ::testing::AllOf;
+
+/***************************************************************************************************
+** PRIVATE FUNCTIONS
+***************************************************************************************************/
+
+/*!
+** @brief Parses the final hex value from a comma-separated string to an int
+*/
+uint32_t parseFinalHex(const std::string& input) {
+    // Find last comma
+    std::size_t lastComma = input.find_last_of(',');
+    std::string lastVar;
+
+    if (lastComma == std::string::npos) {
+        // No comma means whole string is the variable
+        lastVar = input;
+    } 
+    else {
+        lastVar = input.substr(lastComma + 1);
+    }
+
+    // Trim whitespace from both ends
+    auto trim = [](std::string& s) {
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+        s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
+    };
+    trim(lastVar);
+
+    // Convert hex string (expecting format "0x1234...")
+    uint32_t value = 0;
+    try {
+        value = std::stoul(lastVar, nullptr, 16);
+    } 
+    catch (const std::exception& e) {
+        std::cerr << "Error parsing hex string: " << e.what() << std::endl;
+        throw;
+    }
+
+    return value;
+}
 
 /***************************************************************************************************
 ** TESTS
@@ -56,11 +101,46 @@ void goldenPathTest(SerialStatusTest& sst, const char* pass_string, int firstPri
 ** @param[in] firstPrintTick The tick at which the first successful print should be made. 100 ms by 
 **                           default
 **
-** Programs the board to be the latest non-compatible version and runs. Verifies that the status bit
-** has version error and error bit set. TODO: Currently the test will fail if other error bits are 
-** also set. Fix this.
+** Programs the board to be a different board type and runs. Verifies that the status bit has 
+** version error bit set
 */
 void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick) {
+    /* Update OTP with wrong board ID */
+    if(sst.testFixture->bi.v2.boardType == 0) {
+        sst.testFixture->bi.v2.boardType = 1;
+    }
+    else {
+        sst.testFixture->bi.v2.boardType = 0;
+    }
+
+    HAL_otpWrite(&(sst.testFixture->bi));
+
+    sst.boundInit();
+
+    /* This should force a print on the USB bus */
+    sst.testFixture->goToTick(firstPrintTick);
+
+    /* Check the printout is correct */
+    vector<string>* ss = hostUSBread();
+
+    /* Get the final element of the most recent message, strip any whitespace, parse as an integer
+    ** and check the error bit */
+    string final = ss->back();
+    uint32_t status = parseFinalHex(final);
+    EXPECT_TRUE(status & BS_VERSION_ERROR_Msk);
+}
+
+/*!
+** @brief Tests for if the code is downloaded to the wrong board version
+**
+** @param[in] sst            Test data object
+** @param[in] firstPrintTick The tick at which the first successful print should be made. 100 ms by 
+**                           default
+**
+** Programs the board to be the latest non-compatible version and runs. Verifies that the status bit
+** has version error and error bit set.
+*/
+void incorrectBoardVersionTest(SerialStatusTest& sst, int firstPrintTick) {
     /* Update OTP with incorrect board number */
     if(BREAKING_MINOR != 0) {
         sst.testFixture->bi.v2.pcbVersion.minor = BREAKING_MINOR - 1;
@@ -82,7 +162,13 @@ void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick) {
     sst.testFixture->goToTick(firstPrintTick);
 
     /* Check the printout is correct */
-    EXPECT_READ_USB(::testing::Contains(::testing::HasSubstr("0x84")));
+    vector<string>* ss = hostUSBread();
+
+    /* Get the final element of the most recent message, strip any whitespace, parse as an integer
+    ** and check the error bit */
+    string final = ss->back();
+    uint32_t status = parseFinalHex(final);
+    EXPECT_TRUE(status & BS_VERSION_ERROR_Msk);
 }
 
 /*!
@@ -99,12 +185,13 @@ void statusPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) 
     /* Note: usb RX buffer is flushed during the first loop, so a single loop must be done before
     ** printing anything */
     sst.testFixture->_loopFunction(sst.testFixture->bootMsg);
+    vector<string>* ss = hostUSBread(true);
+    delete ss;
+
     sst.testFixture->writeBoardMessage("Status\n");
 
     vector<const char*> bs_pre = {"\r", 
-        "Boot Unit Test\r", 
-        "Start of board status:\r", 
-        "The board is operating normally.\r"};
+        "Start of board status:\r"};
     vector<const char*> bs_post = {"\r", 
         "End of board status. \r"
     };

--- a/unit_testing/Util/serialStatus_tests.h
+++ b/unit_testing/Util/serialStatus_tests.h
@@ -39,6 +39,7 @@ class SerialStatusTest {
 */
 
 void goldenPathTest(SerialStatusTest& sst, const char* pass_string, int firstPrintTick=100);
+void incorrectBoardVersionTest(SerialStatusTest& sst, int firstPrintTick=100);
 void incorrectBoardTest(SerialStatusTest& sst, int firstPrintTick=100);
 void statusPrintoutTest(SerialStatusTest& sst, std::vector<const char*> pass_string);
 void statusDefPrintoutTest(SerialStatusTest& sst, const char* boardErrorsString, std::vector<const char*> boardStatusDefString);

--- a/unit_testing/fakes/fake_USBprint.cpp
+++ b/unit_testing/fakes/fake_USBprint.cpp
@@ -35,6 +35,31 @@ static char     RX_buffer[TX_RX_BUFFER_LENGTH] = {0};
 static size_t   rx_len = 0, rx_off = 0;
 static bool     connected = false;
 
+/***************************************************************************************************
+** PRIVATE FUNCTION DECLARATIONS
+***************************************************************************************************/
+
+string trim(const string& str);
+
+/***************************************************************************************************
+** PRIVATE FUNCTION DEFINITIONS
+***************************************************************************************************/
+
+/*!
+** @brief Trims whitespace from start and end of a string
+*/
+string trim(const string& str) {
+    size_t first = str.find_first_not_of(" \t\n\r\f\v");
+    if (first == string::npos)
+        return ""; // string is all whitespace
+    size_t last = str.find_last_not_of(" \t\n\r\f\v");
+    return str.substr(first, last - first + 1);
+}
+
+/***************************************************************************************************
+** PUBLIC FUNCTION DECLARATIONS
+***************************************************************************************************/
+
 /* TODO: Make this Log transmissions to a "log_stdout" file, and "receive" transmissions from a 
 ** "stdin" file. Writing to a the output log file is pretty easy, but input in a way that mimics 
 ** the USB link for the CDC will be harder. Perhaps make a new thread that continually checks an 
@@ -189,11 +214,10 @@ void itoa(int n, char* s, int radix)
 vector<string> getChannelsFromLine(string& channel_line) {
     vector<string> channels;
 
-
     stringstream ss(channel_line);
     string item;
     while(getline(ss, item, ',')) {
-        channels.push_back(item);
+        channels.push_back(trim(item));
     }
 
     return channels;

--- a/unit_testing/fakes/fake_USBprint.cpp
+++ b/unit_testing/fakes/fake_USBprint.cpp
@@ -143,18 +143,18 @@ void usbFlush()
 /*!
 ** @brief Acts as the read function for the host (to allow checking what the device sent)
 */
-vector<string>* hostUSBread(bool flush)
+vector<string> hostUSBread(bool flush)
 {
-    vector<string>* result = new vector<string>;
+    vector<string> result;
     string str;
     while(getline(test_ss, str)) {
-        result->push_back(str);
+        result.push_back(str);
     }
 
     if(!flush) {
         /* Put everything back into the stream */
         test_ss.clear();
-        for(vector<string>::iterator it = result->begin(); it != result->end(); it++) {
+        for(vector<string>::iterator it = result.begin(); it != result.end(); it++) {
             test_ss << *it;
         }
     }
@@ -181,4 +181,20 @@ void hostUSBDisconnect()
 void itoa(int n, char* s, int radix)
 {
     
+}
+
+/*!
+** @brief Breaks down a "line" from the board into channels
+*/
+vector<string> getChannelsFromLine(string& channel_line) {
+    vector<string> channels;
+
+
+    stringstream ss(channel_line);
+    string item;
+    while(getline(ss, item, ',')) {
+        channels.push_back(item);
+    }
+
+    return channels;
 }

--- a/unit_testing/fakes/fake_USBprint.h
+++ b/unit_testing/fakes/fake_USBprint.h
@@ -16,18 +16,18 @@
 ** DEFINES
 ***************************************************************************************************/
 
+using namespace std;
+
 /* Allow a range of single line container tests */
 #define EXPECT_READ_USB(x) { \
-    vector<string>* ss = hostUSBread(); \
-    EXPECT_THAT(*ss, (x)); \
-    delete ss; \
+    vector<string> ss = hostUSBread(); \
+    EXPECT_THAT(ss, (x)); \
 }
 
 /* Allow a range of single line container tests */
 #define EXPECT_FLUSH_USB(x) { \
-    vector<string>* ss = hostUSBread(true); \
-    EXPECT_THAT(*ss, (x)); \
-    delete ss; \
+    vector<string> ss = hostUSBread(true); \
+    EXPECT_THAT(ss, (x)); \
 }
 
 /***************************************************************************************************
@@ -35,10 +35,12 @@
 ***************************************************************************************************/
 
 void hostUSBprintf(const char * format, ...);
-std::vector<std::string>* hostUSBread(bool flush=false);
+vector<string> hostUSBread(bool flush=false);
 
 void hostUSBConnect();
 void hostUSBDisconnect();
 void itoa(int n, char* s, int radix);
+
+vector<string> getChannelsFromLine(string& channel_line);
 
 #endif /* FAKE_USBPRINT_H_ */


### PR DESCRIPTION
### Primary Changes

* Added MCP4531 driver (can also support other units in the same series)
* Expanded SerialStatus tests to add incorrect Board type as well as board version tests
* Added AnalogInput to systemInfo

### Secondary Changes

* Updated the way hostUsbRead returns its value. It should lead to better memory handling, and simpler syntax, but may break some unit tests

### Testing

See https://github.com/copenhagenatomics/CA_Embedded/pull/245