### PR TITLE
Feature/fake usb update

### DIFF
--- a/unit_testing/fakes/fake_USBprint.cpp
+++ b/unit_testing/fakes/fake_USBprint.cpp
@@ -118,6 +118,7 @@ int usbRx(uint8_t* buf)
 {
     if(rx_len != 0) {
         *buf = RX_buffer[rx_off++];
+        rx_off %= TX_RX_BUFFER_LENGTH;
         rx_len--;
 
         return 0;
@@ -139,6 +140,7 @@ uint32_t isUsbError() {
 */
 void hostUSBprintf(const char * format, ...)
 {
+    char temp_buf[TX_RX_BUFFER_LENGTH] = {0};
     va_list argptr;
     va_start(argptr, format);
 
@@ -147,7 +149,13 @@ void hostUSBprintf(const char * format, ...)
     }
 
     size_t temp = rx_off + rx_len;
-    size_t len = vsnprintf(&RX_buffer[temp], TX_RX_BUFFER_LENGTH - temp, format, argptr);
+    size_t len = vsnprintf(temp_buf, TX_RX_BUFFER_LENGTH, format, argptr);
+    
+    /* Note: len does not include terminating null character */
+    for(int i = 0; i < (int)(len + 1); i++) {
+        RX_buffer[temp] = temp_buf[i];
+        temp = (temp + 1) % TX_RX_BUFFER_LENGTH;
+    }
 
     test_in.write((const char *)&RX_buffer[temp], len);
     test_in.flush();

--- a/unit_testing/fakes/fake_USBprint.cpp
+++ b/unit_testing/fakes/fake_USBprint.cpp
@@ -236,3 +236,14 @@ double getChannelNAsDouble(string& channel_line, int n) {
 uint32_t getLineStatus(string& channel_line) {
     return stoul(getChannelsFromLine(channel_line).back(), nullptr, 16);
 }
+
+/*!
+** @brief Flushes USB buffer and returns the status flags from the most recent data line
+*/
+uint32_t flushAndGetUSBStatus() {
+    vector<string> lines = hostUSBread(true);
+    string dataLine;
+    for (auto& l : lines)
+        if (l.find(',') != string::npos) dataLine = l;
+    return getLineStatus(dataLine);
+}

--- a/unit_testing/fakes/fake_USBprint.h
+++ b/unit_testing/fakes/fake_USBprint.h
@@ -44,5 +44,6 @@ void itoa(int n, char* s, int radix);
 vector<string> getChannelsFromLine(string& channel_line);
 double getChannelNAsDouble(string& channel_line, int n);
 uint32_t getLineStatus(string& channel_line);
+uint32_t flushAndGetUSBStatus();
 
 #endif /* FAKE_USBPRINT_H_ */


### PR DESCRIPTION
### Primary Changes

* Fixed a fault when sending long / lots of messages through a unit test. RX_Buffer will overflow. Solution: format message into temporary buffer, then copy that into RX buffer character by character, wrapping around when necessary 

### Testing

- [x] All unit tests either build & pass (10) OR fail to build for an unrelated reason (3)