### PR TITLE
Spec update CAProtocol ACDC

### DIFF
--- a/STM32/Util/Src/CAProtocolACDC.c
+++ b/STM32/Util/Src/CAProtocolACDC.c
@@ -101,8 +101,8 @@ void ACDCInputHandler(ACDCProtocolCtx *ctx, const char *input) {
         /* Valid commands are:
            all on - turn all ports on indefinitely
            all off - turn all ports off
-           pX on - turn off port number X
-           pX off - turn on port number X indefinitely 'always on'
+           pX off - turn off port number X
+           pX on - turn on port number X indefinitely 'always on'
            pX on YY - turn on port number X for YY seconds
            pX on ZZZ% - turn on port number X on ZZ percent of the time using PWM 'always on'
            pX on YY ZZZ% - turn on port number X for YY seconds ZZ percent of the time using PWM */

--- a/STM32/Util/specs/CAProtocolACDC.md
+++ b/STM32/Util/specs/CAProtocolACDC.md
@@ -1,0 +1,23 @@
+# Specification Document - CAProtocolACDC
+
+Author: Luke Walker
+Date: 28/05/2026
+
+# Introduction
+
+This document contains the specification for the CAProtocolACDC.
+
+# Specification
+
+* Defines the following commands:
+  * all on - turn all ports on indefinitely
+  * all off - turn all ports off
+  * pX off - turn off port number X
+  * pX on - turn on port number X indefinitely 'always on'
+  * pX on YY - turn on port number X for YY seconds
+  * pX on ZZZ% - turn on port number X on ZZ percent of the time using PWM 'always on'
+  * pX on YY ZZZ% - turn on port number X for YY seconds ZZ percent of the time using PWM
+* Implementation of the commands can be accomplished using the following callbacks:
+  * allOn
+  * allOff
+  * portState

--- a/unit_testing/fakes/fake_USBprint.cpp
+++ b/unit_testing/fakes/fake_USBprint.cpp
@@ -229,3 +229,10 @@ vector<string> getChannelsFromLine(string& channel_line) {
 double getChannelNAsDouble(string& channel_line, int n) {
     return stod(getChannelsFromLine(channel_line)[n]);
 }
+
+/*!
+** @brief Returns the final element from a string cast as a uint32_t (used for status flags)
+*/
+uint32_t getLineStatus(string& channel_line) {
+    return stoul(getChannelsFromLine(channel_line).back(), nullptr, 16);
+}

--- a/unit_testing/fakes/fake_USBprint.h
+++ b/unit_testing/fakes/fake_USBprint.h
@@ -43,5 +43,6 @@ void itoa(int n, char* s, int radix);
 
 vector<string> getChannelsFromLine(string& channel_line);
 double getChannelNAsDouble(string& channel_line, int n);
+uint32_t getLineStatus(string& channel_line);
 
 #endif /* FAKE_USBPRINT_H_ */


### PR DESCRIPTION
### Primary Changes

- Added CAProtocolACDC Spec for AI Assist coding
- Corrected comment
- getLineStatus function for improved test coverage (verify status bits directly in output, rather than inferred)

### Testing

- [x] Tested in AC board unit tests: https://github.com/copenhagenatomics/CA_Embedded/pull/260