### PR TITLE
Removing empty lines

### DIFF
--- a/STM32/Util/Src/systeminfo.c
+++ b/STM32/Util/Src/systeminfo.c
@@ -241,7 +241,7 @@ const char* statusInfo(bool printStart) {
 
     // Print end of message and return
     if (!printStart) {
-        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status. \r\n");
+        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status.");
         return buf;
     }
 
@@ -312,7 +312,7 @@ const char* statusDefInfo(bool printStart) {
 
     // Print end of message and return
     if (!printStart) {
-        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status definition.\r\n");
+        len += snprintf(&buf[len], sizeof(buf) - len, "\r\nEnd of board status definition.");
         return buf;
     }
 
@@ -338,7 +338,6 @@ const char* statusDefInfo(bool printStart) {
                     (uint32_t)BS_FLASH_ONGOING_Msk);
     len += snprintf(&buf[len], sizeof(buf) - len, "0x%08" PRIx32 ",100Hz Output\r\n",
                     (uint32_t)BS_100_HZ_OUTPUT_Msk);
-    
 
     return buf;
 }

--- a/unit_testing/Util/serialStatus_tests.cpp
+++ b/unit_testing/Util/serialStatus_tests.cpp
@@ -193,14 +193,12 @@ void statusPrintoutTest(SerialStatusTest& sst, vector<const char*> pass_string) 
 
     sst.testFixture->writeBoardMessage("Status\n");
 
-    vector<const char*> bs_pre = {"\r", 
-        "Start of board status:\r"};
-    vector<const char*> bs_post = {"\r", 
-        "End of board status. \r"
-    };
+    vector<const char*> bs_pre  = {"\r", "Start of board status:\r"};
+    vector<const char*> bs_post = {"End of board status."};
 
     bs_pre.insert(bs_pre.end(), pass_string.begin(), pass_string.end());
     bs_pre.insert(bs_pre.end(), bs_post.begin(), bs_post.end());
+
 
     EXPECT_FLUSH_USB(::testing::ElementsAreArray(bs_pre));
 }
@@ -236,9 +234,7 @@ void statusDefPrintoutTest(SerialStatusTest& sst, const char* boardErrorsString,
             "0x01000000,Flash ongoing\r",
             "0x00800000,100Hz Output\r",
     };
-    vector<const char*> bsdPost = {"\r",
-        "End of board status definition.\r"
-    };
+    vector<const char*> bsdPost = {"End of board status definition."};
 
     bsdPre1.push_back(boardErrorsString);
     bsdPre1.insert(bsdPre1.end(), bsdPre2.begin(), bsdPre2.end());


### PR DESCRIPTION
Some empty lines where printed when the standard commands were received

- Tested on FanController
- Other PRs will follow when implementing it on all boards